### PR TITLE
fix: stop Bose audio being yanked back to Mac and unbreak Android RFCOMM

### DIFF
--- a/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
@@ -32,7 +32,7 @@ object BoseProtocol {
      *  the only option for context-free singletons. Works on all API levels. */
     @Suppress("DEPRECATION")
     private val adapter: BluetoothAdapter?
-        get() = adapter
+        get() = BluetoothAdapter.getDefaultAdapter()
 
     const val BOSE_MAC = "E4:58:BC:C0:2F:72"
 

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -135,8 +135,29 @@ class BoseManager: ObservableObject {
                 }
             }
 
-            // Try reconnect
+            // Try reconnect — but first check whether the headphones are
+            // currently routing audio to a different device (e.g. user
+            // switched to phone/iPad from elsewhere). If so, do NOT yank
+            // audio back to Mac. RFCOMM opens its own ACL, so this works
+            // even while Mac is A2DP-disconnected.
             self.rfcommQueue.async {
+                if self.boseReady, let bose = self.bose {
+                    let active = bose.getConnectedDevices()
+                    let macMacBytes = bose.macForName("mac")
+                    let otherDeviceActive = active.contains { mac in
+                        macMacBytes == nil || mac != macMacBytes!
+                    }
+                    if otherDeviceActive {
+                        // User intentionally routed audio elsewhere —
+                        // cancel the reconnect window so we stop fighting it.
+                        DispatchQueue.main.async {
+                            self.reconnectTimer?.invalidate()
+                            self.reconnectTimer = nil
+                            self.disconnectedAt = nil
+                        }
+                        return
+                    }
+                }
                 self.btConnect()
             }
         }


### PR DESCRIPTION
## Why

Switching the Bose QC Ultra 2 to the iPad (from the S21 widget or anywhere else) was failing — within ~30 s the audio would reappear on the Mac or phone.

Live tracing on the S21 showed two bugs combining:

## What was broken

### 1. `android: BoseProtocol.adapter` self-recursive getter (StackOverflow on every BMAP call)

Introduced in #59. The "centralized adapter access" refactor accidentally produced:

```kotlin
private val adapter: BluetoothAdapter?
    get() = adapter   // calls itself → StackOverflowError
```

The currently-installed APK on the S21 predates that commit (built 2026-04-06 12:40, bug landed 13:30), which is why nothing was visibly broken yet — but any rebuild from main would crash on the first `BoseProtocol.connect()`.

### 2. `macos: BoseManager.startReconnectTimer` stealing audio back

When the Mac detected its ACL to the Bose had dropped, it ran a 30-second reconnect window calling `blueutil --connect` every 3 s. That happily fights any user attempt to route audio elsewhere — switch to iPad → Bose drops Mac's multipoint slot → Mac auto-reconnects → Mac is audio-active again. The user's perceived "~2 min" is the upper bound of this loop.

## Fix

1. `BoseProtocol.adapter` now returns `BluetoothAdapter.getDefaultAdapter()`.

2. `BoseManager.startReconnectTimer` now queries the headphones via on-demand RFCOMM (`getConnectedDevices`) before each reconnect tick. If any non-Mac device is currently audio-active, the reconnect window is cancelled. The "auto-reconnect after an unintentional idle drop" behaviour is preserved — only the user-initiated-switch case is now respected.

## Verification

- Mac `./build.sh --install` clean (only a pre-existing `Data` warning in BoseRFCOMM.swift).
- Android `./gradlew assembleDebug` clean, installed on S21 (versionCode 2, lastUpdateTime 2026-04-11 18:19).
- Live logcat after reinstall shows BoseService doing a full state refresh (battery, ANC, devices, EQ, etc.) end-to-end with **no StackOverflowError** — confirms the recursion fix.
- Old Mac PID killed, only the LaunchAgent-managed instance (new build) is running.

## Not in this PR

CLAUDE.md notes "ipad — Needs re-pairing". Even with this fix, switching to iPad will silently fall back unless the iPad is awake and properly paired with the Bose at the moment of the switch — that's an environmental issue (iPad side / Bose paired list), not a code one.
