### PR TITLE
fix: detect BMAP RESULT frame to distinguish real switch from target-offline

### DIFF
--- a/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
@@ -341,15 +341,33 @@ object BoseProtocol {
     // Connect / Disconnect device
     // ======================================================================
 
+    enum class SwitchResult { SWITCHED, TARGET_OFFLINE, FAILED }
+
     /**
      * Connect (switch audio to) a device by MAC.
      * Command: 04,01,05,07,00,{MAC} (START operator)
      * NEVER use 0x03 (RemoveDevice) -- it unpairs.
+     *
+     * Response distinguishes success from target-offline:
+     * - ACK + RESULT (22 bytes): switch completed — target was ACL-connected
+     * - ACK only (10 bytes): target unreachable — not ACL-connected to Bose
      */
-    fun connectDevice(mac: ByteArray): Boolean {
+    fun connectDevice(mac: ByteArray): SwitchResult {
         val cmd = byteArrayOf(0x04, 0x01, OP_START, 0x07, 0x00) + mac
-        val resp = send(cmd, timeoutMs = 10000) ?: return false
-        return resp.size >= 4 && (resp[2] == OP_ACK || resp[2] == OP_RESP)
+        val resp = send(cmd, timeoutMs = 10000) ?: return SwitchResult.FAILED
+        if (resp.size < 4) return SwitchResult.FAILED
+
+        // ACK (10 bytes) + RESULT/SET frame (12+ bytes) = switch happened
+        // ACK alone (10 bytes) = target not reachable
+        if (resp.size > 10 && resp[2] == OP_ACK) {
+            Log.i(TAG, "connectDevice: ACK + RESULT (${resp.size} bytes) — switch confirmed")
+            return SwitchResult.SWITCHED
+        }
+        if (resp[2] == OP_ACK) {
+            Log.w(TAG, "connectDevice: ACK only (${resp.size} bytes) — target offline")
+            return SwitchResult.TARGET_OFFLINE
+        }
+        return SwitchResult.FAILED
     }
 
     /**

--- a/android/app/src/main/java/au/com/jd/bose/BoseService.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseService.kt
@@ -217,59 +217,37 @@ class BoseService : Service() {
             }
 
             Log.i(TAG, "Switching to $deviceName")
-            val ack = BoseProtocol.connectDevice(mac)
+            val result = BoseProtocol.connectDevice(mac)
 
-            if (!ack) {
-                broadcastError("Failed to switch to $deviceName")
-                return
-            }
+            when (result) {
+                BoseProtocol.SwitchResult.SWITCHED -> {
+                    Log.i(TAG, "Switch to $deviceName confirmed by RESULT frame")
+                    updateNotification("Active: $deviceName")
 
-            // Verify the switch. ACK means "command received", not "audio
-            // routed". Poll getConnectedDevices a few times — remote devices
-            // (iPad, iPhone) can take several seconds to establish A2DP.
-            BoseProtocol.disconnect()
+                    if (deviceName == "phone") {
+                        val adapter = getSystemService(BluetoothManager::class.java)?.adapter
+                        val boseDevice = adapter?.getRemoteDevice(BoseProtocol.BOSE_MAC)
+                        if (boseDevice != null) {
+                            Log.i(TAG, "Proactively connecting A2DP for local device")
+                            ensureA2dp(boseDevice)
+                        }
 
-            var verified = false
-            var activeNames = emptyList<String>()
-            for (attempt in 1..3) {
-                Thread.sleep(2000)
-                if (!BoseProtocol.connect()) continue
-                activeNames = BoseProtocol.getConnectedDevices()
-                    .map { BoseProtocol.nameForMac(it) }
-                BoseProtocol.disconnect()
-                if (activeNames.contains(deviceName)) {
-                    verified = true
-                    break
-                }
-                Log.d(TAG, "Verify attempt $attempt: active=$activeNames, wanted=$deviceName")
-            }
-
-            if (verified) {
-                Log.i(TAG, "Switch verified: $deviceName is audio-active")
-                updateNotification("Active: $deviceName")
-
-                if (deviceName == "phone") {
-                    val adapter = getSystemService(BluetoothManager::class.java)?.adapter
-                    val boseDevice = adapter?.getRemoteDevice(BoseProtocol.BOSE_MAC)
-                    if (boseDevice != null) {
-                        Log.i(TAG, "Proactively connecting A2DP for local device")
-                        ensureA2dp(boseDevice)
+                        Thread.sleep(500)
+                        nudgeMediaPlayback()
                     }
 
-                    Thread.sleep(500)
-                    nudgeMediaPlayback()
+                    BoseWidgetProvider.updateAll(this, deviceName, setOf(deviceName))
+                    broadcastStatus(deviceName, true)
                 }
 
-                BoseWidgetProvider.updateAll(this, deviceName, activeNames.toSet())
-                broadcastStatus(deviceName, true)
-            } else {
-                // Switch wasn't confirmed but the command was ACK'd — the
-                // device may still be connecting. Update widget optimistically
-                // so the user sees feedback, but log the uncertainty.
-                Log.w(TAG, "Switch unconfirmed after 3 attempts: active=$activeNames, wanted=$deviceName")
-                updateNotification("Active: $deviceName (unconfirmed)")
-                BoseWidgetProvider.updateAll(this, deviceName, setOf(deviceName))
-                broadcastStatus(deviceName, true)
+                BoseProtocol.SwitchResult.TARGET_OFFLINE -> {
+                    Log.w(TAG, "$deviceName is not connected to Bose — can't switch")
+                    broadcastError("$deviceName is offline — connect it to Bose first")
+                }
+
+                BoseProtocol.SwitchResult.FAILED -> {
+                    broadcastError("Failed to switch to $deviceName")
+                }
             }
         } catch (e: Exception) {
             Log.e(TAG, "Switch error", e)

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -126,8 +126,15 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                     _state.value = _state.value.copy(loading = false)
                     return@launch
                 }
-                BoseProtocol.withConnection {
+                val result = BoseProtocol.withConnection {
                     BoseProtocol.connectDevice(mac)
+                }
+                if (result == BoseProtocol.SwitchResult.TARGET_OFFLINE) {
+                    _state.value = _state.value.copy(
+                        loading = false,
+                        error = "$name is offline — connect it to Bose first",
+                    )
+                    return@launch
                 }
                 refreshAll()
             } catch (e: Exception) {


### PR DESCRIPTION
Protocol discovery: connectDevice returns ACK+RESULT (22 bytes) when target is ACL-connected, ACK-only (10 bytes) when offline. Replaces polling verification (#63) with instant detection. Shows 'offline — connect it to Bose first' instead of false green widget.