### PR TITLE
chore: commit .harness/state.json gitignore line (step 4 of #74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ xcuserdata/
 bose-ctl
 bosed
 .worktrees/
+.harness/state.json


### PR DESCRIPTION
Commits the `.harness/state.json` line that `harness-add-feature` re-appends to `.gitignore` on every worktree create. With it uncommitted on main it showed as pending dirt each session; committing it makes harness's ensure a no-op.

`state.json` stays tracked with skip-worktree on the main checkout (unchanged). No code touched — single `.gitignore` line.

Step 4 of #74 (the only code-actionable item; steps 1–3 are James-driven hardware/Hammerspoon/Focus verification).