### PR TITLE
fix: widget taps crash on Android 12+ (background service restriction)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="false"
@@ -38,9 +41,11 @@
         <!-- Home Screen Widget -->
         <receiver
             android:name=".BoseWidgetProvider"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="dev.bose.ctl.STATUS_UPDATE" />
+                <action android:name="dev.bose.ctl.WIDGET_CLICK" />
             </intent-filter>
             <meta-data
                 android:name="android.appwidget.provider"
@@ -50,7 +55,8 @@
         <!-- Background Bluetooth service -->
         <service
             android:name=".BoseService"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
 
         <!-- Device picker dialog -->
         <activity

--- a/android/app/src/main/java/dev/bose/ctl/BoseService.kt
+++ b/android/app/src/main/java/dev/bose/ctl/BoseService.kt
@@ -1,20 +1,28 @@
 package dev.bose.ctl
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Binder
+import android.os.Build
 import android.os.IBinder
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import java.util.concurrent.Executors
 
 /**
- * Background service for managing Bose RFCOMM connection.
- * Handles connecting, querying, and switching devices off the main thread.
+ * Foreground service for managing Bose RFCOMM connection.
+ * Must run as foreground service because Android 12+ blocks background service starts
+ * from widget BroadcastReceivers.
  */
 class BoseService : Service() {
 
     companion object {
         private const val TAG = "BoseService"
+        private const val CHANNEL_ID = "bose_ctl"
+        private const val NOTIFICATION_ID = 1
 
         const val ACTION_CONNECT_DEVICE = "dev.bose.ctl.CONNECT_DEVICE"
         const val EXTRA_DEVICE_NAME = "device_name"
@@ -36,17 +44,59 @@ class BoseService : Service() {
 
     override fun onBind(intent: Intent?): IBinder = binder
 
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForegroundWithNotification()
+
         when (intent?.action) {
             ACTION_CONNECT_DEVICE -> {
                 val deviceName = intent.getStringExtra(EXTRA_DEVICE_NAME) ?: return START_NOT_STICKY
-                executor.submit { switchDevice(deviceName) }
+                executor.submit {
+                    switchDevice(deviceName)
+                    stopSelf(startId)
+                }
             }
             ACTION_REFRESH -> {
-                executor.submit { refreshStatus() }
+                executor.submit {
+                    refreshStatus()
+                    stopSelf(startId)
+                }
             }
+            else -> stopSelf(startId)
         }
         return START_NOT_STICKY
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Bose Control",
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            description = "RFCOMM operations"
+            setShowBadge(false)
+        }
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    private fun startForegroundWithNotification() {
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_headphones)
+            .setContentTitle("Bose")
+            .setContentText("Switching source...")
+            .setSilent(true)
+            .build()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(NOTIFICATION_ID, notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE)
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
     }
 
     private fun ensureConnected(): Boolean {

--- a/android/app/src/main/java/dev/bose/ctl/BoseWidgetProvider.kt
+++ b/android/app/src/main/java/dev/bose/ctl/BoseWidgetProvider.kt
@@ -6,28 +6,23 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.graphics.Color
 import android.util.Log
 import android.widget.RemoteViews
 
 /**
  * Home screen widget (4x1) showing device buttons.
- * Active device is highlighted in green (#00ff88).
- * Tapping any device sends CONNECT command via BoseService.
+ * Active device is highlighted in green, connected in orange, disconnected in grey.
+ * Tapping any device starts BoseService directly via PendingIntent.getForegroundService()
+ * to avoid Android 12+ background service start restrictions.
  */
 class BoseWidgetProvider : AppWidgetProvider() {
 
     companion object {
         private const val TAG = "BoseWidget"
-        private const val COLOR_ACTIVE = 0xFF00FF88.toInt()       // Green
-        private const val COLOR_CONNECTED = 0xFFFF9F43.toInt()    // Orange
-        private const val COLOR_DISCONNECTED = 0xFF333333.toInt() // Dark grey
-        private const val COLOR_BG = 0xFF1A1A1A.toInt()
-        private const val ACTION_WIDGET_CLICK = "dev.bose.ctl.WIDGET_CLICK"
+        private const val COLOR_ACTIVE = 0xFF00FF88.toInt()
+        private const val COLOR_CONNECTED = 0xFFFF9F43.toInt()
+        private const val COLOR_DISCONNECTED = 0xFF333333.toInt()
 
-        /**
-         * Update all widget instances with current active device and connected list.
-         */
         fun updateAll(context: Context, activeDevice: String?, connectedDevices: List<String> = emptyList()) {
             val manager = AppWidgetManager.getInstance(context)
             val component = ComponentName(context, BoseWidgetProvider::class.java)
@@ -62,14 +57,14 @@ class BoseWidgetProvider : AppWidgetProvider() {
                 }
                 views.setTextColor(viewId, color)
 
-                // Set click intent
-                val intent = Intent(context, BoseWidgetProvider::class.java).apply {
-                    action = ACTION_WIDGET_CLICK
-                    putExtra("device_name", name)
+                // Start foreground service directly — avoids background start restriction
+                val intent = Intent(context, BoseService::class.java).apply {
+                    action = BoseService.ACTION_CONNECT_DEVICE
+                    putExtra(BoseService.EXTRA_DEVICE_NAME, name)
                 }
-                val pi = PendingIntent.getBroadcast(
+                val pi = PendingIntent.getForegroundService(
                     context, viewId, intent,
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
                 )
                 views.setOnClickPendingIntent(viewId, pi)
             }
@@ -79,7 +74,6 @@ class BoseWidgetProvider : AppWidgetProvider() {
     }
 
     override fun onUpdate(context: Context, manager: AppWidgetManager, widgetIds: IntArray) {
-        // Get saved active device and connected list
         val prefs = context.getSharedPreferences("bose_ctl", Context.MODE_PRIVATE)
         val activeDevice = prefs.getString("active_device", null)
         val connectedDevices = prefs.getStringSet("connected_devices", emptySet())?.toList() ?: emptyList()
@@ -87,41 +81,22 @@ class BoseWidgetProvider : AppWidgetProvider() {
         for (id in widgetIds) {
             updateWidget(context, manager, id, activeDevice, connectedDevices)
         }
-
-        // Request fresh status
-        val intent = Intent(context, BoseService::class.java).apply {
-            action = BoseService.ACTION_REFRESH
-        }
-        context.startService(intent)
     }
 
     override fun onReceive(context: Context, intent: Intent) {
         super.onReceive(context, intent)
 
-        when (intent.action) {
-            ACTION_WIDGET_CLICK -> {
-                val deviceName = intent.getStringExtra("device_name") ?: return
-                Log.i(TAG, "Widget click: $deviceName")
-
-                val serviceIntent = Intent(context, BoseService::class.java).apply {
-                    action = BoseService.ACTION_CONNECT_DEVICE
-                    putExtra(BoseService.EXTRA_DEVICE_NAME, deviceName)
-                }
-                context.startService(serviceIntent)
-            }
-            BoseService.BROADCAST_STATUS -> {
-                val success = intent.getBooleanExtra(BoseService.EXTRA_SUCCESS, false)
-                if (success) {
-                    val activeDevice = intent.getStringExtra(BoseService.EXTRA_ACTIVE_DEVICE)
-                    val connectedDevices = intent.getStringArrayListExtra(BoseService.EXTRA_CONNECTED_DEVICES) ?: arrayListOf()
-                    // Save for widget updates
-                    context.getSharedPreferences("bose_ctl", Context.MODE_PRIVATE)
-                        .edit()
-                        .putString("active_device", activeDevice)
-                        .putStringSet("connected_devices", connectedDevices.toSet())
-                        .apply()
-                    updateAll(context, activeDevice, connectedDevices)
-                }
+        if (intent.action == BoseService.BROADCAST_STATUS) {
+            val success = intent.getBooleanExtra(BoseService.EXTRA_SUCCESS, false)
+            if (success) {
+                val activeDevice = intent.getStringExtra(BoseService.EXTRA_ACTIVE_DEVICE)
+                val connectedDevices = intent.getStringArrayListExtra(BoseService.EXTRA_CONNECTED_DEVICES) ?: arrayListOf()
+                context.getSharedPreferences("bose_ctl", Context.MODE_PRIVATE)
+                    .edit()
+                    .putString("active_device", activeDevice)
+                    .putStringSet("connected_devices", connectedDevices.toSet())
+                    .apply()
+                updateAll(context, activeDevice, connectedDevices)
             }
         }
     }


### PR DESCRIPTION
Widget taps silently crash with BackgroundServiceStartNotAllowedException on Android 12+. Uses PendingIntent.getForegroundService() to start BoseService directly from widget buttons with user-interaction foreground exemption.