### PR TITLE
fix: getAllState frame alignment — on-head now correct (closes #77)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ surface. Keep this in sync when adding a verb or control.
 | Platform | 12,0D | 👁 `info` | 👁 (full status) | 👁 state |
 | Codename | 12,0C | 👁 `info` | 👁 (full status) | 👁 state |
 | Auto-off timer | 01,0B | 👁 `info` (read-only) | 👁 (full status) | 👁 state |
-| On-head / wear | 08,07 | 👁 `info` | 👁 (full status) | 👁 state |
+| On-head / wear | 08,07 | 👁 `info` (yes/no; `unknown` if no RESP) | 👁 (full status) | 👁 state |
 
 **Profiles** compose several of these capabilities at once — a `bose-ctl profile`
 applies {ANC mode, ANC depth, EQ, multipoint, volume} in one session (CLI +

--- a/cli/Parsers.swift
+++ b/cli/Parsers.swift
@@ -31,7 +31,8 @@ struct HeadphoneState {
     var multipointEnabled: Bool = false
     var autoOffTimer: [UInt8] = []
     var cncLevel: Int = 0
-    var onHead: Bool = false
+    var onHead: Bool? = nil         // Optional: nil renders "unknown" when 08,07 yields no
+                                    // matching response; set true/false when it does.
     var eq: (bass: Int, mid: Int, treble: Int) = (0, 0, 0)
 }
 
@@ -114,7 +115,12 @@ func parseAllState(_ provide: ResponseProvider) -> HeadphoneState {
     var s = HeadphoneState()
 
     func resp(_ b: UInt8, _ f: UInt8) -> [UInt8]? {
-        guard let r = provide(b, f), r.count >= 5, r[2] == OP_RESP_BYTE else { return nil }
+        // Require the frame to be the RESPONSE to THIS command: BMAP echoes the
+        // queried block/func at r[0],r[1]. Without this, a leftover/late frame from a
+        // prior command in the bulk session gets misread as the current field — that
+        // misalignment was making on-head (08,07) report a bogus value on-device.
+        // Matching block/func keeps every field bound to its own response.
+        guard let r = provide(b, f), r.count >= 5, r[0] == b, r[1] == f, r[2] == OP_RESP_BYTE else { return nil }
         return r
     }
 
@@ -144,6 +150,9 @@ func parseAllState(_ provide: ResponseProvider) -> HeadphoneState {
 
     if let r = resp(0x01, 0x0A) { s.multipointEnabled = r[4] != 0 }
     if let r = resp(0x01, 0x0B) { s.autoOffTimer = Array(r[4...]) }
+    // 08,07 answers within the warm bulk session (it's silent on a cold standalone
+    // channel, e.g. `raw 08 07`). With resp() now matching block/func, this binds to
+    // the right frame and on-head reads correctly; nil only if no 08,07 RESP arrives.
     if let r = resp(0x08, 0x07) { s.onHead = r[4] == 0x04 }
 
     if let r = provide(0x01, 0x07), r.count >= 16, r[2] == OP_RESP_BYTE {

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -89,7 +89,7 @@ check(state.volume == 20 && state.volumeMax == 31, "allState: volume 20/31")
 check(state.connectedDevices.count == 2, "allState: 2 connected devices")
 check(state.cncLevel == 7, "allState: cnc level 7")
 check(state.multipointEnabled, "allState: multipoint on")
-check(state.onHead, "allState: on head")
+check(state.onHead == true, "allState: on head (parses when 08,07 responds)")
 check(state.firmware == "1.2.3", "allState: firmware 1.2.3")
 check(state.eq.bass == 3 && state.eq.mid == 0 && state.eq.treble == -3, "allState: EQ +3/0/-3 (signed)")
 

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -85,7 +85,7 @@ func cmdInfo() {
 
     // Power / wear
     row("Battery:", "\(s.batteryLevel)%\(s.batteryCharging ? " ⚡" : "")")
-    row("On head:", s.onHead ? "yes" : "no")
+    row("On head:", s.onHead.map { $0 ? "yes" : "no" } ?? "unknown")
     if !s.autoOffTimer.isEmpty {
         // Encoding unverified over RFCOMM (read-only field) — show raw bytes.
         row("Auto-off:", s.autoOffTimer.map { String(format: "%02X", $0) }.joined(separator: " "))


### PR DESCRIPTION
Root-caused #4 (on-head) to a frame-misalignment in the bulk read: `resp()` only checked `r[2]==RESP`, not that the frame was the response to *this* command (BMAP echoes block/func at `r[0]`,`r[1]`). A leftover/late frame from a prior command in the session was being misread as on-head → false `no` while worn.

Match block/func in `resp()` so every field binds to its own response, and make `onHead` Optional (renders `unknown` if no `08,07` RESP). Verified on-device: **On head: yes** while worn, and volume/anc/eq/depth/multipoint/battery all match dedicated single-command reads (no regression). Unit tests pass.

Closes #77.