### PR TITLE
feat: landscape frosted-dark Mac app redesign

### DIFF
--- a/docs/plans/2026-04-11-mac-app-redesign-plan.md
+++ b/docs/plans/2026-04-11-mac-app-redesign-plan.md
@@ -1,0 +1,317 @@
+# Mac App Redesign — Landscape Frosted Dark Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the portrait dark-green Mac app with a 640x360 landscape frosted-dark two-panel layout.
+
+**Architecture:** Complete rewrite of ContentView.swift (new layout, new theme, new structure). BoseApp.swift updated for window size + style. BoseManager.swift unchanged — all @Published properties stay the same. AppDelegate.swift repurposed for NSWindow configuration (vibrancy, title bar).
+
+**Tech Stack:** SwiftUI, NSVisualEffectView (vibrancy), SF Symbols, existing BoseManager/BoseRFCOMM
+
+---
+
+### Task 1: Window Configuration
+
+**Files:**
+- Modify: `macos/BoseControl/BoseApp.swift`
+- Modify: `macos/BoseControl/AppDelegate.swift`
+
+**Step 1: Update BoseApp.swift window size and style**
+
+```swift
+/// BoseControl: Native macOS app for Bose QC Ultra 2
+
+import SwiftUI
+
+@main
+struct BoseControlApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @StateObject private var manager = BoseManager()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(manager: manager)
+                .onAppear { manager.startPolling() }
+        }
+        .defaultSize(width: 640, height: 360)
+        .windowResizability(.contentSize)
+    }
+}
+```
+
+**Step 2: Update AppDelegate.swift for frosted window chrome**
+
+```swift
+import AppKit
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Configure the main window for frosted dark appearance
+        DispatchQueue.main.async {
+            guard let window = NSApplication.shared.windows.first else { return }
+            window.titlebarAppearsTransparent = true
+            window.styleMask.insert(.fullSizeContentView)
+            window.isMovableByWindowBackground = true
+            window.backgroundColor = .clear
+            window.appearance = NSAppearance(named: .darkAqua)
+        }
+    }
+}
+```
+
+**Step 3: Build and verify window**
+
+Run: `cd macos && ./build.sh`
+Expected: compiles clean. App opens at 640x360 with transparent title bar.
+
+**Step 4: Commit**
+
+```bash
+git add macos/BoseControl/BoseApp.swift macos/BoseControl/AppDelegate.swift
+git commit -m "feat: configure 640x360 landscape window with frosted chrome"
+```
+
+---
+
+### Task 2: Rewrite ContentView — Theme + Layout Shell
+
+**Files:**
+- Rewrite: `macos/BoseControl/ContentView.swift`
+
+**Step 1: Replace ContentView.swift with new two-panel layout shell**
+
+Replace the entire file. New colour constants (no green), two-panel HStack, VisualEffectBackground, placeholder content in each panel.
+
+```swift
+/// ContentView: Landscape frosted-dark two-panel layout for Bose QC Ultra 2.
+/// Left panel: status sidebar (battery, ANC, volume).
+/// Right panel: device grid + EQ.
+
+import SwiftUI
+
+// MARK: - Theme
+
+private enum Theme {
+    static let accentWhite = Color.white
+    static let dimWhite = Color(white: 0.7)
+    static let subtleGrey = Color(white: 0.4)
+    static let panelBg = Color(white: 0.12)
+    static let cardBg = Color(white: 0.16)
+    static let activeBg = Color(white: 0.22)
+}
+
+// MARK: - Visual Effect Background
+
+struct VisualEffectBackground: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = .hudWindow
+        view.blendingMode = .behindWindow
+        view.state = .active
+        return view
+    }
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}
+
+// MARK: - Device Model
+
+private struct DeviceButton: Identifiable {
+    let id: String
+    let label: String
+    let symbol: String
+}
+
+private let deviceButtons: [DeviceButton] = [
+    DeviceButton(id: "mac", label: "Mac", symbol: "laptopcomputer"),
+    DeviceButton(id: "phone", label: "Phone", symbol: "iphone"),
+    DeviceButton(id: "ipad", label: "iPad", symbol: "ipad"),
+    DeviceButton(id: "iphone", label: "iPhone", symbol: "iphone.gen2"),
+    DeviceButton(id: "quest", label: "Quest", symbol: "visionpro"),
+    DeviceButton(id: "tv", label: "TV", symbol: "tv"),
+]
+
+// MARK: - Main View
+
+struct ContentView: View {
+    @ObservedObject var manager: BoseManager
+
+    var body: some View {
+        ZStack {
+            VisualEffectBackground()
+                .ignoresSafeArea()
+
+            if manager.isConnected {
+                HStack(spacing: 0) {
+                    leftPanel
+                        .frame(width: 220)
+                    Divider()
+                        .background(Theme.subtleGrey.opacity(0.3))
+                    rightPanel
+                        .frame(maxWidth: .infinity)
+                }
+                .padding(.top, 28) // clear title bar
+            } else {
+                VStack(spacing: 12) {
+                    Image(systemName: "headphones")
+                        .font(.system(size: 32, weight: .light))
+                        .foregroundColor(Theme.subtleGrey)
+                    Text("Not Connected")
+                        .font(.system(size: 14))
+                        .foregroundColor(Theme.subtleGrey)
+                }
+            }
+        }
+        .onAppear { manager.refreshState() }
+    }
+
+    // MARK: - Left Panel (placeholder — filled in Task 3)
+
+    private var leftPanel: some View {
+        VStack { Text("sidebar").foregroundColor(.white) }
+    }
+
+    // MARK: - Right Panel (placeholder — filled in Task 4)
+
+    private var rightPanel: some View {
+        VStack { Text("devices + eq").foregroundColor(.white) }
+    }
+}
+```
+
+**Step 2: Build and verify shell**
+
+Run: `cd macos && ./build.sh`
+Expected: compiles clean. App opens with frosted translucent background, two placeholder panels, "Not Connected" state when headphones off.
+
+**Step 3: Commit**
+
+```bash
+git add macos/BoseControl/ContentView.swift
+git commit -m "feat: two-panel frosted layout shell with new theme"
+```
+
+---
+
+### Task 3: Left Panel — Status Sidebar
+
+**Files:**
+- Modify: `macos/BoseControl/ContentView.swift` — replace `leftPanel`
+
+**Step 1: Implement the sidebar**
+
+Replace the `leftPanel` computed property with the full implementation: battery (large), device name, ANC segmented control, volume slider, firmware at bottom.
+
+Key details:
+- Battery: large font (36pt), white, with charging bolt icon
+- Device name: 14pt, dimWhite
+- ANC: 4 buttons in a row using `Picker` with `.segmented` style, or manual buttons
+- Volume: SwiftUI `Slider`, white tint
+- Firmware: 10pt, subtleGrey, pinned to bottom with Spacer
+
+Use `manager.batteryLevel`, `manager.ancMode`, `manager.volume`, `manager.volumeMax`, `manager.firmware`, `manager.deviceName` — all existing @Published properties.
+
+ANC modes map to: 0=Quiet, 1=Aware, 2=C1, 3=C2. Set via `manager.setAncMode(Int)`.
+Volume set via `manager.setVolume(Int)`.
+
+**Step 2: Build and verify**
+
+Run: `cd macos && ./build.sh`
+Expected: left panel shows battery %, ANC buttons, volume slider. Values update from headphones.
+
+**Step 3: Commit**
+
+```bash
+git add macos/BoseControl/ContentView.swift
+git commit -m "feat: status sidebar — battery, ANC, volume"
+```
+
+---
+
+### Task 4: Right Panel — Device Grid
+
+**Files:**
+- Modify: `macos/BoseControl/ContentView.swift` — replace `rightPanel`
+
+**Step 1: Implement the device grid + EQ**
+
+Replace `rightPanel` with:
+- 3x2 `LazyVGrid` of device buttons using `deviceButtons` array
+- Each button shows SF Symbol + label, styled by state from `manager.deviceStates[id]`:
+  - `"active"` → white text, `Theme.activeBg` background, subtle white border
+  - `"connected"` → `Theme.dimWhite` text, `Theme.cardBg` background
+  - `"offline"` → `Theme.subtleGrey` text at 40% opacity
+- Tap calls `manager.connectDevice(id)` — this uses existing BoseManager which does RFCOMM + blueutil for mac
+- Mac button gets a `"Connect Mac"` subtitle or keyboard shortcut badge
+- Below grid: EQ section — preset row (Flat/Bass+/Treble+/Vocal) + 3 compact sliders
+
+Device state keys: `manager.deviceStates` is `[String: String]` with values `"active"`, `"connected"`, `"offline"`.
+EQ: `manager.eq` is `(bass: Int, mid: Int, treble: Int)`. Set via `manager.setEQ(bass:mid:treble:)`.
+
+**Step 2: Add keyboard shortcut for Connect Mac**
+
+In ContentView body, add `.onAppear` with `NSEvent.addLocalMonitorForEvents(matching: .keyDown)` or use SwiftUI `.keyboardShortcut` on the Mac button.
+
+Shortcut: Cmd+M calls `manager.connectDevice("mac")`.
+
+**Step 3: Build and verify**
+
+Run: `cd macos && ./build.sh`
+Expected: 3x2 device grid with correct state colours. Tapping a device triggers RFCOMM switch. EQ sliders work. Cmd+M connects Mac.
+
+**Step 4: Commit**
+
+```bash
+git add macos/BoseControl/ContentView.swift
+git commit -m "feat: device grid, EQ section, Cmd+M shortcut"
+```
+
+---
+
+### Task 5: Polish + Install
+
+**Files:**
+- Modify: `macos/BoseControl/ContentView.swift` — animations, hover states
+- Modify: `macos/BoseControl/Info.plist` — if window size needs updating
+
+**Step 1: Add hover and click feedback**
+
+- Device buttons: `.onHover` brightness bump, press animation (`.scaleEffect(0.97)`)
+- ANC buttons: highlight active with white background
+- Smooth transitions: `.animation(.easeInOut(duration: 0.2), value: manager.deviceStates)`
+
+**Step 2: Build, install, verify end-to-end**
+
+Run: `cd macos && ./build.sh --install`
+
+Verify:
+- Window is 640x360, frosted dark, translucent
+- Left panel: battery, ANC, volume all update live
+- Right panel: device grid shows correct states, switching works
+- EQ sliders + presets work
+- Cmd+M connects Mac
+- Kill old process, new one launched via LaunchAgent
+
+**Step 3: Commit**
+
+```bash
+git add macos/BoseControl/
+git commit -m "feat: polish — hover states, animations, final install"
+```
+
+---
+
+### Task 6: PR and Ship
+
+**Step 1: Push and create PR**
+
+```bash
+gh pr create --title "feat: landscape frosted-dark Mac app redesign" \
+  --body "Replaces the portrait dark-green UI with a 640x360 landscape two-panel layout. Frosted dark theme with macOS vibrancy. Device grid front and center, Cmd+M for quick Mac connect."
+```
+
+**Step 2: Merge and clean up**
+
+```bash
+gh pr merge --squash --admin
+# Clean up worktree from main repo
+```

--- a/docs/plans/2026-04-11-mac-app-redesign.md
+++ b/docs/plans/2026-04-11-mac-app-redesign.md
@@ -1,0 +1,49 @@
+# Mac App Redesign — Landscape Frosted Dark
+
+## Summary
+
+Replace the current 380x600 portrait dark-green UI with a 640x360 landscape frosted-dark two-panel layout. Focus on device switching with all controls visible on one screen.
+
+## Window
+
+- 640x360, fixed size (not resizable)
+- `NSVisualEffectView` with `.hudWindow` or `.dark` material for translucent background
+- No title bar chrome — use `.titlebarAppearsTransparent` + `.fullSizeContentView`
+
+## Theme
+
+- **Background**: frosted dark translucency (macOS vibrancy), no solid black
+- **Active accent**: white / light grey (replaces neon green)
+- **Secondary**: muted warm grey
+- **Text**: white on translucent
+- **Device states**:
+  - Active = white text + subtle white glow
+  - Connected = dimmed white
+  - Offline = 40% opacity grey
+- No neon green anywhere
+
+## Layout
+
+### Left Panel (~220px) — Status sidebar
+
+- Headphone name ("verBosita") + battery % (large, prominent)
+- ANC mode — 4 segmented buttons: Quiet / Aware / C1 / C2
+- Volume slider (compact)
+- Firmware version (small, bottom)
+
+### Right Panel (~420px) — Controls
+
+- **Device grid** (top, primary): 3x2 grid of device buttons (phone, mac, ipad, iphone, quest, tv). Bigger than current. State colours per theme above. Tapping switches audio (uses polling verification from #67).
+- **"Connect Mac" button**: prominent at top of device grid or as a dedicated shortcut for quick Mac reclaim.
+- **EQ** (bottom, compact): preset row (Flat/Bass+/Treble+/Vocal) + 3 inline sliders (bass/mid/treble)
+
+## Removed
+
+- Expandable settings section (multipoint, device rename, ANC depth, auto-off, immersion, wear detection) — too rare to warrant screen space. Move to a menu bar dropdown or remove entirely.
+- Expandable info section (serial, platform, codename, codec, MAC, EQ readout) — firmware stays in sidebar, rest dropped.
+- Scrolling — everything fits on one screen.
+- Refresh button — state updates via existing 10s poll.
+
+## Keyboard Shortcut
+
+- Cmd+M or Option+B to connect Mac (quick reclaim)

--- a/macos/BoseControl/AppDelegate.swift
+++ b/macos/BoseControl/AppDelegate.swift
@@ -1,4 +1,18 @@
-/// AppDelegate: No longer needed — BoseManager owned by SwiftUI @StateObject.
-/// Kept as empty file to avoid build script changes. Can be deleted if build.sh is updated.
+/// AppDelegate: Window chrome configuration for frosted-dark redesign.
 
-import Foundation
+import AppKit
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        configureWindow()
+    }
+
+    private func configureWindow() {
+        guard let window = NSApplication.shared.windows.first else { return }
+        window.titlebarAppearsTransparent = true
+        window.styleMask.insert(.fullSizeContentView)
+        window.isMovableByWindowBackground = true
+        window.backgroundColor = .clear
+        window.appearance = NSAppearance(named: .darkAqua)
+    }
+}

--- a/macos/BoseControl/BoseApp.swift
+++ b/macos/BoseControl/BoseApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 @main
 struct BoseControlApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var manager = BoseManager()
 
     var body: some Scene {
@@ -11,6 +12,7 @@ struct BoseControlApp: App {
             ContentView(manager: manager)
                 .onAppear { manager.startPolling() }
         }
-        .defaultSize(width: 380, height: 600)
+        .defaultSize(width: 640, height: 360)
+        .windowResizability(.contentSize)
     }
 }

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -51,6 +51,11 @@ struct VisualEffectBackground: NSViewRepresentable {
 struct ContentView: View {
     @ObservedObject var manager: BoseManager
 
+    @State private var volumeSlider: Double = 0
+    @State private var eqBass: Double = 0
+    @State private var eqMid: Double = 0
+    @State private var eqTreble: Double = 0
+
     var body: some View {
         Group {
             if manager.isConnected {
@@ -63,6 +68,28 @@ struct ContentView: View {
         .background(VisualEffectBackground())
         .onAppear {
             manager.refreshState()
+            syncSliders()
+            installCmdMShortcut()
+        }
+        .onReceive(manager.objectWillChange) { _ in
+            DispatchQueue.main.async { syncSliders() }
+        }
+    }
+
+    private func syncSliders() {
+        volumeSlider = Double(manager.volume)
+        eqBass = Double(manager.eq.bass)
+        eqMid = Double(manager.eq.mid)
+        eqTreble = Double(manager.eq.treble)
+    }
+
+    private func installCmdMShortcut() {
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "m" {
+                manager.connectDevice("mac")
+                return nil
+            }
+            return event
         }
     }
 
@@ -112,25 +139,41 @@ struct ContentView: View {
             }
 
             // ANC mode
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 6) {
                 Text("NOISE CONTROL")
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(secondaryColor)
                     .tracking(1)
-                Text(manager.ancModeName)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(activeColor)
+                HStack(spacing: 4) {
+                    ancButton("Quiet", 0)
+                    ancButton("Aware", 1)
+                    ancButton("C1", 2)
+                    ancButton("C2", 3)
+                }
             }
 
             // Volume
-            VStack(alignment: .leading, spacing: 4) {
-                Text("VOLUME")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(secondaryColor)
-                    .tracking(1)
-                Text("\(manager.volume) / \(manager.volumeMax)")
-                    .font(.system(size: 13, weight: .medium, design: .monospaced))
-                    .foregroundColor(activeColor)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("VOLUME")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(secondaryColor)
+                        .tracking(1)
+                    Spacer()
+                    Text("\(Int(volumeSlider))")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundColor(secondaryColor)
+                }
+                Slider(
+                    value: $volumeSlider,
+                    in: 0...Double(manager.volumeMax),
+                    onEditingChanged: { editing in
+                        if !editing {
+                            manager.setVolume(Int(volumeSlider))
+                        }
+                    }
+                )
+                .tint(activeColor)
             }
 
             // Wear detection
@@ -154,35 +197,156 @@ struct ContentView: View {
         .padding(16)
     }
 
-    // MARK: - Right Panel (Device Grid + EQ Placeholder)
+    // MARK: - Right Panel (Device Grid + EQ)
 
     private var rightPanel: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            // Devices
+        VStack(alignment: .leading, spacing: 14) {
             Text("DEVICES")
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundColor(secondaryColor)
                 .tracking(1)
 
-            Text("Device grid placeholder")
-                .font(.system(size: 12))
-                .foregroundColor(secondaryColor)
+            deviceGrid
 
-            Spacer()
-
-            // EQ
             Text("EQUALIZER")
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundColor(secondaryColor)
                 .tracking(1)
+                .padding(.top, 4)
 
-            Text("EQ controls placeholder")
-                .font(.system(size: 12))
-                .foregroundColor(secondaryColor)
-
-            Spacer()
+            eqPresets
+            eqSliders
         }
         .padding(16)
+    }
+
+    private var deviceGrid: some View {
+        let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
+        return LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(deviceButtons) { button in
+                deviceButton(button)
+            }
+        }
+    }
+
+    private func deviceButton(_ button: DeviceButton) -> some View {
+        let state = manager.deviceStates[button.id] ?? "offline"
+        let isActive = state == "active"
+        let isConnected = state == "connected"
+
+        let textColor: Color = isActive ? activeColor : (isConnected ? secondaryColor : offlineColor)
+        let bg: Color = isActive ? Color.white.opacity(0.14) : cardColor
+        let borderColor: Color = isActive ? activeColor.opacity(0.7) : Color.white.opacity(0.04)
+
+        return Button(action: { manager.connectDevice(button.id) }) {
+            VStack(spacing: 3) {
+                Image(systemName: button.symbol)
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundColor(textColor)
+                Text(button.label)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(textColor)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 52)
+            .background(bg)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(borderColor, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .opacity(state == "offline" ? 0.6 : 1.0)
+    }
+
+    private struct EqPreset {
+        let name: String
+        let bass: Int
+        let mid: Int
+        let treble: Int
+    }
+
+    private let eqPresetList: [EqPreset] = [
+        EqPreset(name: "Flat", bass: 0, mid: 0, treble: 0),
+        EqPreset(name: "Bass+", bass: 6, mid: 0, treble: -2),
+        EqPreset(name: "Treble+", bass: -2, mid: 0, treble: 6),
+        EqPreset(name: "Vocal", bass: -2, mid: 4, treble: 2),
+    ]
+
+    private var eqPresets: some View {
+        HStack(spacing: 6) {
+            ForEach(eqPresetList, id: \.name) { preset in
+                let selected = manager.eq.bass == preset.bass &&
+                    manager.eq.mid == preset.mid &&
+                    manager.eq.treble == preset.treble
+                Button(action: {
+                    eqBass = Double(preset.bass)
+                    eqMid = Double(preset.mid)
+                    eqTreble = Double(preset.treble)
+                    manager.setEQ(bass: preset.bass, mid: preset.mid, treble: preset.treble)
+                }) {
+                    Text(preset.name)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(selected ? .black : secondaryColor)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 5)
+                        .background(selected ? activeColor : cardColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var eqSliders: some View {
+        VStack(spacing: 4) {
+            eqBandSlider("Bass", value: $eqBass) {
+                manager.setEQ(bass: Int(eqBass), mid: Int(eqMid), treble: Int(eqTreble))
+            }
+            eqBandSlider("Mid", value: $eqMid) {
+                manager.setEQ(bass: Int(eqBass), mid: Int(eqMid), treble: Int(eqTreble))
+            }
+            eqBandSlider("Treble", value: $eqTreble) {
+                manager.setEQ(bass: Int(eqBass), mid: Int(eqMid), treble: Int(eqTreble))
+            }
+        }
+    }
+
+    private func eqBandSlider(_ label: String, value: Binding<Double>, onCommit: @escaping () -> Void) -> some View {
+        HStack(spacing: 8) {
+            Text(label)
+                .font(.system(size: 10))
+                .foregroundColor(secondaryColor)
+                .frame(width: 38, alignment: .leading)
+            Slider(
+                value: value,
+                in: -10...10,
+                step: 1,
+                onEditingChanged: { editing in
+                    if !editing { onCommit() }
+                }
+            )
+            .tint(activeColor)
+            Text("\(Int(value.wrappedValue))")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(secondaryColor)
+                .frame(width: 22, alignment: .trailing)
+        }
+    }
+
+    private func ancButton(_ label: String, _ mode: Int) -> some View {
+        let isActive = manager.ancMode == mode
+        return Button(action: { manager.setAncMode(mode) }) {
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(isActive ? .black : secondaryColor)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 5)
+                .background(isActive ? activeColor : cardColor)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Disconnected View

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -1,16 +1,17 @@
-/// ContentView: Main SwiftUI interface for Bose headphone control.
-/// Dark theme, sections: header, devices, ANC, volume, EQ, settings, info.
+/// ContentView: Frosted-dark two-panel layout for Bose headphone control.
+/// Left panel = status sidebar (220px), right panel = device grid + EQ.
+/// Uses NSVisualEffectView for macOS vibrancy/translucency.
 
 import SwiftUI
-import Combine
 
-// MARK: - Color Constants
+// MARK: - Theme Colors
 
-private let bgColor = Color(red: 0.1, green: 0.1, blue: 0.1)          // #1A1A1A
-private let cardColor = Color(red: 0.15, green: 0.15, blue: 0.15)     // #262626
-private let accentGreen = Color(red: 0, green: 1.0, blue: 0.533)      // #00FF88
-private let textPrimary = Color.white
-private let textSecondary = Color(white: 0.6)
+/// No neon green. White/light grey for active, warm grey for secondary, 40% opacity grey for offline.
+private let activeColor = Color.white
+private let secondaryColor = Color(white: 0.55)
+private let offlineColor = Color(white: 0.4)
+private let cardColor = Color.white.opacity(0.06)
+private let dividerColor = Color.white.opacity(0.08)
 
 // MARK: - Device Button Model
 
@@ -21,109 +22,203 @@ private struct DeviceButton: Identifiable {
 }
 
 private let deviceButtons: [DeviceButton] = [
-    DeviceButton(id: "phone", label: "Phone", symbol: "iphone"),
     DeviceButton(id: "mac", label: "Mac", symbol: "laptopcomputer"),
+    DeviceButton(id: "phone", label: "Phone", symbol: "iphone"),
     DeviceButton(id: "ipad", label: "iPad", symbol: "ipad"),
     DeviceButton(id: "iphone", label: "iPhone", symbol: "iphone"),
     DeviceButton(id: "tv", label: "TV", symbol: "tv"),
     DeviceButton(id: "quest", label: "Quest", symbol: "visionpro"),
 ]
 
+// MARK: - Visual Effect Background
+
+/// NSViewRepresentable wrapping NSVisualEffectView with .hudWindow material
+/// for macOS dark vibrancy/translucency.
+struct VisualEffectBackground: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = .hudWindow
+        view.blendingMode = .behindWindow
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}
+
 // MARK: - Main View
 
 struct ContentView: View {
     @ObservedObject var manager: BoseManager
-    @State private var showSettings = false
-    @State private var showInfo = false
-    @State private var editingName = false
-    @State private var nameField: String = ""
-    @State private var volumeSliderValue: Double = 0
-    @State private var eqBass: Double = 0
-    @State private var eqMid: Double = 0
-    @State private var eqTreble: Double = 0
-    @State private var cncSliderValue: Double = 0
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 12) {
-                headerSection
-                if manager.isConnected {
-                    devicesSection
-                    ancSection
-                    volumeSection
-                    eqSection
-                    settingsSection
-                    infoSection
-                } else {
-                    disconnectedView
-                }
+        Group {
+            if manager.isConnected {
+                connectedLayout
+            } else {
+                disconnectedView
             }
-            .padding(16)
         }
-        .frame(maxWidth: .infinity)
-        .background(bgColor)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Bose")
+        .frame(width: 640, height: 360)
+        .background(VisualEffectBackground())
         .onAppear {
-            syncSliders()
             manager.refreshState()
-        }
-        .onReceive(manager.objectWillChange) { _ in
-            DispatchQueue.main.async { syncSliders() }
         }
     }
 
-    // MARK: - Header
+    // MARK: - Connected Layout
 
-    private var headerSection: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 2) {
+    private var connectedLayout: some View {
+        HStack(spacing: 0) {
+            // Left panel — status sidebar
+            leftPanel
+                .frame(width: 220)
+
+            // Divider
+            Rectangle()
+                .fill(dividerColor)
+                .frame(width: 1)
+
+            // Right panel — device grid + EQ
+            rightPanel
+                .frame(maxWidth: .infinity)
+        }
+        .padding(.top, 28)  // clear transparent title bar
+    }
+
+    // MARK: - Left Panel (Status Sidebar)
+
+    private var leftPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Device name + battery
+            VStack(alignment: .leading, spacing: 4) {
                 Text(manager.deviceName)
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(textPrimary)
-                    .accessibilityLabel("Device name: \(manager.deviceName)")
+                    .foregroundColor(activeColor)
 
-                if manager.isConnected {
-                    HStack(spacing: 6) {
-                        batteryView
-                        if manager.isRefreshing {
-                            ProgressView()
-                                .scaleEffect(0.6)
-                                .frame(width: 12, height: 12)
-                                .accessibilityLabel("Refreshing state")
-                        }
+                HStack(spacing: 6) {
+                    Image(systemName: batteryIcon)
+                        .font(.system(size: 11))
+                        .foregroundColor(batteryColor)
+                    Text("\(manager.batteryLevel)%")
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        .foregroundColor(batteryColor)
+                    if manager.batteryCharging {
+                        Image(systemName: "bolt.fill")
+                            .font(.system(size: 10))
+                            .foregroundColor(.orange)
                     }
-                } else {
-                    Text("Disconnected")
+                }
+            }
+
+            // ANC mode
+            VStack(alignment: .leading, spacing: 4) {
+                Text("NOISE CONTROL")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(secondaryColor)
+                    .tracking(1)
+                Text(manager.ancModeName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(activeColor)
+            }
+
+            // Volume
+            VStack(alignment: .leading, spacing: 4) {
+                Text("VOLUME")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(secondaryColor)
+                    .tracking(1)
+                Text("\(manager.volume) / \(manager.volumeMax)")
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .foregroundColor(activeColor)
+            }
+
+            // Wear detection
+            VStack(alignment: .leading, spacing: 4) {
+                Text("STATUS")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(secondaryColor)
+                    .tracking(1)
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(manager.onHead ? Color.green : Color.orange)
+                        .frame(width: 6, height: 6)
+                    Text(manager.onHead ? "On head" : "Off head")
                         .font(.system(size: 12))
-                        .foregroundColor(textSecondary)
-                        .accessibilityLabel("Connection status: Disconnected")
+                        .foregroundColor(activeColor)
                 }
             }
 
             Spacer()
+        }
+        .padding(16)
+    }
 
-            if manager.isConnected {
-                ancPill
+    // MARK: - Right Panel (Device Grid + EQ Placeholder)
+
+    private var rightPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Devices
+            Text("DEVICES")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(secondaryColor)
+                .tracking(1)
+
+            Text("Device grid placeholder")
+                .font(.system(size: 12))
+                .foregroundColor(secondaryColor)
+
+            Spacer()
+
+            // EQ
+            Text("EQUALIZER")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(secondaryColor)
+                .tracking(1)
+
+            Text("EQ controls placeholder")
+                .font(.system(size: 12))
+                .foregroundColor(secondaryColor)
+
+            Spacer()
+        }
+        .padding(16)
+    }
+
+    // MARK: - Disconnected View
+
+    private var disconnectedView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "headphones")
+                .font(.system(size: 48, weight: .thin))
+                .foregroundColor(offlineColor)
+
+            Text("Not Connected")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(secondaryColor)
+
+            Button(action: {
+                manager.connectDevice("mac")
+            }) {
+                Text("Connect")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.black)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 8)
+                    .background(activeColor)
+                    .cornerRadius(8)
             }
+            .buttonStyle(.plain)
+
+            Spacer()
         }
-        .padding(.bottom, 4)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Header")
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, 28)
     }
 
-    private var batteryView: some View {
-        HStack(spacing: 3) {
-            Image(systemName: manager.batteryCharging ? "bolt.fill" : batteryIcon)
-                .font(.system(size: 11))
-                .foregroundColor(batteryColor)
-            Text("\(manager.batteryLevel)%")
-                .font(.system(size: 12, weight: .medium, design: .monospaced))
-                .foregroundColor(batteryColor)
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Battery level: \(manager.batteryLevel) percent\(manager.batteryCharging ? ", charging" : "")")
-    }
+    // MARK: - Helpers
 
     private var batteryIcon: String {
         switch manager.batteryLevel {
@@ -136,469 +231,9 @@ struct ContentView: View {
     }
 
     private var batteryColor: Color {
-        if manager.batteryCharging { return accentGreen }
+        if manager.batteryCharging { return .green }
         if manager.batteryLevel < 15 { return .red }
         if manager.batteryLevel < 30 { return .orange }
-        return textPrimary
-    }
-
-    private var ancPill: some View {
-        Text(manager.ancModeName)
-            .font(.system(size: 11, weight: .medium))
-            .foregroundColor(bgColor)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 4)
-            .background(accentGreen)
-            .cornerRadius(12)
-            .accessibilityLabel("Current noise control mode: \(manager.ancModeName)")
-    }
-
-    // MARK: - Disconnected
-
-    private var disconnectedView: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "headphones")
-                .font(.system(size: 40))
-                .foregroundColor(textSecondary)
-                .accessibilityLabel("Headphones icon")
-            Text("Headphones not connected")
-                .font(.system(size: 13))
-                .foregroundColor(textSecondary)
-                .accessibilityLabel("Headphones not connected")
-            Button(action: {
-                manager.connectDevice("mac")
-            }) {
-                Text("Connect")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(bgColor)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 8)
-                    .background(accentGreen)
-                    .cornerRadius(8)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Connect headphones to Mac")
-            .accessibilityIdentifier("connect-button")
-        }
-        .padding(.vertical, 20)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Disconnected view")
-    }
-
-    // MARK: - Devices
-
-    private var devicesSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            sectionLabel("DEVICES")
-
-            HStack(spacing: 8) {
-                ForEach(deviceButtons) { device in
-                    deviceButton(device)
-                }
-            }
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Devices section")
-    }
-
-    private func deviceButton(_ device: DeviceButton) -> some View {
-        let state = manager.deviceStates[device.id] ?? "offline"
-        let actionVerb = (state == "active" || state == "connected") ? "Disconnect" : "Connect"
-
-        return Button(action: {
-            if state == "active" || state == "connected" {
-                manager.disconnectDevice(device.id)
-            } else {
-                manager.connectDevice(device.id)
-            }
-        }) {
-            VStack(spacing: 4) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(state == "active" ? accentGreen.opacity(0.15) : cardColor)
-                        .frame(width: 50, height: 44)
-
-                    Image(systemName: device.symbol)
-                        .font(.system(size: 18))
-                        .foregroundColor(
-                            state == "active" ? accentGreen :
-                            state == "connected" ? .orange :
-                            textSecondary
-                        )
-                }
-
-                HStack(spacing: 2) {
-                    Circle()
-                        .fill(
-                            state == "active" ? accentGreen :
-                            state == "connected" ? .orange :
-                            Color(white: 0.3)
-                        )
-                        .frame(width: 6, height: 6)
-                    Text(device.label)
-                        .font(.system(size: 9))
-                        .foregroundColor(textSecondary)
-                }
-            }
-        }
-        .buttonStyle(.plain)
-        .frame(maxWidth: .infinity)
-        .accessibilityLabel("\(actionVerb) \(device.label), status: \(state)")
-        .accessibilityIdentifier("device-\(device.id)")
-    }
-
-    // MARK: - ANC
-
-    private var ancSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            sectionLabel("NOISE CONTROL")
-
-            HStack(spacing: 0) {
-                ancButton("Quiet", mode: 0)
-                ancButton("Aware", mode: 1)
-                ancButton("C1", mode: 2)
-                ancButton("C2", mode: 3)
-            }
-            .background(cardColor)
-            .cornerRadius(8)
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Noise control section")
-    }
-
-    private func ancButton(_ label: String, mode: Int) -> some View {
-        let isSelected = manager.ancMode == mode
-        let fullModeNames = ["Quiet", "Aware", "Custom 1", "Custom 2"]
-        let modeName = mode < fullModeNames.count ? fullModeNames[mode] : label
-
-        return Button(action: {
-            manager.setAncMode(mode)
-        }) {
-            Text(label)
-                .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-                .foregroundColor(isSelected ? bgColor : textSecondary)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
-                .background(isSelected ? accentGreen : Color.clear)
-                .cornerRadius(8)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Noise control: \(modeName)\(isSelected ? " (selected)" : "")")
-        .accessibilityIdentifier("anc-\(label.lowercased())")
-    }
-
-    // MARK: - Volume
-
-    private var volumeSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                sectionLabel("VOLUME")
-                Spacer()
-                Text("\(Int(volumeSliderValue))/\(manager.volumeMax)")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(textSecondary)
-                    .accessibilityLabel("Volume: \(Int(volumeSliderValue)) of \(manager.volumeMax)")
-            }
-
-            HStack(spacing: 8) {
-                Image(systemName: "speaker.fill")
-                    .font(.system(size: 11))
-                    .foregroundColor(textSecondary)
-                    .accessibilityLabel("Volume minimum")
-
-                Slider(value: $volumeSliderValue, in: 0...Double(manager.volumeMax), step: 1) { editing in
-                    if !editing {
-                        manager.setVolume(Int(volumeSliderValue))
-                    }
-                }
-                .accentColor(accentGreen)
-                .accessibilityLabel("Volume slider")
-                .accessibilityValue("\(Int(volumeSliderValue)) of \(manager.volumeMax)")
-                .accessibilityIdentifier("volume-slider")
-
-                Image(systemName: "speaker.wave.3.fill")
-                    .font(.system(size: 11))
-                    .foregroundColor(textSecondary)
-                    .accessibilityLabel("Volume maximum")
-            }
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Volume section")
-    }
-
-    // MARK: - EQ
-
-    private var eqSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            sectionLabel("EQUALIZER")
-
-            // Presets
-            HStack(spacing: 6) {
-                eqPresetButton("Flat", bass: 0, mid: 0, treble: 0)
-                eqPresetButton("Bass+", bass: 6, mid: 0, treble: -2)
-                eqPresetButton("Treble+", bass: -2, mid: 0, treble: 6)
-                eqPresetButton("Vocal", bass: -2, mid: 4, treble: 2)
-            }
-
-            // Sliders
-            eqSlider("Bass", value: $eqBass, band: 0)
-            eqSlider("Mid", value: $eqMid, band: 1)
-            eqSlider("Treble", value: $eqTreble, band: 2)
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Equalizer section")
-    }
-
-    private func eqPresetButton(_ label: String, bass: Int, mid: Int, treble: Int) -> some View {
-        let isSelected = manager.eq.bass == bass && manager.eq.mid == mid && manager.eq.treble == treble
-        return Button(action: {
-            eqBass = Double(bass)
-            eqMid = Double(mid)
-            eqTreble = Double(treble)
-            manager.setEQ(bass: bass, mid: mid, treble: treble)
-        }) {
-            Text(label)
-                .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
-                .foregroundColor(isSelected ? bgColor : textSecondary)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
-                .background(isSelected ? accentGreen : cardColor)
-                .cornerRadius(6)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("EQ preset: \(label)\(isSelected ? " (selected)" : "")")
-    }
-
-    private func eqSlider(_ label: String, value: Binding<Double>, band: Int) -> some View {
-        HStack(spacing: 8) {
-            Text(label)
-                .font(.system(size: 11))
-                .foregroundColor(textSecondary)
-                .frame(width: 42, alignment: .leading)
-
-            Slider(value: value, in: -10...10, step: 1) { editing in
-                if !editing {
-                    manager.setEQ(
-                        bass: Int(eqBass),
-                        mid: Int(eqMid),
-                        treble: Int(eqTreble)
-                    )
-                }
-            }
-            .accentColor(accentGreen)
-            .accessibilityLabel("\(label) equalizer")
-            .accessibilityValue("\(Int(value.wrappedValue))")
-
-            Text("\(Int(value.wrappedValue))")
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(textPrimary)
-                .frame(width: 24, alignment: .trailing)
-        }
-    }
-
-    // MARK: - Settings
-
-    private var settingsSection: some View {
-        DisclosureGroup(
-            isExpanded: $showSettings,
-            content: {
-                VStack(spacing: 10) {
-                    // Device name
-                    HStack {
-                        Text("Name")
-                            .font(.system(size: 12))
-                            .foregroundColor(textSecondary)
-                        Spacer()
-                        if editingName {
-                            HStack(spacing: 4) {
-                                TextField("Name", text: $nameField)
-                                    .textFieldStyle(.plain)
-                                    .font(.system(size: 12))
-                                    .foregroundColor(textPrimary)
-                                    .frame(width: 120)
-                                    .padding(4)
-                                    .background(cardColor)
-                                    .cornerRadius(4)
-                                    .onSubmit {
-                                        manager.setDeviceName(nameField)
-                                        editingName = false
-                                    }
-                                    .accessibilityLabel("Device name text field")
-                                    .accessibilityIdentifier("device-name-field")
-                                Button("Save") {
-                                    manager.setDeviceName(nameField)
-                                    editingName = false
-                                }
-                                .font(.system(size: 10))
-                                .buttonStyle(.plain)
-                                .foregroundColor(accentGreen)
-                                .accessibilityLabel("Save device name")
-                                .accessibilityIdentifier("save-device-name")
-                            }
-                        } else {
-                            Button(action: {
-                                nameField = manager.deviceName
-                                editingName = true
-                            }) {
-                                Text(manager.deviceName)
-                                    .font(.system(size: 12))
-                                    .foregroundColor(textPrimary)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("Edit device name: \(manager.deviceName)")
-                            .accessibilityIdentifier("edit-device-name")
-                        }
-                    }
-                    .accessibilityElement(children: .contain)
-                    .accessibilityLabel("Device name setting")
-
-                    // Multipoint toggle
-                    HStack {
-                        Text("Multipoint")
-                            .font(.system(size: 12))
-                            .foregroundColor(textSecondary)
-                        Spacer()
-                        Toggle("", isOn: Binding(
-                            get: { manager.multipointEnabled },
-                            set: { manager.setMultipoint($0) }
-                        ))
-                        .toggleStyle(.switch)
-                        .scaleEffect(0.7)
-                        .frame(width: 40)
-                        .accessibilityLabel("Multipoint toggle, \(manager.multipointEnabled ? "enabled" : "disabled")")
-                        .accessibilityIdentifier("multipoint-toggle")
-                    }
-                    .accessibilityElement(children: .contain)
-                    .accessibilityLabel("Multipoint setting")
-
-                    // Auto-off timer
-                    settingsRow("Auto-off", value: manager.autoOffTimer.isEmpty ? "-" : manager.autoOffTimer)
-                        .accessibilityLabel("Auto-off timer: \(manager.autoOffTimer.isEmpty ? "not set" : manager.autoOffTimer)")
-
-                    // CNC Level (custom ANC depth)
-                    HStack(spacing: 8) {
-                        Text("ANC Depth")
-                            .font(.system(size: 12))
-                            .foregroundColor(textSecondary)
-                            .frame(width: 65, alignment: .leading)
-
-                        Slider(value: $cncSliderValue, in: 0...10, step: 1) { editing in
-                            if !editing {
-                                manager.setCncLevel(Int(cncSliderValue))
-                            }
-                        }
-                        .accentColor(accentGreen)
-
-                        Text("\(Int(cncSliderValue))")
-                            .font(.system(size: 11, design: .monospaced))
-                            .foregroundColor(textPrimary)
-                            .frame(width: 20, alignment: .trailing)
-                    }
-                    .accessibilityLabel("ANC depth: \(Int(cncSliderValue))")
-
-                    // Wear detection
-                    HStack {
-                        Text("Wear Detection")
-                            .font(.system(size: 12))
-                            .foregroundColor(textSecondary)
-                        Spacer()
-                        HStack(spacing: 4) {
-                            Circle()
-                                .fill(manager.onHead ? accentGreen : .orange)
-                                .frame(width: 6, height: 6)
-                            Text(manager.onHead ? "On head" : "Off head")
-                                .font(.system(size: 12))
-                                .foregroundColor(textPrimary)
-                        }
-                    }
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel("Wear detection: \(manager.onHead ? "on head" : "off head")")
-
-                }
-                .padding(.top, 8)
-            },
-            label: {
-                sectionLabel("SETTINGS")
-            }
-        )
-        .accentColor(textSecondary)
-        .accessibilityLabel("Settings section, \(showSettings ? "expanded" : "collapsed")")
-        .accessibilityIdentifier("settings-disclosure")
-    }
-
-    // MARK: - Info
-
-    private var infoSection: some View {
-        DisclosureGroup(
-            isExpanded: $showInfo,
-            content: {
-                VStack(spacing: 8) {
-                    infoRow("Firmware", value: manager.firmware)
-                        .accessibilityLabel("Firmware: \(manager.firmware.isEmpty ? "unknown" : manager.firmware)")
-                    infoRow("Serial", value: manager.serialNumber)
-                        .accessibilityLabel("Serial number: \(manager.serialNumber.isEmpty ? "unknown" : manager.serialNumber)")
-                    infoRow("Product", value: manager.productName)
-                        .accessibilityLabel("Product: \(manager.productName.isEmpty ? "unknown" : manager.productName)")
-                    infoRow("Platform", value: manager.platform)
-                        .accessibilityLabel("Platform: \(manager.platform.isEmpty ? "unknown" : manager.platform)")
-                    infoRow("Codename", value: manager.codename)
-                        .accessibilityLabel("Codename: \(manager.codename.isEmpty ? "unknown" : manager.codename)")
-                    infoRow("Codec", value: manager.audioCodec)
-                        .accessibilityLabel("Audio codec: \(manager.audioCodec.isEmpty ? "unknown" : manager.audioCodec)")
-                    infoRow("MAC", value: BOSE_MAC.replacingOccurrences(of: "-", with: ":"))
-                        .accessibilityLabel("MAC address: \(BOSE_MAC)")
-                }
-                .padding(.top, 8)
-            },
-            label: {
-                sectionLabel("INFO")
-            }
-        )
-        .accentColor(textSecondary)
-        .accessibilityLabel("Info section, \(showInfo ? "expanded" : "collapsed")")
-        .accessibilityIdentifier("info-disclosure")
-    }
-
-    // MARK: - Helpers
-
-    private func syncSliders() {
-        volumeSliderValue = Double(manager.volume)
-        eqBass = Double(manager.eq.bass)
-        eqMid = Double(manager.eq.mid)
-        eqTreble = Double(manager.eq.treble)
-        cncSliderValue = Double(manager.cncLevel)
-    }
-
-    private func sectionLabel(_ text: String) -> some View {
-        Text(text)
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundColor(textSecondary)
-            .tracking(1)
-    }
-
-    private func settingsRow(_ label: String, value: String) -> some View {
-        HStack {
-            Text(label)
-                .font(.system(size: 12))
-                .foregroundColor(textSecondary)
-            Spacer()
-            Text(value)
-                .font(.system(size: 12))
-                .foregroundColor(textPrimary)
-        }
-    }
-
-    private func infoRow(_ label: String, value: String) -> some View {
-        HStack {
-            Text(label)
-                .font(.system(size: 11))
-                .foregroundColor(textSecondary)
-            Spacer()
-            Text(value.isEmpty ? "-" : value)
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(textPrimary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-        }
+        return activeColor
     }
 }


### PR DESCRIPTION
Replaces the portrait dark-green UI with a 640x360 landscape two-panel layout. Frosted dark theme via NSVisualEffectView with .hudWindow material. White/grey accents instead of neon green. Interactive sidebar (battery, ANC segmented buttons, volume slider). Right panel has 3x2 device grid with state colors, EQ presets + sliders. Cmd+M quick-connect Mac shortcut.