### PR TITLE
fix: resolve info-vs-devices 05,01 active-sink divergence (#81)

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-bose profiles + context automation: presets, battery nudge, ANC cycle chord, Focus hooks
-bose profiles + context automation: presets, battery nudge, ANC cycle chord, Focus hooks
+fix #81: info-vs-devices 05,01 divergence + ANC-off verify
+fix #81: info-vs-devices 05,01 divergence + ANC-off verify
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - bose-profiles-automation
+# Agent Progress - fix-info-devices-divergence
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-05T09:29:45Z
+# Created: 2026-06-05T18:04:24Z
 
-feature=bose-profiles-automation
-name=bose profiles + context automation: presets, battery nudge, ANC cycle chord, Focus hooks
+feature=fix-info-devices-divergence
+name=fix #81: info-vs-devices 05,01 divergence + ANC-off verify
 status=pending
 step=0
 step_name=Not started
-created=2026-06-05T09:29:45Z
+created=2026-06-05T18:04:24Z

--- a/cli/Composites.swift
+++ b/cli/Composites.swift
@@ -55,6 +55,14 @@ extension Transport {
     /// from the generated `BMAP.getDeviceInfo`; only the response decode is hand-written.
     func getDeviceStates(query devices: [[UInt8]]) -> (active: [[UInt8]], connected: [[UInt8]])? {
         session { ch, t in
+            // 05,01 is SILENT as the first frame on a fresh channel (same firmware
+            // quirk as 08,07 on-head) — it only answers once the session is warm. The
+            // bulk `getAllState` path reads it 4th (after battery/anc/volume) and gets
+            // the active sink; this dedicated path read it cold and came back empty,
+            // which is why `devices` disagreed with `info` (#81). Prime with one cheap
+            // GET (battery 02,02 responds even cold) so the active-sink read matches.
+            // Single attempt, no retry loop.
+            _ = t.send(ch, [0x02, 0x02, 0x01, 0x00], timeout: 2.0)
             let active = t.send(ch, Transport.connectedDevicesGet).map { parseConnectedDevices($0) } ?? []
             let activeKeys = Set(active.map { macKey($0) })
             var connected: [[UInt8]] = []

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -38,6 +38,16 @@ func displayName(forMac mac: [UInt8]) -> String {
     BoseDeviceMap.name(forMac: mac) ?? macString(mac)
 }
 
+/// Display name for an audio-ACTIVE (05,01) device. `bose-ctl` only ever runs on
+/// the Mac, and the Bose firmware reports the Mac's own audio link under a
+/// non-resolvable private address (e.g. 0C:96:E6:05:3E:F2) that does NOT match the
+/// static [devices.mac] controller address — while every OTHER device reports its
+/// real, mappable address. So an active entry that maps to no known device is the
+/// local Mac's own link; render it as "mac". (#81)
+func activeName(forMac mac: [UInt8]) -> String {
+    BoseDeviceMap.name(forMac: mac) ?? "mac"
+}
+
 func isMacDevice(_ mac: [UInt8]) -> Bool {
     BoseDeviceMap.mac("mac") == mac
 }
@@ -99,8 +109,9 @@ func cmdInfo() {
     if !s.audioCodec.isEmpty { row("Codec:", s.audioCodec) }
     row("Multipoint:", s.multipointEnabled ? "on" : "off")
 
-    // Audio-active devices (05,01); first entry is the active sink.
-    let names = s.connectedDevices.map { displayName(forMac: $0) }
+    // Audio-active devices (05,01); first entry is the active sink. Unmapped == the
+    // local Mac's own private link address (see activeName).
+    let names = s.connectedDevices.map { activeName(forMac: $0) }
     if names.isEmpty {
         row("Devices:", "none")
     } else {
@@ -240,11 +251,15 @@ func cmdDevices() {
     guard let states = transport.getDeviceStates(query: BoseDeviceMap.knownDevices.map { $0.mac }) else {
         fail("headphones not reachable")
     }
-    let active = Set(states.active.map { macString($0) })
-    let idle = Set(states.connected.map { macString($0) })
+    // Match by resolved NAME, not raw MAC: the Mac's active 05,01 entry is a private
+    // link address that never equals the static [devices.mac] address, so it only
+    // lines up with the `mac` row once resolved through activeName (#81). Active wins
+    // over idle when a device resolves to both.
+    let active = Set(states.active.map { activeName(forMac: $0) })
+    let idle = Set(states.connected.map { displayName(forMac: $0) })
     for dev in BoseDeviceMap.knownDevices {
-        let state = active.contains(dev.macString) ? "●"
-                  : idle.contains(dev.macString) ? "○" : "·"
+        let state = active.contains(dev.name) ? "●"
+                  : idle.contains(dev.name) ? "○" : "·"
         print("  \(state) \(dev.name)")
     }
 }


### PR DESCRIPTION
Resolves the two loose ends from #81.

## Primary — 05,01 active-sink divergence
`info` and `devices` disagreed about the active audio sink. Root cause: **05,01 is silent as the first frame on a fresh RFCOMM channel** (same quirk as 08,07 on-head). The bulk `getAllState` path reads it warm (4th command) and sees the sink; the dedicated `getDeviceStates` path read it **cold** and got nothing.

The "unmapped MAC" `0C:96:E6:05:3E:F2` is **genuine, not a misparse** — captured via a temp debug dump of both paths' raw 05,01 frames; it parses identically to the golden `twoDevices` fixture. It's the **Mac's own audio link** under a non-resolvable private address the firmware reports (`0C` = NRPA prefix), distinct from the static `[devices.mac]` controller address. Stable across runs, matches no controller/device address locally.

**Fixes:**
- `getDeviceStates`: prime the channel with one cheap GET (battery 02,02 answers even cold) before the 05,01 read → dedicated path now reads the same warm frame as the bulk path. Single attempt, no retry loop.
- `activeName(forMac:)`: an active 05,01 entry mapping to no known device is the local Mac's private link → render `mac`.
- `cmdInfo`/`cmdDevices`: render/match the active sink by resolved name.

**Result (verified live, verBosita fw 8.2.20):** both paths read the identical frame and agree — `info` → `Devices: mac (active)`, `devices` → `● mac`.

## Secondary — ANC-off display (for #3)
Observed live: with ANC disabled, `bose-ctl anc` prints `off` (byte 255), not `unknown(255)`. Pure verification of #79's enum change; no code change.

## Verification
- 53/53 golden byte tests pass.
- #80 on-head + all scalar reads unaffected (`On head: yes` while worn).
- Temp debug fully removed.

## Notes
- `activeName` is a one-line helper over the golden-tested `parseConnectedDevices`; the test target compiles only hardware-free files (not `main.swift`/`Devices.generated.swift`), so it's verified live rather than unit-tested.
- The `unmapped active → mac` heuristic is the agreed render (an unknown third active device would also label `mac`; documented inline).

## Out of scope (untouched)
#80 `resp()` guard, `devices.toml`, set-verb session fix (#78), profiles.json (#79), bose.lua (#76). No poller/retry loop.