### PR TITLE
fix: device detection shows all connected devices correctly

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Fix Android device state parsing offset
-Fix Android device state parsing offset
+Fix device detection to show all connected devices
+Fix device detection to show all connected devices
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - fix-device-states
+# Agent Progress - fix-device-detection
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-04-05T01:55:18Z
+# Created: 2026-04-05T02:11:12Z
 
-feature=fix-device-states
-name=Fix Android device state parsing offset
+feature=fix-device-detection
+name=Fix device detection to show all connected devices
 status=pending
 step=0
 step_name=Not started
-created=2026-04-05T01:55:18Z
+created=2026-04-05T02:11:12Z

--- a/BoseRFCOMM.swift
+++ b/BoseRFCOMM.swift
@@ -794,8 +794,8 @@ class BoseRFCOMM {
         var ancMode: Int = 0  // 0=quiet, 1=aware, 2=custom1, 3=custom2
         var volume: Int = 0
         var volumeMax: Int = 31
-        var connectedDevices: [[UInt8]] = []
-        var activeDevice: [UInt8]? = nil
+        var connectedDevices: [[UInt8]] = []   // audio-connected (from 05,01)
+        var aclConnectedDevices: [[UInt8]] = [] // BT-connected (from per-device 04,05)
         var firmware: String = ""
         var serialNumber: String = ""
         var productName: String = ""
@@ -857,10 +857,16 @@ class BoseRFCOMM {
                     }
                 }
 
-                // Active device
-                if let resp = sendBMAP(channel, bytes: [0x04, 0x09, OP_GET, 0x00]),
-                   resp.count >= 10, resp[2] == OP_RESP {
-                    state.activeDevice = Array(resp[4..<10])
+                // Per-device ACL connection status (04,05 per known device)
+                for (_, mac) in boseKnownDevices {
+                    let cmd: [UInt8] = [0x04, 0x05, OP_GET, 0x06] + mac
+                    if let resp = sendBMAP(channel, bytes: cmd, timeout: 2.0),
+                       resp.count >= 11, resp[2] == OP_RESP {
+                        let status = Int(resp[10])
+                        if (status & 0x01) != 0 {  // bit 0 = ACL connected
+                            state.aclConnectedDevices.append(mac)
+                        }
+                    }
                 }
 
                 // Firmware

--- a/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
@@ -347,24 +347,27 @@ object BoseProtocol {
     // Device info
     // ======================================================================
 
-    data class DeviceInfo(val status: Int, val name: String)
+    data class DeviceInfo(
+        val status: Int,
+        val name: String,
+        val connected: Boolean,  // bit 0 of status
+    )
 
-    /** GET device info. 04,05,01,06,{MAC} -> status + name */
+    /** GET device info. 04,05,01,06,{MAC} -> MAC at 4-9, status at 10, name from 13 */
     fun getDeviceInfo(mac: ByteArray): DeviceInfo? {
         val cmd = byteArrayOf(0x04, 0x05, OP_GET, 0x06) + mac
-        val resp = send(cmd) ?: return null
-        if (resp.size < 6 || resp[2] != OP_RESP) return null
+        val resp = send(cmd, timeoutMs = 2000) ?: return null
+        if (resp.size < 11 || resp[2] != OP_RESP) return null
 
-        val payloadLen = resp[3].toInt() and 0xFF
-        if (payloadLen < 1) return null
-
-        val status = resp[4].toInt() and 0xFF
-        val name = if (resp.size > 5) {
-            String(resp, 5, (resp.size - 5).coerceAtMost(payloadLen - 1), Charsets.UTF_8)
+        val status = resp[10].toInt() and 0xFF
+        val connected = (status and 0x01) != 0
+        val nameOffset = 13
+        val name = if (resp.size > nameOffset) {
+            String(resp, nameOffset, resp.size - nameOffset, Charsets.UTF_8)
                 .trim('\u0000')
         } else ""
 
-        return DeviceInfo(status, name)
+        return DeviceInfo(status, name, connected)
     }
 
     // ======================================================================

--- a/android/app/src/main/java/au/com/jd/bose/BoseService.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseService.kt
@@ -246,14 +246,21 @@ class BoseService : Service() {
                 return
             }
 
-            // Get connected devices (ground truth)
-            val connectedMacs = BoseProtocol.getConnectedDevices()
-            val connectedNames = connectedMacs.map { BoseProtocol.nameForMac(it) }
+            // Audio-connected devices (ground truth for active)
+            val audioMacs = BoseProtocol.getConnectedDevices()
+            val audioNames = audioMacs.map { BoseProtocol.nameForMac(it) }
+
+            // Per-device ACL status for all connected devices
+            val connectedNames = mutableListOf<String>()
+            for ((name, mac) in BoseProtocol.DEVICES) {
+                val info = BoseProtocol.getDeviceInfo(mac)
+                if (info != null && info.connected) connectedNames.add(name)
+            }
 
             // Battery
             val battery = BoseProtocol.getBattery()
 
-            val activeName = connectedNames.firstOrNull() ?: "none"
+            val activeName = audioNames.firstOrNull() ?: connectedNames.firstOrNull() ?: "none"
             updateNotification(buildString {
                 append("Active: $activeName")
                 battery?.let { append(" | ${it.level}%") }

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -89,16 +89,23 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                         )
                     }
 
-                    // Connected devices (ground truth) + active device
-                    val connectedMacs = BoseProtocol.getConnectedDevices()
-                    val connectedNames = connectedMacs.map { BoseProtocol.nameForMac(it) }.toSet()
-                    val activeMac = BoseProtocol.getActiveDevice()
-                    val activeName = activeMac?.let { BoseProtocol.nameForMac(it) }
+                    // Audio-connected devices (05,01) = active (green)
+                    val audioMacs = BoseProtocol.getConnectedDevices()
+                    val audioNames = audioMacs.map { BoseProtocol.nameForMac(it) }.toSet()
+
+                    // Per-device ACL status (04,05) = connected (orange)
+                    val aclNames = mutableSetOf<String>()
+                    for ((name, mac) in BoseProtocol.DEVICES) {
+                        val info = BoseProtocol.getDeviceInfo(mac)
+                        if (info != null && info.connected) {
+                            aclNames.add(name)
+                        }
+                    }
 
                     val deviceStates = BoseProtocol.DEVICES.keys.associateWith { name ->
                         when {
-                            name == activeName -> DeviceState.ACTIVE
-                            connectedNames.contains(name) -> DeviceState.CONNECTED
+                            audioNames.contains(name) -> DeviceState.ACTIVE
+                            aclNames.contains(name) -> DeviceState.CONNECTED
                             else -> DeviceState.OFFLINE
                         }
                     }

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -229,23 +229,20 @@ class BoseManager: ObservableObject {
                     .map { String(format: "%02X", $0) }.joined(separator: " ")
             }
 
-            // Build device states from connected devices + active device
+            // Build device states: audio-connected = active, ACL-only = connected
             var newStates: [String: String] = [:]
             for key in self.deviceStates.keys {
                 newStates[key] = "offline"
             }
 
-            let connectedMacStrings = Set(s.connectedDevices.map {
-                bose.macToString($0)
-            })
-
-            let activeMacString = s.activeDevice.map { bose.macToString($0) }
+            let audioMacs = Set(s.connectedDevices.map { bose.macToString($0) })
+            let aclMacs = Set(s.aclConnectedDevices.map { bose.macToString($0) })
 
             for (name, mac) in boseKnownDevices {
                 let macStr = bose.macToString(mac)
-                if macStr == activeMacString {
+                if audioMacs.contains(macStr) {
                     newStates[name] = "active"
-                } else if connectedMacStrings.contains(macStr) {
+                } else if aclMacs.contains(macStr) {
                     newStates[name] = "connected"
                 } else {
                     newStates[name] = "offline"


### PR DESCRIPTION
Phone shows green (active), Mac shows orange (connected). Both apps fixed.

- Replaced unreliable getActiveDevice (04,09) with per-device getDeviceInfo (04,05)
- Fixed Android getDeviceInfo parsing offset (status at byte 10, not byte 4)
- Audio-connected = active (green), ACL-only = connected (orange)