### PR TITLE
bose v2 follow-ups: info view, 3-state devices, anc-depth + name, capability map, parse nits

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Convert macOS app from menu bar to windowed UI
-Convert macOS app from menu bar to windowed UI
+bose v2 follow-ups #71: info view, 3-state devices, anc-depth + name verbs, capability map, parse nits
+bose v2 follow-ups #71: info view, 3-state devices, anc-depth + name verbs, capability map, parse nits
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - mac-windowed-app
+# Agent Progress - bose-v2-followups-71
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-04-06T03:41:27Z
+# Created: 2026-06-05T08:59:29Z
 
-feature=mac-windowed-app
-name=Convert macOS app from menu bar to windowed UI
+feature=bose-v2-followups-71
+name=bose v2 follow-ups #71: info view, 3-state devices, anc-depth + name verbs, capability map, parse nits
 status=pending
 step=0
 step_name=Not started
-created=2026-04-06T03:41:27Z
+created=2026-06-05T08:59:29Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,51 @@ Auto-off timer (01,0B) is read-only over RFCOMM — distinct from StandbyTimer (
 | AudioCodec | 0x04 | GET returns codec ID + bitrate |
 | Volume | **0x05** | GET/SET_GET: current + max level (0-31) |
 
+## Capability → Exposure Map
+
+Every BMAP capability and where each surface exposes it. Source: `bmap.toml`
+commands + the off-spec diagnostic GETs that `getAllState`/`parseAllState` issue
+directly (raw `[block,func,GET]`, not generated builders) + the Android control
+surface. Keep this in sync when adding a verb or control.
+
+**Legend:** ✅ get+set · 👁 read-only/display · — not exposed
+
+### `bmap.toml` commands
+
+| Capability | Block,Func | `bose-ctl` | Raycast | Hammerspoon | Android |
+|------------|-----------|-----------|---------|-------------|---------|
+| ANC mode | 1F,03 | ✅ `anc` | 👁 (in status) | — | ✅ mode selector |
+| ANC depth (CNC) | 1F,0A | ✅ `anc-depth` | ✅ `bose-anc-depth` | — | ✅ slider |
+| Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
+| EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
+| Multipoint | 01,0A | ✅ `multipoint` | — | — | ✅ toggle |
+| Connect device | 04,01 | ✅ `connect`/`swap` | ✅ `bose-connect` | ✅ Opt+B toggle | ✅ widget/tile/picker |
+| Disconnect device | 04,02 | ✅ `disconnect` | ✅ `bose-disconnect` | 👁 (toggle path) | — |
+| Device info (ACL) | 04,05 | 👁 `devices` (○ state) | — | — | 👁 widget colour |
+| Connected devices | 05,01 | 👁 `devices`/`status`/`info` | 👁 (in status) | 👁 toggle-direction | 👁 widget/tile active |
+| Media control | 05,03 | ✅ `play`/`pause`/`next`/`prev` | — | — | ✅ notification controls |
+| Audio codec | 05,04 | 👁 `info` | 👁 (full status) | — | 👁 state |
+| Volume | 05,05 | ✅ `volume` | 👁 (in status) | — | ✅ slider |
+| Firmware | 00,05 | 👁 `status`/`info` | 👁 (status) | — | 👁 state |
+| Battery | 02,02 | 👁 `battery`/`status`/`info` | 👁 (status) | — | 👁 widget overlay |
+
+### Off-spec diagnostic GETs (issued directly in `getAllState`, not in `bmap.toml`)
+
+| Capability | Block,Func | `bose-ctl` | Raycast | Android |
+|------------|-----------|-----------|---------|---------|
+| Serial number | 00,07 | 👁 `info` | 👁 (full status) | 👁 state |
+| Product name | 00,0F | 👁 `info` | 👁 (full status) | 👁 state |
+| Platform | 12,0D | 👁 `info` | 👁 (full status) | 👁 state |
+| Codename | 12,0C | 👁 `info` | 👁 (full status) | 👁 state |
+| Auto-off timer | 01,0B | 👁 `info` (read-only) | 👁 (full status) | 👁 state |
+| On-head / wear | 08,07 | 👁 `info` | 👁 (full status) | 👁 state |
+
+**Notable gaps (intentional):** Hammerspoon is deliberately one keypress (Opt+B
+Mac↔phone) and exposes nothing else. Raycast covers the common dropdowns
+(connect/disconnect/status) plus the full-status and ANC-depth additions; deeper
+config (EQ/name/multipoint) is CLI- or Android-only by design. The macOS surface
+has **no resident process** — every reading is on-demand, never polled.
+
 ## connectDevice Behaviour (verified 2026-04-11 via raw BMAP captures)
 
 **connectDevice pages offline devices.** It doesn't just route audio between

--- a/android/app/src/generated/java/au/com/jd/bose/BMAP.generated.kt
+++ b/android/app/src/generated/java/au/com/jd/bose/BMAP.generated.kt
@@ -47,6 +47,10 @@ object BMAP {
         return intArrayOf(0x04, 0x02, 0x05, 0x06) + mac
     }
 
+    fun getDeviceInfo(mac: IntArray): IntArray {
+        return intArrayOf(0x04, 0x05, 0x01, 0x06) + mac
+    }
+
     fun mediaControl(action: Int): IntArray {
         return intArrayOf(0x05, 0x03, 0x05, 0x01, (action and 0xFF))
     }

--- a/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
@@ -90,7 +90,9 @@ object BoseProtocol {
 
     fun getMultipoint(): Boolean? {
         val resp = Transport.send(BMAP.getMultipoint()) ?: return null
-        if (resp.size >= 5 && resp[2] == OP_RESP) return resp[4] == 0x07
+        // Wire values are 07=on / 00=off. Use `!= 0` to match Parsers.parseAllState
+        // and macOS Parsers.swift (both treat any non-zero byte as enabled).
+        if (resp.size >= 5 && resp[2] == OP_RESP) return resp[4] != 0x00
         return null
     }
 
@@ -237,10 +239,10 @@ object BoseProtocol {
 
     data class DeviceInfo(val status: Int, val name: String, val connected: Boolean)
 
-    /** GET device info (04,05). Status byte unreliable — cross-ref getConnectedDevices. */
+    /** GET device info (04,05). Status byte unreliable — cross-ref getConnectedDevices.
+     *  Request frame from the generated builder (device_info in bmap.toml). */
     fun getDeviceInfo(mac: IntArray): DeviceInfo? {
-        val frame = intArrayOf(0x04, 0x05, 0x01, 0x06) + mac
-        val resp = Transport.send(frame, timeoutMs = 2000) ?: return null
+        val resp = Transport.send(BMAP.getDeviceInfo(mac), timeoutMs = 2000) ?: return null
         if (resp.size < 11 || resp[2] != OP_RESP) return null
         val status = resp[10]
         val connected = (status and 0x01) != 0

--- a/cli/Composites.swift
+++ b/cli/Composites.swift
@@ -23,6 +23,13 @@ extension Transport {
         return parseConnectedDevices(r)
     }
 
+    /// GET the current CNC/ANC-depth level (1F,0A). nil if unreachable/unparsable.
+    /// Mirrors Android `Composites.getCncLevel()`.
+    func getCncLevel() -> Int? {
+        guard let r = oneShot(Transport.cncLevelGet) else { return nil }
+        return parseCncLevel(r).map { Int($0.level) }
+    }
+
     /// Read-modify-write the CNC level (1F,0A): preserve the other four fields.
     @discardableResult
     func setCncLevel(_ level: Int) -> Bool {
@@ -39,4 +46,31 @@ extension Transport {
             parseAllState { block, function in t.send(ch, [block, function, 0x01, 0x00], timeout: 2.0) }
         }
     }
+
+    /// Three-state device readout in ONE RFCOMM session:
+    ///   `active`    — audio sink (05,01 ground truth)
+    ///   `connected` — ACL up (per-device 04,05) but NOT the active sink
+    /// Already-active devices skip the per-device probe. Returns nil only if the
+    /// session can't open (headphones unreachable). The 04,05 request frame comes
+    /// from the generated `BMAP.getDeviceInfo`; only the response decode is hand-written.
+    func getDeviceStates(query devices: [[UInt8]]) -> (active: [[UInt8]], connected: [[UInt8]])? {
+        session { ch, t in
+            let active = t.send(ch, Transport.connectedDevicesGet).map { parseConnectedDevices($0) } ?? []
+            let activeKeys = Set(active.map { macKey($0) })
+            var connected: [[UInt8]] = []
+            for mac in devices where !activeKeys.contains(macKey(mac)) {
+                if let r = t.send(ch, BMAP.getDeviceInfo(mac: mac), timeout: 2.0),
+                   parseDeviceInfo(r)?.connected == true {
+                    connected.append(mac)
+                }
+            }
+            return (active, connected)
+        }
+    }
+}
+
+/// Uppercase-hex MAC key for set membership (keeps this file independent of
+/// main.swift's `macString`).
+private func macKey(_ mac: [UInt8]) -> String {
+    mac.map { String(format: "%02X", $0) }.joined()
 }

--- a/cli/Parsers.swift
+++ b/cli/Parsers.swift
@@ -76,6 +76,26 @@ func buildCncSet(level: Int, preserving cfg: CncConfig) -> [UInt8] {
      cfg.autoCNC, cfg.spatial, cfg.windBlock, cfg.ancToggle]
 }
 
+/// Decoded per-device info (04,05 RESP). `connected` is ACL presence (status
+/// bit 0) — reliable for "is this device linked at all", NOT for audio routing
+/// (use parseConnectedDevices / 05,01 for the active sink). Mirrors the Android
+/// `BoseProtocol.DeviceInfo` decode (status at byte 10, optional name from 13).
+struct DeviceInfo: Equatable {
+    var status: Int
+    var name: String
+    var connected: Bool
+}
+
+/// Parse a device-info RESPONSE (04,05): status byte at index 10, optional
+/// length-prefixed name from index 13. Returns nil on a short/non-RESP frame.
+func parseDeviceInfo(_ resp: [UInt8]) -> DeviceInfo? {
+    guard resp.count >= 11, resp[2] == OP_RESP_BYTE else { return nil }
+    let status = Int(resp[10])
+    let connected = (status & 0x01) != 0
+    let name = resp.count > 13 ? parseString(resp, from: 13) : ""
+    return DeviceInfo(status: status, name: name, connected: connected)
+}
+
 /// Decode a UTF-8 string field response from a given payload offset.
 func parseString(_ resp: [UInt8], from offset: Int = 4) -> String {
     guard resp.count > offset else { return "" }

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -97,6 +97,29 @@ check(state.eq.bass == 3 && state.eq.mid == 0 && state.eq.treble == -3, "allStat
 let empty = parseAllState { _, _ in nil }
 check(empty.batteryLevel == 0 && empty.connectedDevices.isEmpty, "allState: all-nil provider -> defaults")
 
+// ── parseDeviceInfo (04,05) ──────────────────────────────────────────────────────
+
+// RESP: status byte at index 10 (bit0 = ACL connected), optional name from index 13.
+let devInfoConnected: [UInt8] = [
+    0x04, 0x05, 0x03, 0x10,             // header (RESP)
+    0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x27, // bytes 4..9 (echoed mac — ignored)
+    0x03,                              // byte 10 = status, bit0 set -> connected
+    0x00, 0x00,                        // bytes 11,12 filler
+] + Array("mac".utf8)                  // name from byte 13
+let di = parseDeviceInfo(devInfoConnected)
+check(di?.connected == true, "deviceInfo: status bit0 set -> connected")
+check(di?.status == 3, "deviceInfo: status == 3")
+check(di?.name == "mac", "deviceInfo: name parsed from byte 13")
+
+// status bit0 clear -> not connected, no name present.
+let devInfoOffline: [UInt8] = [0x04, 0x05, 0x03, 0x07, 0xF4, 0x81, 0xC4, 0xB5, 0xFA, 0xAB, 0x00]
+check(parseDeviceInfo(devInfoOffline)?.connected == false, "deviceInfo: status bit0 clear -> not connected")
+
+// Short frame and non-RESP (GET echo) -> nil.
+check(parseDeviceInfo([0x04, 0x05, 0x03, 0x00]) == nil, "deviceInfo: short frame -> nil")
+check(parseDeviceInfo([0x04, 0x05, 0x01, 0x06, 0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x27, 0x00]) == nil,
+      "deviceInfo: non-RESP (GET echo) -> nil")
+
 // ── summary ─────────────────────────────────────────────────────────────────────
 
 if failures == 0 {

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -63,6 +63,52 @@ func cmdStatus() {
     if !s.firmware.isEmpty { print("Firmware: \(s.firmware)") }
 }
 
+/// info — the COMPLETE HeadphoneState from getAllState (one RFCOMM session).
+/// `status` is the quick subset; `info` dumps everything the bulk read returns
+/// (identity, power/wear, full audio config, and the audio-active device list).
+/// No new protocol work — pure formatting over the existing composite.
+func cmdInfo() {
+    guard let s = transport.getAllState() else { fail("headphones not reachable") }
+
+    // Left-pad a 12-char label so values line up in a column.
+    func row(_ key: String, _ value: String) {
+        print("\(key.padding(toLength: 12, withPad: " ", startingAt: 0))\(value)")
+    }
+
+    // Identity
+    if !s.productName.isEmpty  { row("Product:", s.productName) }
+    if !s.deviceName.isEmpty   { row("Name:", s.deviceName) }
+    if !s.firmware.isEmpty     { row("Firmware:", s.firmware) }
+    if !s.serialNumber.isEmpty { row("Serial:", s.serialNumber) }
+    if !s.platform.isEmpty     { row("Platform:", s.platform) }
+    if !s.codename.isEmpty     { row("Codename:", s.codename) }
+
+    // Power / wear
+    row("Battery:", "\(s.batteryLevel)%\(s.batteryCharging ? " ⚡" : "")")
+    row("On head:", s.onHead ? "yes" : "no")
+    if !s.autoOffTimer.isEmpty {
+        // Encoding unverified over RFCOMM (read-only field) — show raw bytes.
+        row("Auto-off:", s.autoOffTimer.map { String(format: "%02X", $0) }.joined(separator: " "))
+    }
+
+    // Audio
+    row("ANC:", ancModeName(s.ancMode))
+    row("ANC depth:", "\(s.cncLevel)/10")
+    row("Volume:", "\(s.volume)/\(s.volumeMax)")
+    row("EQ:", "bass \(s.eq.bass)  mid \(s.eq.mid)  treble \(s.eq.treble)")
+    if !s.audioCodec.isEmpty { row("Codec:", s.audioCodec) }
+    row("Multipoint:", s.multipointEnabled ? "on" : "off")
+
+    // Audio-active devices (05,01); first entry is the active sink.
+    let names = s.connectedDevices.map { displayName(forMac: $0) }
+    if names.isEmpty {
+        row("Devices:", "none")
+    } else {
+        row("Devices:", "\(names[0]) (active)")
+        for n in names.dropFirst() { row("", n) }
+    }
+}
+
 func ancModeName(_ mode: Int) -> String {
     AncMode(rawValue: UInt8(truncatingIfNeeded: mode))
         .map { "\($0)" } ?? "unknown(\(mode))"
@@ -97,17 +143,50 @@ func cmdAnc(_ mode: String?) {
     print("ANC: \(ancModeName(Int(r[4])))")
 }
 
-/// devices — known devices with audio-active / connection state (ground truth).
-/// Uses the getConnectedDevices composite (05,01) — the reliable source — not the
-/// v1 unreliable getDeviceInfo status byte.
+/// anc-depth [0-10] — get/set ANC/CNC depth. SET is a read-modify-write composite
+/// (preserves autoCNC/spatial/windBlock/ancToggle); GET reads the live level.
+func cmdAncDepth(_ arg: String?) {
+    if let arg = arg {
+        guard let level = Int(arg), (0...10).contains(level) else { fail("anc-depth must be 0-10") }
+        guard transport.setCncLevel(level) else { fail("failed to set ANC depth") }
+    }
+    guard let level = transport.getCncLevel() else { fail("ANC depth query failed") }
+    print("ANC depth: \(level)/10")
+}
+
+/// name [new name] — get/set the headphone name. SET is `01,02,06,{len},00,{utf8}`
+/// (max 30 UTF-8 bytes): the generated builder emits only the [block,func,op]
+/// header, so the length-prefixed body is hand-assembled here (mirrors Android
+/// `BoseProtocol.setDeviceName`).
+func cmdName(_ newName: String?) {
+    if let newName = newName {
+        let nameBytes = Array(newName.utf8)
+        guard !nameBytes.isEmpty, nameBytes.count <= 30 else {
+            fail("name must be 1-30 UTF-8 bytes")
+        }
+        let header = BMAP.setDeviceName()           // [0x01, 0x02, 0x06, 0x00]
+        let frame = [header[0], header[1], header[2], UInt8(nameBytes.count + 1), 0x00] + nameBytes
+        guard transport.oneShot(frame) != nil else { fail("failed to set name") }
+    }
+    guard let r = transport.oneShot([0x01, 0x02, 0x01, 0x00]),
+          r.count >= 6, r[2] == OP_RESP_BYTE else { fail("name query failed") }
+    print("Name: \(parseString(r, from: 5))")
+}
+
+/// devices — known devices in three states (one RFCOMM session):
+///   ● active     — audio sink (getConnectedDevices, 05,01 ground truth)
+///   ○ connected  — ACL up but not the active sink (per-device getDeviceInfo, 04,05)
+///   · offline    — neither
+/// The v1 readout conflated connected-idle and offline under a single `·`.
 func cmdDevices() {
-    let connected = Set(transport.getConnectedDevices().map { macString($0) })
-    if connected.isEmpty && !transport.isHeadphoneConnected() {
+    guard let states = transport.getDeviceStates(query: BoseDeviceMap.knownDevices.map { $0.mac }) else {
         fail("headphones not reachable")
     }
+    let active = Set(states.active.map { macString($0) })
+    let idle = Set(states.connected.map { macString($0) })
     for dev in BoseDeviceMap.knownDevices {
-        let isConnected = connected.contains(dev.macString)
-        let state = isConnected ? "●" : "·"
+        let state = active.contains(dev.macString) ? "●"
+                  : idle.contains(dev.macString) ? "○" : "·"
         print("  \(state) \(dev.name)")
     }
 }
@@ -282,12 +361,15 @@ func usage() {
 
     Usage:
       bose-ctl status               Connection, battery, ANC, volume, EQ (one session)
+      bose-ctl info                 Full state: identity, power, all audio config, devices
       bose-ctl battery              Battery level
-      bose-ctl devices              Known devices with audio-active state
+      bose-ctl devices              Known devices: ● active / ○ connected / · offline
       bose-ctl connect <device>     Route audio to device (poll-confirmed)
       bose-ctl disconnect <device>  Disconnect a device
       bose-ctl swap <device>        Route audio to device (multipoint; keeps others)
       bose-ctl anc [mode]           Get/set ANC (quiet/aware/custom1/custom2)
+      bose-ctl anc-depth [0-10]     Get/set ANC depth (0=min … 10=max)
+      bose-ctl name [new name]      Get/set headphone name (max 30 UTF-8 bytes)
       bose-ctl volume [0-31]        Get/set volume
       bose-ctl multipoint [on|off]  Get/set multipoint
       bose-ctl play|pause|next|prev Media transport
@@ -308,8 +390,11 @@ func requireArg(_ name: String) -> String {
 
 switch args[1].lowercased() {
 case "status", "s":            cmdStatus()
+case "info":                   cmdInfo()
 case "battery", "b":           cmdBattery()
 case "anc":                    cmdAnc(args.count >= 3 ? args[2] : nil)
+case "anc-depth":              cmdAncDepth(args.count >= 3 ? args[2] : nil)
+case "name":                   cmdName(args.count >= 3 ? args[2...].joined(separator: " ") : nil)
 case "devices":                cmdDevices()
 case "connect", "c":           cmdConnect(requireArg("device"))
 case "disconnect", "d":        cmdDisconnect(requireArg("device"))

--- a/protocol/generated/BMAP.generated.kt
+++ b/protocol/generated/BMAP.generated.kt
@@ -47,6 +47,10 @@ object BMAP {
         return intArrayOf(0x04, 0x02, 0x05, 0x06) + mac
     }
 
+    fun getDeviceInfo(mac: IntArray): IntArray {
+        return intArrayOf(0x04, 0x05, 0x01, 0x06) + mac
+    }
+
     fun mediaControl(action: Int): IntArray {
         return intArrayOf(0x05, 0x03, 0x05, 0x01, (action and 0xFF))
     }

--- a/protocol/generated/BMAP.generated.swift
+++ b/protocol/generated/BMAP.generated.swift
@@ -71,6 +71,10 @@ enum BMAP {
         return [0x04, 0x02, 0x05, 0x06] + mac
     }
 
+    static func getDeviceInfo(mac: [UInt8]) -> [UInt8] {
+        return [0x04, 0x05, 0x01, 0x06] + mac
+    }
+
     static func mediaControl(action: UInt8) -> [UInt8] {
         return [0x05, 0x03, 0x05, 0x01, action]
     }

--- a/protocol/spec/bmap.toml
+++ b/protocol/spec/bmap.toml
@@ -182,6 +182,25 @@ disconnect_mac = "04 02 05 06 BC D0 74 11 DB 27"
 [commands.disconnect_device.test_args]
 disconnect_mac = { mac = "BC:D0:74:11:DB:27" }
 
+[commands.device_info]
+block = 0x04
+function = 0x05
+summary = "GET per-device info (ACL state). Status byte unreliable for AUDIO routing — cross-ref connected_devices; reliable only for ACL presence."
+# Request `04,05,01,06,{MAC}` is a clean generated GET+MAC builder (like eq_band.get).
+# Only the variable-length response decode (status byte + name) is hand-written
+# per-platform, so this is NOT marked composite.
+
+[commands.device_info.get]
+operator = "GET"
+payload = ["mac:mac"]
+
+[commands.device_info.verified_bytes]
+# `04,05,01,06,{MAC}` — mac device from device map (BC:D0:74:11:DB:27)
+get_mac = "04 05 01 06 BC D0 74 11 DB 27"
+
+[commands.device_info.test_args]
+get_mac = { mac = "BC:D0:74:11:DB:27" }
+
 
 # ── Block 0x05 — Audio ─────────────────────────────────────────────────────────
 

--- a/raycast/bose-anc-depth.sh
+++ b/raycast/bose-anc-depth.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Raycast script command — get/set Bose ANC depth (0=min … 10=max).
+# Leave the argument blank to read the current depth.
+# Requires the Bose to be connected to this Mac (it talks over RFCOMM on demand).
+#
+# @raycast.schemaVersion 1
+# @raycast.title Bose: ANC Depth
+# @raycast.mode inline
+# @raycast.icon 🎧
+# @raycast.packageName Bose
+# @raycast.argument1 { "type": "text", "placeholder": "0-10 (blank = read)", "optional": true }
+
+"$HOME/bin/bose-ctl" anc-depth "$1"

--- a/raycast/bose-full-status.sh
+++ b/raycast/bose-full-status.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Raycast script command — full Bose QC Ultra state (identity, power, all audio
+# config, multipoint, codec, and the audio-active device list).
+# Requires the Bose to be connected to this Mac (it talks over RFCOMM on demand).
+#
+# @raycast.schemaVersion 1
+# @raycast.title Bose: Full Status
+# @raycast.mode fullOutput
+# @raycast.icon 🎧
+# @raycast.packageName Bose
+
+"$HOME/bin/bose-ctl" info


### PR DESCRIPTION
Closes #71

Five non-blocking enhancement follow-ups from PR #70.

- **#1** `bose-ctl info` — full `HeadphoneState` dump + `raycast/bose-full-status.sh`
- **#2** `bose-ctl devices` 3-state (● active / ○ connected / · offline) via one-session `getDeviceStates` composite + `parseDeviceInfo`
- **#3** `bose-ctl anc-depth` + `bose-ctl name` verbs (Swift `getCncLevel`) + `raycast/bose-anc-depth.sh`
- **#4** capability → exposure map in CLAUDE.md
- **#5a** `device_info` (04,05) added to bmap.toml as a generated GET+MAC builder; both platforms call `BMAP.getDeviceInfo`
- **#5b** Android `getMultipoint` aligned to `!= 0x00`

CI green: cli build+tests, protocol make check (29), Android assembleDebug+testDebugUnitTest. Hardware-smoked by James.