### PR TITLE
bose profiles + context automation

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-bose v2 follow-ups #71: info view, 3-state devices, anc-depth + name verbs, capability map, parse nits
-bose v2 follow-ups #71: info view, 3-state devices, anc-depth + name verbs, capability map, parse nits
+bose profiles + context automation: presets, battery nudge, ANC cycle chord, Focus hooks
+bose profiles + context automation: presets, battery nudge, ANC cycle chord, Focus hooks
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - bose-v2-followups-71
+# Agent Progress - bose-profiles-automation
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-05T08:59:29Z
+# Created: 2026-06-05T09:29:45Z
 
-feature=bose-v2-followups-71
-name=bose v2 follow-ups #71: info view, 3-state devices, anc-depth + name verbs, capability map, parse nits
+feature=bose-profiles-automation
+name=bose profiles + context automation: presets, battery nudge, ANC cycle chord, Focus hooks
 status=pending
 step=0
 step_name=Not started
-created=2026-06-05T08:59:29Z
+created=2026-06-05T09:29:45Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,10 @@ original audio-dropout cause — #69-era). The Mac control surface is two thin
 front-ends that shell out to the `cli/` binary (`~/bin/bose-ctl`), so nothing runs
 in the background and the Mac only touches the headphones on an explicit keypress.
 - `raycast/bose-connect.sh` / `bose-disconnect.sh` -- Raycast script commands with a device dropdown → `bose-ctl connect|disconnect <device>`
-- `raycast/bose-status.sh` -- `bose-ctl status` (battery/ANC/volume/EQ)
-- `hammerspoon/bose.lua` -- Hammerspoon module: **Opt+B toggles Mac ↔ phone**. Decides direction from the Mac's default OUTPUT device (`verBosita` ⇒ on Mac), routes via async `bose-ctl`, sets the Mac output device, and shows an alert. Returns a table with `.start()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()` (guarded by a file-exists check, so it activates automatically once this file is on `main`).
+- `raycast/bose-status.sh` / `bose-full-status.sh` -- `bose-ctl status` / `bose-ctl info`
+- `raycast/bose-anc-depth.sh` / `bose-profile.sh` -- `bose-ctl anc-depth [0-10]` / `bose-ctl profile [name]` (text arg)
+- `profiles.json` (repo root) -- settings presets ({ANC mode, depth, EQ, multipoint, volume}) applied by `bose-ctl profile`; versioned + hand-editable, ships flight/office/music. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
+- `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B toggles Mac ↔ phone** (+ one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→custom1), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
 - The Swift core that does the actual RFCOMM work lives in `cli/` (see below) — there is no separate macOS Swift target.
 
 ### Android (`android/`) — regenerated protocol on the kept architecture
@@ -245,7 +247,7 @@ surface. Keep this in sync when adding a verb or control.
 
 | Capability | Block,Func | `bose-ctl` | Raycast | Hammerspoon | Android |
 |------------|-----------|-----------|---------|-------------|---------|
-| ANC mode | 1F,03 | ✅ `anc` | 👁 (in status) | — | ✅ mode selector |
+| ANC mode | 1F,03 | ✅ `anc` | 👁 (in status) | ✅ Opt+N cycle + call-app hook | ✅ mode selector |
 | ANC depth (CNC) | 1F,0A | ✅ `anc-depth` | ✅ `bose-anc-depth` | — | ✅ slider |
 | Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
 | EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
@@ -271,11 +273,15 @@ surface. Keep this in sync when adding a verb or control.
 | Auto-off timer | 01,0B | 👁 `info` (read-only) | 👁 (full status) | 👁 state |
 | On-head / wear | 08,07 | 👁 `info` | 👁 (full status) | 👁 state |
 
-**Notable gaps (intentional):** Hammerspoon is deliberately one keypress (Opt+B
-Mac↔phone) and exposes nothing else. Raycast covers the common dropdowns
-(connect/disconnect/status) plus the full-status and ANC-depth additions; deeper
-config (EQ/name/multipoint) is CLI- or Android-only by design. The macOS surface
-has **no resident process** — every reading is on-demand, never polled.
+**Profiles** compose several of these capabilities at once — a `bose-ctl profile`
+applies {ANC mode, ANC depth, EQ, multipoint, volume} in one session (CLI +
+`bose-profile.sh` Raycast; drivable from macOS Focus via a Shortcut, see README).
+
+**Notable gaps (intentional):** Hammerspoon now does Opt+B (toggle), Opt+N (ANC
+cycle), and a call-app launch hook — still all event-driven, no timers. Raycast
+covers the common dropdowns plus full-status / anc-depth / profile; deeper config
+(EQ/name/multipoint) is CLI- or Android-only by design. The macOS surface has
+**no resident process** — every reading is on-demand, never polled.
 
 ## connectDevice Behaviour (verified 2026-04-11 via raw BMAP captures)
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ See `CLAUDE.md` for the protocol tables, device map, and hard-won lessons.
 |------|------|
 | `protocol/` | `bmap.toml` + `devices.toml` spec, Python codegen, golden byte tests. `make gen` regenerates `protocol/generated/{BMAP,Devices}.generated.{swift,kt}`. |
 | `cli/` | `bose-ctl` CLI + the Swift core (`Transport`/`Parsers`/`Composites`) + generated Swift. The on-demand RFCOMM engine the Mac front-ends call. |
-| `raycast/` | Raycast script commands (connect / disconnect / status) → `bose-ctl`. |
-| `hammerspoon/` | `bose.lua` — Opt+B toggles Mac ↔ phone via `bose-ctl`. |
+| `raycast/` | Raycast script commands (connect / disconnect / status / full-status / anc-depth / profile) → `bose-ctl`. |
+| `hammerspoon/` | `bose.lua` — Opt+B toggles Mac ↔ phone, Opt+N cycles ANC, call-app launch → ANC aware, low-battery warning on toggle. All event-driven. |
+| `profiles.json` | Settings presets ({ANC, depth, EQ, multipoint, volume}) applied via `bose-ctl profile`. Versioned + editable. |
 | `android/` | Jetpack Compose app + foreground service (package `au.com.jd.bose`). |
 
 The Mac has **no resident app** — Raycast + Hammerspoon shell out to `bose-ctl` on demand (a background poller was the original audio-dropout cause).
@@ -40,18 +41,56 @@ protocol, so the clients cannot drift on wire encoding or transport behaviour.
 
 ```
 bose-ctl status               Connection, battery, ANC, volume, EQ (one session)
+bose-ctl info                 Full state: identity, power, all audio config, devices
 bose-ctl battery              Battery level
-bose-ctl devices              Known devices with audio-active state
+bose-ctl devices              Known devices: ● active / ○ connected / · offline
 bose-ctl connect <device>     Route audio to device (poll-confirmed)
 bose-ctl disconnect <device>  Disconnect a device
 bose-ctl swap <device>        Route audio to device (multipoint; keeps others)
 bose-ctl anc [mode]           Get/set ANC (quiet/aware/custom1/custom2)
+bose-ctl anc-depth [0-10]     Get/set ANC depth (0=min … 10=max)
+bose-ctl name [new name]      Get/set headphone name (max 30 UTF-8 bytes)
 bose-ctl volume [0-31]        Get/set volume
 bose-ctl multipoint [on|off]  Get/set multipoint
 bose-ctl play|pause|next|prev Media transport
 bose-ctl eq [bass mid treble] Get/set EQ (each -10 to +10)
+bose-ctl profile [name]       Apply a preset (bare = list); save <name> / rm <name>
 bose-ctl raw <hex>            Send raw BMAP bytes
 ```
+
+## Profiles
+
+A profile is a named bundle of settings — ANC mode, ANC depth, EQ, multipoint, volume —
+applied in one RFCOMM session. They live in `profiles.json` (versioned, hand-editable);
+ships with `flight`, `office`, `music`. A profile only sets the fields it defines.
+
+```bash
+bose-ctl profile                 # list
+bose-ctl profile flight          # apply
+bose-ctl profile save commute    # snapshot the current settings as "commute"
+bose-ctl profile rm commute      # remove
+```
+
+Override the file location with `$BOSE_PROFILES`.
+
+## Automation (event-driven — never polled)
+
+The cardinal rule is **no background polling of the headphones**. These hooks fire on a
+keypress or an OS event, then make one on-demand `bose-ctl` call.
+
+**Hammerspoon** (`hammerspoon/bose.lua`, reload Hammerspoon after editing):
+- `Opt+B` — toggle audio Mac ↔ phone (also warns if battery ≤ 20%, piggybacking the press).
+- `Opt+N` — cycle ANC quiet → aware → custom1.
+- Launching a call app (Teams / Zoom / Meet) switches ANC to aware. Edit `AWARE_ON_LAUNCH`
+  / the chords at the top of `bose.lua` to taste.
+
+**macOS Focus → Shortcuts** (drive profiles from Focus modes, zero polling):
+1. Shortcuts app → new shortcut "Bose Office" → **Run Shell Script**: `~/bin/bose-ctl profile office`.
+   (Repeat per profile: "Bose Flight" → `… profile flight`, etc.)
+2. System Settings → Focus → pick a Focus (e.g. Work) → **Add Automation / Focus filter** →
+   run the matching shortcut on activation.
+
+Apple doesn't expose Focus automations to scripting, so step 2 is a one-time manual wire-up.
 
 ## Protocol
 

--- a/cli/Composites.swift
+++ b/cli/Composites.swift
@@ -67,6 +67,25 @@ extension Transport {
             return (active, connected)
         }
     }
+
+    /// Apply a profile in ONE RFCOMM session. Reads the live CNC config first (only
+    /// if the profile sets ancDepth — that's a read-modify-write), then sends every
+    /// SET the profile defines. Returns false if the session can't open or the
+    /// profile sets nothing.
+    @discardableResult
+    func applyProfile(_ p: Profile) -> Bool {
+        session { ch, t in
+            var cnc: CncConfig? = nil
+            if p.ancDepth != nil, let cur = t.send(ch, Transport.cncLevelGet) {
+                cnc = parseCncLevel(cur)
+            }
+            let frames = profileFrames(p, currentCnc: cnc)
+            guard !frames.isEmpty else { return false }
+            var ok = true
+            for f in frames where t.send(ch, f) == nil { ok = false }
+            return ok
+        } ?? false
+    }
 }
 
 /// Uppercase-hex MAC key for set membership (keeps this file independent of

--- a/cli/Profiles.swift
+++ b/cli/Profiles.swift
@@ -1,0 +1,143 @@
+/// Profiles: named bundles of settings ({ANC mode, ANC depth, EQ, multipoint,
+/// volume}) saved and applied as a unit. Foundation-only (no IOBluetooth): the
+/// pure frame-building + JSON load/save live here and unit-test without hardware;
+/// the live-session apply is `Transport.applyProfile` in Composites.swift.
+///
+/// Storage is JSON (not TOML like the wire spec) because the binary reads AND
+/// writes it at runtime — `profile save` — and Swift has no zero-dep TOML writer.
+/// The file is git-tracked in the repo (versioned), default `~/code/personal/bose/
+/// profiles.json`, overridable via `$BOSE_PROFILES`.
+
+import Foundation
+
+struct EqValues: Codable, Equatable {
+    var bass: Int
+    var mid: Int
+    var treble: Int
+}
+
+/// A settings preset. Every field is optional — a profile only touches what it sets.
+struct Profile: Codable, Equatable {
+    var name: String
+    var ancMode: String? = nil      // quiet / aware / custom1 / custom2
+    var ancDepth: Int? = nil        // 0-10
+    var eq: EqValues? = nil
+    var multipoint: Bool? = nil
+    var volume: Int? = nil          // 0-31
+
+    enum CodingKeys: String, CodingKey { case name, ancMode, ancDepth, eq, multipoint, volume }
+
+    // Custom encode so unset fields are omitted (clean, human-editable JSON) rather
+    // than written as nulls.
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(name, forKey: .name)
+        try c.encodeIfPresent(ancMode, forKey: .ancMode)
+        try c.encodeIfPresent(ancDepth, forKey: .ancDepth)
+        try c.encodeIfPresent(eq, forKey: .eq)
+        try c.encodeIfPresent(multipoint, forKey: .multipoint)
+        try c.encodeIfPresent(volume, forKey: .volume)
+    }
+
+    /// One-line summary of the fields this profile sets (for `profile` listing).
+    var summary: String {
+        var parts: [String] = []
+        if let m = ancMode { parts.append("anc \(m)") }
+        if let d = ancDepth { parts.append("depth \(d)") }
+        if let e = eq { parts.append("eq \(e.bass)/\(e.mid)/\(e.treble)") }
+        if let mp = multipoint { parts.append("mp \(mp ? "on" : "off")") }
+        if let v = volume { parts.append("vol \(v)") }
+        return parts.isEmpty ? "" : " — " + parts.joined(separator: ", ")
+    }
+
+    /// Capture the current device state as a fully-populated profile.
+    init(capturing s: HeadphoneState, name: String) {
+        self.name = name
+        self.ancMode = AncMode(rawValue: UInt8(truncatingIfNeeded: s.ancMode)).map { "\($0)" }
+        self.ancDepth = s.cncLevel
+        self.eq = EqValues(bass: s.eq.bass, mid: s.eq.mid, treble: s.eq.treble)
+        self.multipoint = s.multipointEnabled
+        self.volume = s.volume
+    }
+
+    init(name: String, ancMode: String? = nil, ancDepth: Int? = nil,
+         eq: EqValues? = nil, multipoint: Bool? = nil, volume: Int? = nil) {
+        self.name = name; self.ancMode = ancMode; self.ancDepth = ancDepth
+        self.eq = eq; self.multipoint = multipoint; self.volume = volume
+    }
+}
+
+struct ProfileStore: Codable {
+    var profiles: [Profile]
+
+    /// `$BOSE_PROFILES` → repo `profiles.json` (versioned) → `~/.config/bose/profiles.json`.
+    static func defaultPath() -> String {
+        let env = ProcessInfo.processInfo.environment
+        if let p = env["BOSE_PROFILES"], !p.isEmpty { return p }
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let repo = "\(home)/code/personal/bose/profiles.json"
+        if FileManager.default.fileExists(atPath: repo) { return repo }
+        return "\(home)/.config/bose/profiles.json"
+    }
+
+    /// Load, returning an empty store for a missing/unreadable/invalid file.
+    static func load(_ path: String) -> ProfileStore {
+        guard let data = FileManager.default.contents(atPath: path),
+              let store = try? JSONDecoder().decode(ProfileStore.self, from: data) else {
+            return ProfileStore(profiles: [])
+        }
+        return store
+    }
+
+    func save(_ path: String) throws {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try enc.encode(self)
+        let dir = (path as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try data.write(to: URL(fileURLWithPath: path))
+    }
+
+    func profile(named name: String) -> Profile? {
+        profiles.first { $0.name.lowercased() == name.lowercased() }
+    }
+
+    mutating func upsert(_ p: Profile) {
+        if let i = profiles.firstIndex(where: { $0.name.lowercased() == p.name.lowercased() }) {
+            profiles[i] = p
+        } else {
+            profiles.append(p)
+        }
+    }
+}
+
+/// Map an ANC-mode name to its byte, single-sourced from the generated `AncMode` enum.
+func ancModeByte(_ name: String) -> UInt8? {
+    switch name.lowercased() {
+    case "quiet": return AncMode.quiet.rawValue
+    case "aware": return AncMode.aware.rawValue
+    case "custom1": return AncMode.custom1.rawValue
+    case "custom2": return AncMode.custom2.rawValue
+    default: return nil
+    }
+}
+
+/// Build the ordered SET frames a profile applies. ANC-depth is a read-modify-write,
+/// so the live CNC config is passed in; if `currentCnc` is nil the depth frame is
+/// skipped (the caller reads it within the session). Pure — unit-tested.
+func profileFrames(_ p: Profile, currentCnc: CncConfig?) -> [[UInt8]] {
+    var frames: [[UInt8]] = []
+    if let m = p.ancMode, let b = ancModeByte(m) { frames.append(BMAP.setAncMode(mode: b)) }
+    if let v = p.volume { frames.append(BMAP.setVolume(level: UInt8(max(0, min(31, v))))) }
+    if let mp = p.multipoint { frames.append(BMAP.setMultipoint(state: mp ? 0x07 : 0x00)) }
+    if let e = p.eq {
+        let clamp: (Int) -> Int8 = { Int8(max(-10, min(10, $0))) }
+        frames.append(BMAP.setEqBand(value: clamp(e.bass), band: EqBand.bass.rawValue))
+        frames.append(BMAP.setEqBand(value: clamp(e.mid), band: EqBand.mid.rawValue))
+        frames.append(BMAP.setEqBand(value: clamp(e.treble), band: EqBand.treble.rawValue))
+    }
+    if let d = p.ancDepth, let cnc = currentCnc {
+        frames.append(buildCncSet(level: d, preserving: cnc))
+    }
+    return frames
+}

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -120,6 +120,57 @@ check(parseDeviceInfo([0x04, 0x05, 0x03, 0x00]) == nil, "deviceInfo: short frame
 check(parseDeviceInfo([0x04, 0x05, 0x01, 0x06, 0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x27, 0x00]) == nil,
       "deviceInfo: non-RESP (GET echo) -> nil")
 
+// ── profiles ─────────────────────────────────────────────────────────────────────
+
+// profileFrames: full profile → ordered SET frames (anc, vol, mp, 3x eq, depth).
+let cnc2 = CncConfig(level: 7, autoCNC: 1, spatial: 0, windBlock: 1, ancToggle: 1)
+let full = Profile(name: "t", ancMode: "aware", ancDepth: 5,
+                   eq: EqValues(bass: 3, mid: 0, treble: -3), multipoint: true, volume: 20)
+let pf = profileFrames(full, currentCnc: cnc2)
+check(pf.count == 7, "profileFrames: 7 frames")
+check(pf[0] == [0x1F, 0x03, 0x05, 0x02, 0x01, 0x01], "profileFrames: anc aware (START)")
+check(pf[1] == [0x05, 0x05, 0x02, 0x01, 0x14], "profileFrames: volume 20 (SET_GET)")
+check(pf[2] == [0x01, 0x0A, 0x02, 0x01, 0x07], "profileFrames: multipoint on")
+check(pf[3] == [0x01, 0x07, 0x02, 0x02, 0x03, 0x00], "profileFrames: eq bass +3")
+check(pf[5] == [0x01, 0x07, 0x02, 0x02, 0xFD, 0x02], "profileFrames: eq treble -3 (signed)")
+check(pf[6] == [0x1F, 0x0A, 0x02, 0x05, 0x05, 0x01, 0x00, 0x01, 0x01], "profileFrames: cnc depth 5 preserves rest")
+// nil currentCnc → depth frame skipped; empty profile → no frames.
+check(profileFrames(full, currentCnc: nil).count == 6, "profileFrames: nil cnc skips depth")
+check(profileFrames(Profile(name: "empty"), currentCnc: nil).isEmpty, "profileFrames: empty profile -> none")
+// EQ values clamp into -10...10.
+let clampP = profileFrames(Profile(name: "c", eq: EqValues(bass: 99, mid: -99, treble: 0)), currentCnc: nil)
+check(clampP[0] == [0x01, 0x07, 0x02, 0x02, 0x0A, 0x00], "profileFrames: eq clamps +99 -> +10")
+check(clampP[1] == [0x01, 0x07, 0x02, 0x02, 0xF6, 0x01], "profileFrames: eq clamps -99 -> -10")
+
+// JSON round-trip: decode store, case-insensitive lookup, absent field stays nil.
+let pjson = "{\"profiles\":[{\"name\":\"flight\",\"ancMode\":\"quiet\",\"ancDepth\":10,\"multipoint\":false}]}"
+let store = try! JSONDecoder().decode(ProfileStore.self, from: Data(pjson.utf8))
+check(store.profiles.count == 1, "profileStore: decodes 1")
+check(store.profile(named: "FLIGHT")?.ancDepth == 10, "profileStore: case-insensitive lookup")
+check(store.profile(named: "flight")?.volume == nil, "profile: absent field stays nil")
+
+// Encode omits unset fields (clean human-editable JSON).
+let encoded = String(data: try! JSONEncoder().encode(Profile(name: "x", ancMode: "quiet")), encoding: .utf8)!
+check(encoded.contains("ancMode"), "profile encode: keeps set field")
+check(!encoded.contains("volume"), "profile encode: omits nil fields")
+
+// upsert replaces by name (case-insensitive), doesn't duplicate.
+var st = ProfileStore(profiles: [Profile(name: "a", volume: 5)])
+st.upsert(Profile(name: "A", volume: 9))
+st.upsert(Profile(name: "b"))
+check(st.profiles.count == 2, "store upsert: replaces, no dup")
+check(st.profile(named: "a")?.volume == 9, "store upsert: updated value")
+
+// capture: HeadphoneState → fully-populated profile.
+var snap = HeadphoneState()
+snap.ancMode = 1; snap.cncLevel = 8; snap.eq = (bass: 2, mid: -1, treble: 4)
+snap.multipointEnabled = true; snap.volume = 12
+let cap = Profile(capturing: snap, name: "now")
+check(cap.ancMode == "aware", "profile capture: ancMode name")
+check(cap.ancDepth == 8 && cap.volume == 12, "profile capture: depth + volume")
+check(cap.eq == EqValues(bass: 2, mid: -1, treble: 4), "profile capture: eq")
+check(cap.multipoint == true, "profile capture: multipoint")
+
 // ── summary ─────────────────────────────────────────────────────────────────────
 
 if failures == 0 {

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -39,6 +39,7 @@ swiftc -O \
     "$GEN_DIR/Devices.generated.swift" \
     "$SCRIPT_DIR/Transport.swift" \
     "$SCRIPT_DIR/Parsers.swift" \
+    "$SCRIPT_DIR/Profiles.swift" \
     "$SCRIPT_DIR/Composites.swift" \
     "$SCRIPT_DIR/main.swift" \
     -framework IOBluetooth \

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -173,6 +173,51 @@ func cmdName(_ newName: String?) {
     print("Name: \(parseString(r, from: 5))")
 }
 
+/// profile [name | save <name> | rm <name>] — list, apply, save, or remove a settings
+/// preset. A preset bundles {ANC mode, ANC depth, EQ, multipoint, volume}; applying
+/// sends only the fields a preset defines, in ONE RFCOMM session. Presets live in a
+/// git-tracked JSON file (see Profiles.swift); `save` snapshots the current state.
+func cmdProfile(_ a: [String]) {
+    let path = ProfileStore.defaultPath()
+    var store = ProfileStore.load(path)
+
+    if a.isEmpty {
+        if store.profiles.isEmpty {
+            print("No profiles. Save one: bose-ctl profile save <name>")
+        } else {
+            print("Profiles (\(path)):")
+            for p in store.profiles { print("  \(p.name)\(p.summary)") }
+        }
+        return
+    }
+
+    switch a[0].lowercased() {
+    case "save":
+        guard a.count >= 2 else { fail("usage: bose-ctl profile save <name>") }
+        let name = a[1...].joined(separator: " ")
+        guard let s = transport.getAllState() else { fail("headphones not reachable") }
+        store.upsert(Profile(capturing: s, name: name))
+        do { try store.save(path) } catch { fail("could not write \(path): \(error)") }
+        print("Saved profile '\(name)'\(Profile(capturing: s, name: name).summary)")
+
+    case "rm", "remove", "delete":
+        guard a.count >= 2 else { fail("usage: bose-ctl profile rm <name>") }
+        let name = a[1...].joined(separator: " ")
+        guard store.profile(named: name) != nil else { fail("unknown profile: \(name)") }
+        store.profiles.removeAll { $0.name.lowercased() == name.lowercased() }
+        do { try store.save(path) } catch { fail("could not write \(path): \(error)") }
+        print("Removed profile '\(name)'")
+
+    default:
+        let name = a.joined(separator: " ")
+        guard let p = store.profile(named: name) else {
+            fail("unknown profile: \(name) (list: bose-ctl profile)")
+        }
+        guard transport.applyProfile(p) else { fail("failed to apply '\(name)'") }
+        print("Applied '\(name)'\(p.summary)")
+    }
+}
+
 /// devices — known devices in three states (one RFCOMM session):
 ///   ● active     — audio sink (getConnectedDevices, 05,01 ground truth)
 ///   ○ connected  — ACL up but not the active sink (per-device getDeviceInfo, 04,05)
@@ -374,6 +419,7 @@ func usage() {
       bose-ctl multipoint [on|off]  Get/set multipoint
       bose-ctl play|pause|next|prev Media transport
       bose-ctl eq [bass mid treble] Get/set EQ (each -10 to +10)
+      bose-ctl profile [name]       Apply a preset (bare = list); save <name> / rm <name>
       bose-ctl raw <hex>            Send raw BMAP bytes
 
     Devices: \(BoseDeviceMap.knownDevices.map { $0.name }.joined(separator: ", "))
@@ -406,6 +452,7 @@ case "pause":                  cmdMedia(.pause)
 case "next":                   cmdMedia(.next)
 case "prev":                   cmdMedia(.prev)
 case "eq":                     cmdEq(args.count >= 3 ? Array(args[2...]) : [])
+case "profile", "profiles":    cmdProfile(args.count >= 3 ? Array(args[2...]) : [])
 case "raw":                    cmdRaw(requireArg("hex"))
 case "-h", "--help", "help":   usage()
 default:

--- a/cli/run-tests.sh
+++ b/cli/run-tests.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-# Compile + run the standalone composite-parser unit tests.
-# Parsers.swift is Foundation-only (no IOBluetooth) so this builds + runs headless,
-# no hardware. Exits non-zero on any failing assertion.
+# Compile + run the standalone composite-parser + profile unit tests.
+# Parsers.swift and Profiles.swift are Foundation-only (no IOBluetooth); the
+# generated BMAP.swift is pure byte builders. So this builds + runs headless, no
+# hardware. Exits non-zero on any failing assertion.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+GEN_DIR="$REPO_ROOT/protocol/generated"
 OUT_DIR="$SCRIPT_DIR/build/tests"
 mkdir -p "$OUT_DIR"
 BIN="$OUT_DIR/parser-tests"
@@ -12,7 +15,9 @@ BIN="$OUT_DIR/parser-tests"
 swiftc \
     -target arm64-apple-macos13.0 \
     -sdk "$(xcrun --show-sdk-path)" \
+    "$GEN_DIR/BMAP.generated.swift" \
     "$SCRIPT_DIR/Parsers.swift" \
+    "$SCRIPT_DIR/Profiles.swift" \
     "$SCRIPT_DIR/Tests/main.swift" \
     -o "$BIN"
 

--- a/hammerspoon/bose.lua
+++ b/hammerspoon/bose.lua
@@ -1,14 +1,20 @@
--- bose.lua — Opt+B toggles the Bose QC Ultra between Mac and phone.
+-- bose.lua — Hammerspoon control for the Bose QC Ultra (on-demand, never polled).
 --
--- Direction is decided from the Mac's current default OUTPUT device (no need to
--- query the headphones over Bluetooth): if the Bose is the Mac's output, the next
--- press sends audio to the phone; otherwise it brings the headphones to the Mac.
--- Routing runs via `bose-ctl` (the on-demand RFCOMM CLI) as an async hs.task so it
--- never blocks Hammerspoon. A brief alert confirms where audio went.
+-- Everything here is EVENT-DRIVEN: a keypress or an OS event triggers one async
+-- `bose-ctl` call (the on-demand RFCOMM CLI). Nothing runs on a timer — a resident
+-- poller was the original audio-dropout cause, so this module must never introduce one.
 --
--- Install: this file lives in ~/.hammerspoon/modules/. Wire it in init.lua:
---     Bose = require("bose")
---     Bose.start()
+-- Features:
+--   • Opt+B  — toggle audio between Mac and phone (direction from Mac's output device).
+--              On the way, reads battery and warns if low (piggybacks the keypress;
+--              no separate poll loop).
+--   • Opt+N  — cycle ANC mode quiet → aware → custom1.
+--   • App hook — when a call app LAUNCHES (Teams/Zoom/Meet), switch ANC to aware so
+--                you can hear yourself. Fires once on launch, not on every focus.
+--
+-- Wiring (init.lua dofiles this from the repo path; reload Hammerspoon to apply edits):
+--     BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua")
+--     BoseCtl.start()
 
 local M = {}
 
@@ -18,8 +24,25 @@ local BOSE_NAME    = "verBosita"             -- macOS output-device name when on
 local MAC_SPEAKERS = "MacBook Pro Speakers"  -- Mac audio falls back here after "→ phone"
 local HOTKEY_MODS  = { "alt" }
 local HOTKEY_KEY   = "b"
-local TO_MAC       = "mac"                    -- the two favourites this hotkey flips between
+local TO_MAC       = "mac"                    -- the two favourites the toggle flips between
 local TO_PHONE     = "phone"
+
+-- ANC cycle (Opt+N). Rebind freely — these are personal-config defaults.
+local ANC_MODS     = { "alt" }
+local ANC_KEY      = "n"
+local ANC_CYCLE    = { "quiet", "aware", "custom1" }
+
+-- Low-battery warning threshold (%), checked on each toggle (no separate poll).
+local LOW_BATTERY  = 20
+
+-- Apps whose LAUNCH should switch ANC to aware (so you hear your own voice on calls).
+-- Keys are hs.application names; adjust to taste.
+local AWARE_ON_LAUNCH = {
+  ["Microsoft Teams"]      = true,
+  ["Microsoft Teams (work or school)"] = true,
+  ["zoom.us"]              = true,
+  ["Google Meet"]          = true,
+}
 -------------------------------------------------------------------------------
 
 local function boseIsMacOutput()
@@ -32,8 +55,25 @@ local function setMacOutput(name)
   if dev then dev:setDefaultOutputDevice() end
 end
 
+-- Fire-and-forget bose-ctl (exit code only).
 local function ctl(args, done)
   hs.task.new(CTL, function(code) if done then done(code == 0) end end, args):start()
+end
+
+-- bose-ctl with stdout captured (for reads like battery / anc).
+local function ctlRead(args, done)
+  hs.task.new(CTL, function(code, stdout) done(code == 0, stdout or "") end, args):start()
+end
+
+-- One on-demand battery read; warn if low. Triggered by the toggle keypress, so it's
+-- a single brief RFCOMM open on an explicit action — not a background poll.
+local function warnIfLowBattery()
+  ctlRead({ "battery" }, function(ok, out)
+    local pct = tonumber(out:match("(%d+)%%"))
+    if ok and pct and pct <= LOW_BATTERY then
+      hs.alert.show("🪫  Bose battery " .. pct .. "%")
+    end
+  end)
 end
 
 local function toggle()
@@ -53,15 +93,45 @@ local function toggle()
       end
     end)
   end
+  -- After the link settles, do a one-shot low-battery check (no polling).
+  hs.timer.doAfter(2.5, warnIfLowBattery)
+end
+
+-- Read current ANC, then set the next mode in the cycle.
+local function cycleAnc()
+  ctlRead({ "anc" }, function(_, out)
+    local cur = out:match("ANC:%s*(%w+)")
+    local nextMode = ANC_CYCLE[1]
+    for i, m in ipairs(ANC_CYCLE) do
+      if m == cur then nextMode = ANC_CYCLE[(i % #ANC_CYCLE) + 1]; break end
+    end
+    ctl({ "anc", nextMode }, function(ok)
+      if ok then hs.alert.show("🎧  ANC → " .. nextMode) end
+    end)
+  end)
+end
+
+-- App-launch watcher: switch ANC to aware when a call app starts.
+local function onAppEvent(name, event)
+  if event == hs.application.watcher.launched and name and AWARE_ON_LAUNCH[name] then
+    ctl({ "anc", "aware" }, function(ok)
+      if ok then hs.alert.show("🎧  " .. name .. " → ANC aware") end
+    end)
+  end
 end
 
 function M.start()
   M.hotkey = hs.hotkey.bind(HOTKEY_MODS, HOTKEY_KEY, toggle)
+  M.ancHotkey = hs.hotkey.bind(ANC_MODS, ANC_KEY, cycleAnc)
+  M.appWatcher = hs.application.watcher.new(onAppEvent)
+  M.appWatcher:start()
   return M
 end
 
 function M.stop()
   if M.hotkey then M.hotkey:delete(); M.hotkey = nil end
+  if M.ancHotkey then M.ancHotkey:delete(); M.ancHotkey = nil end
+  if M.appWatcher then M.appWatcher:stop(); M.appWatcher = nil end
 end
 
 return M

--- a/profiles.json
+++ b/profiles.json
@@ -1,0 +1,22 @@
+{
+  "profiles" : [
+    {
+      "name" : "flight",
+      "ancMode" : "quiet",
+      "ancDepth" : 10,
+      "multipoint" : false
+    },
+    {
+      "name" : "office",
+      "ancMode" : "aware",
+      "eq" : { "bass" : 0, "mid" : 0, "treble" : 0 },
+      "multipoint" : true
+    },
+    {
+      "name" : "music",
+      "ancMode" : "quiet",
+      "eq" : { "bass" : 3, "mid" : 0, "treble" : 2 },
+      "multipoint" : true
+    }
+  ]
+}

--- a/raycast/bose-profile.sh
+++ b/raycast/bose-profile.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Raycast script command — apply a Bose settings profile (or list them if blank).
+# Profiles live in profiles.json (see the repo README). Requires the Bose to be
+# connected to this Mac (it talks over RFCOMM on demand).
+#
+# @raycast.schemaVersion 1
+# @raycast.title Bose: Profile
+# @raycast.mode fullOutput
+# @raycast.icon 🎧
+# @raycast.packageName Bose
+# @raycast.argument1 { "type": "text", "placeholder": "profile name (blank = list)", "optional": true }
+
+"$HOME/bin/bose-ctl" profile "$1"


### PR DESCRIPTION
Builds on #72. Four event-driven additions — no background polling.

- **Profiles** — `bose-ctl profile [name|save <name>|rm <name>]`: bundle {ANC mode, ANC depth, EQ, multipoint, volume}, applied in one RFCOMM session. `profiles.json` (versioned; flight/office/music). Pure logic in `Profiles.swift` + `applyProfile` composite; `raycast/bose-profile.sh`. 18 new unit tests.
- **ANC cycle chord** — Opt+N cycles quiet→aware→custom1 (`bose.lua`).
- **Context auto-switch** — call-app launch (Teams/Zoom/Meet) → ANC aware (Hammerspoon watcher); macOS Focus→Shortcuts→profile recipe in README.
- **Battery nudge** — one-shot low-battery warn piggybacked on the Opt+B toggle (no poll).

CLI build + tests green (parser + 18 profile assertions); Lua syntax-checked. No protocol/Android changes. bose.lua applies on Hammerspoon reload.