### PR TITLE
ANC-off display + stable profiles.json (#77 minors 3+5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ BMAP operator (SET/0x06 instead of SET_GET/0x02).
 
 | Setting | Block,Func | Operator | Bytes | Notes |
 |---------|-----------|----------|-------|-------|
-| ANC mode | 1F,03 | START | `1F,03,05,02,{mode},01` | 0=quiet 1=aware 2=custom1 3=custom2 |
+| ANC mode | 1F,03 | START | `1F,03,05,02,{mode},01` | 0=quiet 1=aware 2=custom1 3=custom2; reads 255=off when disabled (decode-only, not settable) |
 | Volume | 05,05 | SET_GET | `05,05,02,01,{level}` | 0-31 |
 | Device name | 01,02 | SET | `01,02,06,{len},00,{utf8}` | max 30 UTF-8 bytes |
 | Multipoint | 01,0A | SET_GET | `01,0A,02,01,{07/00}` | 07=on, 00=off |

--- a/cli/Profiles.swift
+++ b/cli/Profiles.swift
@@ -91,8 +91,13 @@ struct ProfileStore: Codable {
 
     func save(_ path: String) throws {
         let enc = JSONEncoder()
+        // .sortedKeys gives DETERMINISTIC output (stable across saves); the churn it
+        // caused was only because the committed file wasn't in this form. We normalise
+        // profiles.json to match + emit a trailing newline, so a `profile save`/`rm`
+        // round-trip is now byte-stable (a no-op) against the committed file.
         enc.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try enc.encode(self)
+        var data = try enc.encode(self)
+        data.append(0x0A)  // trailing newline
         let dir = (path as NSString).deletingLastPathComponent
         try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         try data.write(to: URL(fileURLWithPath: path))

--- a/profiles.json
+++ b/profiles.json
@@ -1,22 +1,30 @@
 {
   "profiles" : [
     {
-      "name" : "flight",
-      "ancMode" : "quiet",
       "ancDepth" : 10,
-      "multipoint" : false
-    },
-    {
-      "name" : "office",
-      "ancMode" : "aware",
-      "eq" : { "bass" : 0, "mid" : 0, "treble" : 0 },
-      "multipoint" : true
-    },
-    {
-      "name" : "music",
       "ancMode" : "quiet",
-      "eq" : { "bass" : 3, "mid" : 0, "treble" : 2 },
-      "multipoint" : true
+      "multipoint" : false,
+      "name" : "flight"
+    },
+    {
+      "ancMode" : "aware",
+      "eq" : {
+        "bass" : 0,
+        "mid" : 0,
+        "treble" : 0
+      },
+      "multipoint" : true,
+      "name" : "office"
+    },
+    {
+      "ancMode" : "quiet",
+      "eq" : {
+        "bass" : 3,
+        "mid" : 0,
+        "treble" : 2
+      },
+      "multipoint" : true,
+      "name" : "music"
     }
   ]
 }

--- a/protocol/generated/BMAP.generated.kt
+++ b/protocol/generated/BMAP.generated.kt
@@ -6,7 +6,7 @@ package au.com.jd.bose
 
 enum class BMAPOperator(val v: Int) { GET(0x01), SET_GET(0x02), RESP(0x03), ERROR(0x04), START(0x05), SET(0x06), ACK(0x07) }
 
-enum class AncMode(val v: Int) { QUIET(0), AWARE(1), CUSTOM1(2), CUSTOM2(3) }
+enum class AncMode(val v: Int) { QUIET(0), AWARE(1), CUSTOM1(2), CUSTOM2(3), OFF(255) }
 enum class EqBand(val v: Int) { BASS(0), MID(1), TREBLE(2) }
 enum class MediaAction(val v: Int) { PLAY(1), PAUSE(2), NEXT(3), PREV(4) }
 

--- a/protocol/generated/BMAP.generated.swift
+++ b/protocol/generated/BMAP.generated.swift
@@ -19,6 +19,7 @@ enum AncMode: UInt8 {
     case aware = 1
     case custom1 = 2
     case custom2 = 3
+    case off = 255
 }
 
 enum EqBand: UInt8 {

--- a/protocol/spec/bmap.toml
+++ b/protocol/spec/bmap.toml
@@ -18,11 +18,15 @@
 # ── Enums ──────────────────────────────────────────────────────────────────────
 
 [enums.AncMode]
-# ANC mode (1F,03). CLAUDE.md: 0=quiet 1=aware 2=custom1 3=custom2
+# ANC mode (1F,03). CLAUDE.md: 0=quiet 1=aware 2=custom1 3=custom2.
+# 255 (0xFF) is the disabled/off sentinel the QC Ultra 2 reports when ANC is off
+# (observed on-device at depth 0). Decode-only — renders reads as "off" instead of
+# "unknown(255)"; NOT offered as a settable mode (setting 0xFF is unverified).
 quiet = 0
 aware = 1
 custom1 = 2
 custom2 = 3
+off = 255
 
 [enums.EqBand]
 # EQ band selector (01,07). CLAUDE.md: 0=bass 1=mid 2=treble


### PR DESCRIPTION
Addresses two of the three minors from #77:

- **#3** — map ANC mode `0xFF` to `off` (`bmap.toml` enum + regen Swift/Kotlin) so reads render `off` not `unknown(255)`. Decode-only, not settable (unverified). Golden tests pass.
- **#5** — `profile save`/`rm` was rewriting the hand-authored `profiles.json`. Keep `.sortedKeys` (deterministic) + add a trailing newline, and normalise the committed file to match. Verified: 3 consecutive round-trips → identical md5 (true no-op).

**#4 (on-head) deferred** — turned out `08,07` *does* respond inside `getAllState` (parsed as not-on-head); only the standalone `raw` got no response. Needs James confirming wear-state during a fresh capture to know if it's a parse-value bug or genuinely off-head. Stays open in #77.