### PR TITLE
feat: subscribe channel heartbeat

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -1,0 +1,20 @@
+# Agent Context - Recovery Summary
+# Max 20 lines. Updated by agent on Stop hook.
+
+## Feature
+Add heartbeat to subscribe channel
+Add heartbeat to subscribe channel
+
+## Current State
+Not started. No work has been done yet.
+
+## Key Files
+(none yet)
+
+## Blockers
+None
+
+## Next Actions
+1. Review the codebase
+2. Plan implementation approach
+3. Begin work on step 1

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,0 +1,10 @@
+# Agent Progress - subscribe-heartbeat
+# Format: KEY=VALUE, one per line. Agents append, last value wins.
+# Created: 2026-03-16T04:18:57Z
+
+feature=subscribe-heartbeat
+name=Add heartbeat to subscribe channel
+status=pending
+step=0
+step_name=Not started
+created=2026-03-16T04:18:57Z

--- a/BoseDaemon.swift
+++ b/BoseDaemon.swift
@@ -225,9 +225,9 @@ class SubscribeClient {
             return
         }
 
-        // Clear timeout for push listening (block indefinitely)
-        var noTimeout = timeval(tv_sec: 0, tv_usec: 0)
-        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &noTimeout, socklen_t(MemoryLayout<timeval>.size))
+        // Set read timeout to detect missing heartbeats (phone sends every 30s)
+        var listenTv = timeval(tv_sec: 60, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &listenTv, socklen_t(MemoryLayout<timeval>.size))
 
         log.log("Subscribe: listening for push commands...")
 
@@ -238,7 +238,11 @@ class SubscribeClient {
         while true {
             let n = read(fd, &readBuf, readBuf.count)
             if n <= 0 {
-                log.log("Subscribe: connection closed (read=\(n))")
+                if n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    log.log("Subscribe: no heartbeat for 60s — connection stale, reconnecting")
+                } else {
+                    log.log("Subscribe: connection closed (read=\(n))")
+                }
                 return
             }
 
@@ -258,14 +262,21 @@ class SubscribeClient {
     }
 
     private func handlePushCommand(_ json: String) {
-        log.log("Push received: \(json)")
-
         guard let data = json.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let push = obj["push"] as? String else {
-            log.log("Push: invalid format")
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            log.log("Push: invalid format — \(json)")
             return
         }
+
+        // Heartbeat — silently acknowledge
+        if obj["heartbeat"] != nil { return }
+
+        guard let push = obj["push"] as? String else {
+            log.log("Push: no 'push' key — \(json)")
+            return
+        }
+
+        log.log("Push received: \(push)")
 
         switch push {
         case "bt_connect":


### PR DESCRIPTION
Phone sends heartbeat every 30s. Mac sets 60s read timeout — if no heartbeat arrives, treats connection as stale and reconnects.