### PR TITLE
feat: Opt+J connect-to-Mac hotkey (bose.lua)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ in the background and the Mac only touches the headphones on an explicit keypres
 - `raycast/bose-status.sh` / `bose-full-status.sh` -- `bose-ctl status` / `bose-ctl info`
 - `raycast/bose-anc-depth.sh` / `bose-profile.sh` -- `bose-ctl anc-depth [0-10]` / `bose-ctl profile [name]` (text arg)
 - `profiles.json` (repo root) -- settings presets ({ANC mode, depth, EQ, multipoint, volume}) applied by `bose-ctl profile`; versioned + hand-editable, ships flight/office/music. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
-- `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B toggles Mac ↔ phone** (+ one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→custom1), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
+- `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B toggles Mac ↔ phone** (+ one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→custom1), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
 - The Swift core that does the actual RFCOMM work lives in `cli/` (see below) — there is no separate macOS Swift target.
 
 ### Android (`android/`) — regenerated protocol on the kept architecture
@@ -252,7 +252,7 @@ surface. Keep this in sync when adding a verb or control.
 | Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
 | EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
 | Multipoint | 01,0A | ✅ `multipoint` | — | — | ✅ toggle |
-| Connect device | 04,01 | ✅ `connect`/`swap` | ✅ `bose-connect` | ✅ Opt+B toggle | ✅ widget/tile/picker |
+| Connect device | 04,01 | ✅ `connect`/`swap` | ✅ `bose-connect` | ✅ Opt+B toggle · Opt+J → Mac | ✅ widget/tile/picker |
 | Disconnect device | 04,02 | ✅ `disconnect` | ✅ `bose-disconnect` | 👁 (toggle path) | — |
 | Device info (ACL) | 04,05 | 👁 `devices` (○ state) | — | — | 👁 widget colour |
 | Connected devices | 05,01 | 👁 `devices`/`status`/`info` | 👁 (in status) | 👁 toggle-direction | 👁 widget/tile active |
@@ -278,7 +278,7 @@ applies {ANC mode, ANC depth, EQ, multipoint, volume} in one session (CLI +
 `bose-profile.sh` Raycast; drivable from macOS Focus via a Shortcut, see README).
 
 **Notable gaps (intentional):** Hammerspoon now does Opt+B (toggle), Opt+N (ANC
-cycle), and a call-app launch hook — still all event-driven, no timers. Raycast
+cycle), Opt+J (connect → Mac), and a call-app launch hook — still all event-driven, no timers. Raycast
 covers the common dropdowns plus full-status / anc-depth / profile; deeper config
 (EQ/name/multipoint) is CLI- or Android-only by design. The macOS surface has
 **no resident process** — every reading is on-demand, never polled.

--- a/hammerspoon/bose.lua
+++ b/hammerspoon/bose.lua
@@ -9,6 +9,9 @@
 --              On the way, reads battery and warns if low (piggybacks the keypress;
 --              no separate poll loop).
 --   • Opt+N  — cycle ANC mode quiet → aware → custom1.
+--   • Opt+J  — unconditionally bring the headphones to THIS Mac (connect + route
+--              audio here). Unlike Opt+B, never guesses direction from the current
+--              output device — it always connects the Mac.
 --   • App hook — when a call app LAUNCHES (Teams/Zoom/Meet), switch ANC to aware so
 --                you can hear yourself. Fires once on launch, not on every focus.
 --
@@ -31,6 +34,14 @@ local TO_PHONE     = "phone"
 local ANC_MODS     = { "alt" }
 local ANC_KEY      = "n"
 local ANC_CYCLE    = { "quiet", "aware", "custom1" }
+
+-- Connect hotkey (Opt+J): always bring the headphones to THIS Mac, no toggle
+-- guessing. `connect mac` does the A2DP bring-up + BMAP route + poll-confirm.
+-- Change CONNECT_TARGET to route the key at a different device (must be a name
+-- in devices.toml's device map, e.g. "mac"/"quest"/"ipad").
+local CONNECT_MODS   = { "alt" }
+local CONNECT_KEY    = "j"
+local CONNECT_TARGET = "mac"
 
 -- Low-battery warning threshold (%), checked on each toggle (no separate poll).
 local LOW_BATTERY  = 20
@@ -97,6 +108,21 @@ local function toggle()
   hs.timer.doAfter(2.5, warnIfLowBattery)
 end
 
+-- Unconditionally bring the headphones to this Mac (no toggle direction-guessing).
+-- `connect <target>` does the A2DP bring-up + BMAP route + poll-confirm; on success
+-- route the Mac's audio to the Bose so it shows Connected and audio lands here.
+local function connectHere()
+  hs.alert.closeAll()
+  hs.alert.show("🎧  Bose → Mac")
+  ctl({ "connect", CONNECT_TARGET }, function(ok)
+    if ok then
+      hs.timer.doAfter(2.0, function() setMacOutput(BOSE_NAME) end)
+    else
+      hs.alert.show("🎧  connect failed")
+    end
+  end)
+end
+
 -- Read current ANC, then set the next mode in the cycle.
 local function cycleAnc()
   ctlRead({ "anc" }, function(_, out)
@@ -123,6 +149,7 @@ end
 function M.start()
   M.hotkey = hs.hotkey.bind(HOTKEY_MODS, HOTKEY_KEY, toggle)
   M.ancHotkey = hs.hotkey.bind(ANC_MODS, ANC_KEY, cycleAnc)
+  M.connectHotkey = hs.hotkey.bind(CONNECT_MODS, CONNECT_KEY, connectHere)
   M.appWatcher = hs.application.watcher.new(onAppEvent)
   M.appWatcher:start()
   return M
@@ -131,6 +158,7 @@ end
 function M.stop()
   if M.hotkey then M.hotkey:delete(); M.hotkey = nil end
   if M.ancHotkey then M.ancHotkey:delete(); M.ancHotkey = nil end
+  if M.connectHotkey then M.connectHotkey:delete(); M.connectHotkey = nil end
   if M.appWatcher then M.appWatcher:stop(); M.appWatcher = nil end
 end
 


### PR DESCRIPTION
Adds an Opt+J Hammerspoon hotkey that unconditionally brings the headphones to this Mac (`bose-ctl connect mac` + routes Mac audio to verBosita), fixing the Opt+B ambiguity where a selected-but-disconnected Bose sends audio to the phone instead. Configurable chord + `CONNECT_TARGET` at the top of `bose.lua`. Event-driven, no timer. CLAUDE.md updated. Surfaced during #74 hardware smoke.