### PR TITLE
fix: Android device state parsing and RFCOMM concurrency

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Fix Bose Control app stability - event tap, main thread blocking, concurrency
-Fix Bose Control app stability - event tap, main thread blocking, concurrency
+Fix Android device state parsing offset
+Fix Android device state parsing offset
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - fix-app-stability
+# Agent Progress - fix-device-states
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-04-05T01:32:37Z
+# Created: 2026-04-05T01:55:18Z
 
-feature=fix-app-stability
-name=Fix Bose Control app stability - event tap, main thread blocking, concurrency
+feature=fix-device-states
+name=Fix Android device state parsing offset
 status=pending
 step=0
 step_name=Not started
-created=2026-04-05T01:32:37Z
+created=2026-04-05T01:55:18Z

--- a/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
@@ -11,6 +11,8 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.UUID
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * Bose QC Ultra RFCOMM protocol handler.
@@ -59,6 +61,7 @@ object BoseProtocol {
 
     val CYCLE_ORDER = listOf("mac", "ipad", "iphone", "tv", "phone")
 
+    private val rfcommLock = ReentrantLock()
     private var socket: BluetoothSocket? = null
     private var inputStream: InputStream? = null
     private var outputStream: OutputStream? = null
@@ -76,10 +79,12 @@ object BoseProtocol {
      */
     @SuppressLint("MissingPermission")
     fun connect(): Boolean {
-        disconnect()
+        rfcommLock.lock()
+        closeSocket()
 
         val adapter = BluetoothAdapter.getDefaultAdapter() ?: run {
             Log.e(TAG, "No Bluetooth adapter")
+            rfcommLock.unlock()
             return false
         }
 
@@ -105,7 +110,14 @@ object BoseProtocol {
         }
     }
 
+    /** Close socket and release the RFCOMM lock. */
     fun disconnect() {
+        closeSocket()
+        if (rfcommLock.isHeldByCurrentThread) rfcommLock.unlock()
+    }
+
+    /** Close socket without releasing the lock (used internally by connect). */
+    private fun closeSocket() {
         try { inputStream?.close() } catch (_: Exception) {}
         try { outputStream?.close() } catch (_: Exception) {}
         try { socket?.close() } catch (_: Exception) {}
@@ -139,6 +151,7 @@ object BoseProtocol {
     /**
      * On-demand connection pattern: connect, execute block, disconnect.
      * Each command gets a fresh RFCOMM socket.
+     * connect() acquires rfcommLock, disconnect() releases it.
      */
     suspend fun <T> withConnection(block: suspend () -> T): T = withContext(Dispatchers.IO) {
         connect()
@@ -283,23 +296,28 @@ object BoseProtocol {
     // Connected devices (ground truth for connection state)
     // ======================================================================
 
-    /** GET connected devices. 05,01,01,00 -> count + MACs */
+    /** GET connected devices. 05,01,01,00 -> count at byte 6, MACs from byte 7 */
     fun getConnectedDevices(): List<ByteArray> {
         val resp = send(byteArrayOf(0x05, 0x01, OP_GET, 0x00)) ?: return emptyList()
-        if (resp.size < 5 || resp[2] != OP_RESP) return emptyList()
+        if (resp.size < 7 || resp[0] != 0x05.toByte() || resp[1] != 0x01.toByte()
+            || resp[2] != OP_RESP) return emptyList()
 
-        val payloadLen = resp[3].toInt() and 0xFF
-        if (payloadLen < 1) return emptyList()
-
-        val count = resp[4].toInt() and 0xFF
+        val count = resp[6].toInt() and 0xFF
         val devices = mutableListOf<ByteArray>()
-        var i = 5
+        var i = 7
         for (j in 0 until count) {
             if (i + 6 > resp.size) break
             devices.add(resp.copyOfRange(i, i + 6))
             i += 6
         }
         return devices
+    }
+
+    /** GET active device MAC. 04,09,01,00 -> MAC at bytes 4-9 */
+    fun getActiveDevice(): ByteArray? {
+        val resp = send(byteArrayOf(0x04, 0x09, OP_GET, 0x00)) ?: return null
+        if (resp.size < 10 || resp[2] != OP_RESP) return null
+        return resp.copyOfRange(4, 10)
     }
 
     // ======================================================================

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -89,19 +89,17 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                         )
                     }
 
-                    // Connected devices (ground truth)
+                    // Connected devices (ground truth) + active device
                     val connectedMacs = BoseProtocol.getConnectedDevices()
                     val connectedNames = connectedMacs.map { BoseProtocol.nameForMac(it) }.toSet()
+                    val activeMac = BoseProtocol.getActiveDevice()
+                    val activeName = activeMac?.let { BoseProtocol.nameForMac(it) }
 
-                    // Determine active: first connected device is typically active
                     val deviceStates = BoseProtocol.DEVICES.keys.associateWith { name ->
                         when {
-                            connectedNames.contains(name) && connectedNames.first() == name ->
-                                DeviceState.ACTIVE
-                            connectedNames.contains(name) ->
-                                DeviceState.CONNECTED
-                            else ->
-                                DeviceState.OFFLINE
+                            name == activeName -> DeviceState.ACTIVE
+                            connectedNames.contains(name) -> DeviceState.CONNECTED
+                            else -> DeviceState.OFFLINE
                         }
                     }
                     _state.value = _state.value.copy(deviceStates = deviceStates)


### PR DESCRIPTION
Device buttons now show active/connected/offline correctly.

- getConnectedDevices() was reading count from byte 4 (wrong) instead of byte 6
- Added getActiveDevice() query instead of guessing first connected = active
- Added ReentrantLock to prevent BoseService and ViewModel from racing on RFCOMM