### PR TITLE
Restore windowed Mac app as a thin bose-ctl front-end (event-driven)

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-fix #81: info-vs-devices 05,01 divergence + ANC-off verify
-fix #81: info-vs-devices 05,01 divergence + ANC-off verify
+restore windowed Mac app on v2 core (event-driven, no polling)
+restore windowed Mac app on v2 core (event-driven, no polling)
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - fix-info-devices-divergence
+# Agent Progress - restore-windowed-mac-app
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-05T18:04:24Z
+# Created: 2026-06-08T04:05:35Z
 
-feature=fix-info-devices-divergence
-name=fix #81: info-vs-devices 05,01 divergence + ANC-off verify
+feature=restore-windowed-mac-app
+name=restore windowed Mac app on v2 core (event-driven, no polling)
 status=pending
 step=0
 step_name=Not started
-created=2026-06-05T18:04:24Z
+created=2026-06-08T04:05:35Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ Both Mac and phone control headphones independently via on-demand RFCOMM.
 No persistent connections. No coordination. No Tailscale dependency.
 
 ```
-Mac:   BoseControl.app (SwiftUI menu bar) → IOBluetooth RFCOMM → Headphones
 Mac:   bose-ctl (CLI)                     → IOBluetooth RFCOMM → Headphones
+Mac:   Raycast / Hammerspoon / Bose Control.app  ─shell→ bose-ctl → Headphones
 Phone: BoseControl (Android/Compose)      → Android RFCOMM     → Headphones
 ```
 
@@ -21,17 +21,29 @@ simultaneously one waits, but in practice commands are too brief to collide.
 
 ## Components
 
-### macOS — no resident app; on-demand surfaces over `bose-ctl`
-There is intentionally **no menu-bar app or LaunchAgent** (a resident poller was the
-original audio-dropout cause — #69-era). The Mac control surface is two thin
-front-ends that shell out to the `cli/` binary (`~/bin/bose-ctl`), so nothing runs
-in the background and the Mac only touches the headphones on an explicit keypress.
+### macOS — no resident poller; on-demand surfaces over `bose-ctl`
+There is intentionally **no LaunchAgent and nothing that polls** (a resident 10 s
+poll timer was the original audio-dropout cause — #69-era). The Mac control surface
+is three thin front-ends that shell out to the `cli/` binary (`~/bin/bose-ctl`), so
+nothing runs in the background and the Mac only touches the headphones on an
+explicit user action.
+- `macos/BoseControl/` -- **Bose Control.app**: a windowed SwiftUI app (frosted-dark
+  two-panel: battery/ANC mode+depth/volume/multipoint/on-head + device grid + EQ).
+  It is a **thin front-end that shells `bose-ctl`** — NO RFCOMM, NO IOBluetooth, NO
+  protocol code — reading via `bose-ctl info --json` and writing via the verbs. It is
+  **user-launched and event-driven**: reads on window-open, on app-focus, after each
+  write, and on ⌘R — never on a timer. Build `bash macos/build.sh [--install]`
+  (Developer-ID signed → `/Applications`; no LaunchAgent). In-window keys: ⌘1/2/3/4
+  ANC modes, ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M connect Mac. Global hotkeys stay in
+  Hammerspoon. The `--json` read seam lives in `cli/main.swift` (`cmdInfoJSON`, pure
+  formatting over `getAllState` + `getDeviceStates`). It surfaces — but does not fix —
+  the #83 flight/ancDepth behaviour; that fix lands in the CLI and the app inherits it.
 - `raycast/bose-connect.sh` / `bose-disconnect.sh` -- Raycast script commands with a device dropdown → `bose-ctl connect|disconnect <device>`
 - `raycast/bose-status.sh` / `bose-full-status.sh` -- `bose-ctl status` / `bose-ctl info`
 - `raycast/bose-anc-depth.sh` / `bose-profile.sh` -- `bose-ctl anc-depth [0-10]` / `bose-ctl profile [name]` (text arg)
 - `profiles.json` (repo root) -- settings presets ({ANC mode, depth, EQ, multipoint, volume}) applied by `bose-ctl profile`; versioned + hand-editable, ships flight/office/music. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
 - `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B toggles Mac ↔ phone** (+ one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→custom1), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
-- The Swift core that does the actual RFCOMM work lives in `cli/` (see below) — there is no separate macOS Swift target.
+- The Swift core that does the actual RFCOMM work lives in `cli/` (see below). The macOS app target (`macos/BoseControl/`) is pure SwiftUI/Foundation and does NO RFCOMM — it shells `bose-ctl`, so the two never drift and the app can't reintroduce a transport/poll bug.
 
 ### Android (`android/`) — regenerated protocol on the kept architecture
 - `android/` -- Jetpack Compose app (package: `au.com.jd.bose`)
@@ -72,6 +84,9 @@ bash cli/build.sh
 cp cli/build/bose-ctl ~/bin/bose-ctl                       # the engine
 cp raycast/*.sh ~/.config/raycast/script-commands/         # Raycast commands
 # hammerspoon/bose.lua is dofile'd from this repo path by init.lua — no copy needed
+
+# Bose Control.app (windowed) → Developer-ID signed, installed to /Applications
+bash macos/build.sh --install                              # needs ~/bin/bose-ctl present
 
 # Android app (deploy to S21 via ADB)
 cd android && ./gradlew assembleDebug

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -120,6 +120,54 @@ func cmdInfo() {
     }
 }
 
+/// info --json — the same getAllState snapshot as `info`, plus the per-device 3-state
+/// (active/connected/offline) from getDeviceStates, emitted as one JSON object. This
+/// is the read seam the windowed macOS app consumes — the app shells `bose-ctl` and
+/// never touches RFCOMM itself, so it can't reintroduce the polling/transport bugs.
+/// Pure formatting over existing composites — no protocol/spec change.
+func cmdInfoJSON() {
+    func emit(_ obj: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: obj, options: [.sortedKeys]),
+              let str = String(data: data, encoding: .utf8) else { print("{\"connected\":false}"); return }
+        print(str)
+    }
+
+    guard let s = transport.getAllState() else { emit(["connected": false]); return }
+
+    // Per-device 3-state, resolved by NAME (same logic as cmdDevices, #81). If the
+    // dedicated probe is unreachable, fall back to active-only from getAllState.
+    var deviceStates: [String: String] = [:]
+    let activeFromAll = Set(s.connectedDevices.map { activeName(forMac: $0) })
+    if let states = transport.getDeviceStates(query: BoseDeviceMap.knownDevices.map { $0.mac }) {
+        let active = Set(states.active.map { activeName(forMac: $0) })
+        let idle = Set(states.connected.map { displayName(forMac: $0) })
+        for dev in BoseDeviceMap.knownDevices {
+            deviceStates[dev.name] = active.contains(dev.name) ? "active"
+                                   : idle.contains(dev.name) ? "connected" : "offline"
+        }
+    } else {
+        for dev in BoseDeviceMap.knownDevices {
+            deviceStates[dev.name] = activeFromAll.contains(dev.name) ? "active" : "offline"
+        }
+    }
+
+    emit([
+        "connected": true,
+        "deviceName": s.deviceName.isEmpty ? "verBosita" : s.deviceName,
+        "firmware": s.firmware,
+        "batteryLevel": s.batteryLevel,
+        "batteryCharging": s.batteryCharging,
+        "ancMode": s.ancMode,
+        "ancDepth": s.cncLevel,
+        "volume": s.volume,
+        "volumeMax": s.volumeMax,
+        "eq": ["bass": s.eq.bass, "mid": s.eq.mid, "treble": s.eq.treble],
+        "multipoint": s.multipointEnabled,
+        "onHead": s.onHead.map { $0 as Any } ?? NSNull(),
+        "devices": deviceStates,
+    ])
+}
+
 func ancModeName(_ mode: Int) -> String {
     AncMode(rawValue: UInt8(truncatingIfNeeded: mode))
         .map { "\($0)" } ?? "unknown(\(mode))"
@@ -445,7 +493,7 @@ func usage() {
 
     Usage:
       bose-ctl status               Connection, battery, ANC, volume, EQ (one session)
-      bose-ctl info                 Full state: identity, power, all audio config, devices
+      bose-ctl info [--json]        Full state: identity, power, all audio config, devices (--json for the app)
       bose-ctl battery              Battery level
       bose-ctl devices              Known devices: ● active / ○ connected / · offline
       bose-ctl connect <device>     Route audio to device (poll-confirmed)
@@ -475,7 +523,7 @@ func requireArg(_ name: String) -> String {
 
 switch args[1].lowercased() {
 case "status", "s":            cmdStatus()
-case "info":                   cmdInfo()
+case "info":                   args.contains("--json") ? cmdInfoJSON() : cmdInfo()
 case "battery", "b":           cmdBattery()
 case "anc":                    cmdAnc(args.count >= 3 ? args[2] : nil)
 case "anc-depth":              cmdAncDepth(args.count >= 3 ? args[2] : nil)

--- a/docs/plans/2026-06-08-windowed-mac-app-restore-design.md
+++ b/docs/plans/2026-06-08-windowed-mac-app-restore-design.md
@@ -1,0 +1,106 @@
+# Windowed macOS app — restore + re-wire onto the v2 core
+
+**Date:** 2026-06-08
+**Branch:** `feature/restore-windowed-mac-app`
+**Issue context:** follows the v2 rebuild (#70) that deleted the v1 windowed app in favour of Raycast + Hammerspoon. James wants a clickable window back.
+
+## Problem
+
+The Mac control surface is currently Raycast script-commands + Hammerspoon hotkeys
+over `bose-ctl`. There is no app window where you can see current state and toggle
+ANC mode / volume / EQ / routing by clicking. James wants that window.
+
+The v1 windowed SwiftUI app *existed* (the "landscape frosted-dark" redesign,
+#69) but #70 deleted its source — keeping only a stale compiled `.app` built on the
+pre-codegen v1 protocol (the one with the wire bugs since fixed in #78–#82). The
+source is recoverable from git at `f0b71d7`.
+
+The reason #70 killed the app was **polling**: the old `BoseManager` ran a 10 s
+`Timer` that hit the headphones over RFCOMM and contended with the active A2DP
+link — the audio-dropout root cause. The dropout was caused by *polling*, not by
+*having a window*.
+
+## Design
+
+**Restore the UI, replace the data layer. Make the app a third thin front-end over
+`bose-ctl`** — exactly like Raycast and Hammerspoon already are (CLAUDE.md:
+"thin front-ends that shell out to the `cli/` binary"). The app contains **no
+RFCOMM, no IOBluetooth, no protocol code** — it spawns `bose-ctl` for every read
+and write. Consequences:
+
+- It structurally *cannot* reintroduce a transport/polling bug — it never holds a
+  channel.
+- It inherits every CLI fix automatically (including the open #83 flight fix when
+  it lands).
+- The app target is pure SwiftUI + Foundation. Trivial to build and sign.
+
+### Components
+
+1. **`bose-ctl info --json` (new read mode)** — `cli/main.swift`. Reuses the
+   existing `getAllState()` composite (one RFCOMM session) for config + active
+   device, plus `getDeviceStates()` for the idle (○) device state, and emits one
+   JSON object: `connected`, `deviceName`, `firmware`, `batteryLevel`,
+   `batteryCharging`, `ancMode` (int 0–3), `volume`, `volumeMax`,
+   `eq{bass,mid,treble}`, `multipoint` (bool), `ancDepth` (cncLevel 0–10),
+   `onHead` (bool|null), `devices{name: active|connected|offline}`. On
+   unreachable: `{"connected": false}`, exit 0. No protocol/spec change — pure
+   formatting over existing composites.
+
+2. **`BoseManager` (rewritten)** — `macos/BoseControl/BoseManager.swift`. Drops
+   `BoseRFCOMM`, `pollTimer`, `startPolling`, auto-reconnect, IOBluetooth. Keeps
+   the same `@Published` surface ContentView binds to. Runs `bose-ctl` via
+   `Process` on a serial background queue:
+   - `refreshState()` → `info --json` → decode → publish on main.
+   - setters (`setAncMode`/`setVolume`/`setEQ`/`setMultipoint`/`setCncLevel`/
+     `connectDevice`/`applyProfile`) → run the matching verb, optimistic local
+     update, then `refreshState()`.
+   - **No timer.** Reads happen on: window open, window regaining focus, after a
+     write, and manual ⌘R.
+   - Binary resolution: `$BOSE_CTL` → `~/bin/bose-ctl` → repo `cli/build/bose-ctl`.
+
+3. **`ContentView` (restored + extended)** — restored as-is (frosted two-panel:
+   battery, ANC buttons, volume, on-head, device grid, EQ presets + sliders).
+   Adds: **ANC depth slider** (0–10), **multipoint toggle**, and in-window
+   keyboard shortcuts ⌘1/2/3/4 (ANC modes), ⌘↑/⌘↓ (volume), ⌘R (refresh), ⌘M
+   (connect Mac, already present).
+
+4. **`BoseApp` / `AppDelegate`** — `startPolling()` → `refreshState()`; add a
+   `NSApplication.didBecomeActiveNotification` observer that re-reads on focus.
+   Window chrome unchanged.
+
+5. **`macos/build.sh` (rewritten)** — compiles the 4 SwiftUI files only (no
+   `BoseRFCOMM`, no IOBluetooth/CoreBluetooth frameworks), bundles `Info.plist`,
+   Developer-ID signs (per `/mac`), `--install` copies to `/Applications`. **No
+   LaunchAgent** — the app is user-launched and event-driven.
+
+### Coexistence
+
+Raycast commands and Hammerspoon hotkeys (Opt+B/N/J) are untouched and keep
+working — all four surfaces shell the same `bose-ctl`. Global hotkeys stay in
+Hammerspoon; the app only owns in-window keys.
+
+## Known limitation — #83
+
+The multipoint toggle and a custom ANC depth exercise the `ancDepth`/CNC-RMW path
+that is currently buggy on hardware (#83 — after a custom depth write ANC reads
+`off`, and multipoint-off doesn't stick on fw 8.2.20). The window faithfully
+*surfaces* that behaviour; it does not fix it. ANC mode, volume, EQ, routing, and
+the office/music profiles work clean. The #83 fix is a separate hardware-gated
+loop and lands in the CLI — the app inherits it for free.
+
+## Out of scope (YAGNI)
+
+No menu-bar icon, no battery/auto-off polling, no auto-reconnect, no LaunchAgent,
+no device-name editing in the window (CLI-only). Just the window.
+
+## Testing
+
+- `cd protocol && make check` — golden byte tests + no-drift (the `--json` change
+  touches only `main.swift`, not the spec, so this must stay green).
+- `bash cli/build.sh` — CLI compiles with the new read mode; `bose-ctl info --json`
+  emits valid JSON (hardware: real values; no hardware: `{"connected":false}`).
+- `bash macos/build.sh` — app compiles, bundle is well-formed, launch-smoke (window
+  appears, shows disconnected state without headphones).
+- Hardware smoke (James, headphones worn): open window → state reads correctly →
+  click ANC/volume/EQ/route → device reflects it. Flight/multipoint show the known
+  #83 behaviour.

--- a/macos/BoseControl/AppDelegate.swift
+++ b/macos/BoseControl/AppDelegate.swift
@@ -1,0 +1,18 @@
+/// AppDelegate: Window chrome configuration for frosted-dark redesign.
+
+import AppKit
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        configureWindow()
+    }
+
+    private func configureWindow() {
+        guard let window = NSApplication.shared.windows.first else { return }
+        window.titlebarAppearsTransparent = true
+        window.styleMask.insert(.fullSizeContentView)
+        window.isMovableByWindowBackground = true
+        window.backgroundColor = .clear
+        window.appearance = NSAppearance(named: .darkAqua)
+    }
+}

--- a/macos/BoseControl/BoseApp.swift
+++ b/macos/BoseControl/BoseApp.swift
@@ -10,7 +10,13 @@ struct BoseControlApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView(manager: manager)
-                .onAppear { manager.startPolling() }
+                // Event-driven reads only (no poll): ContentView reads on open, and
+                // this re-reads whenever the app regains focus. The v1 10 s poll
+                // timer — the audio-dropout cause — is gone for good.
+                .onReceive(NotificationCenter.default.publisher(
+                    for: NSApplication.didBecomeActiveNotification)) { _ in
+                    manager.refreshState()
+                }
         }
         .defaultSize(width: 640, height: 360)
         .windowResizability(.contentSize)

--- a/macos/BoseControl/BoseApp.swift
+++ b/macos/BoseControl/BoseApp.swift
@@ -1,0 +1,18 @@
+/// BoseControl: Native macOS app for Bose QC Ultra 2
+
+import SwiftUI
+
+@main
+struct BoseControlApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @StateObject private var manager = BoseManager()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(manager: manager)
+                .onAppear { manager.startPolling() }
+        }
+        .defaultSize(width: 640, height: 360)
+        .windowResizability(.contentSize)
+    }
+}

--- a/macos/BoseControl/BoseControl.entitlements
+++ b/macos/BoseControl/BoseControl.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+</dict>
+</plist>

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -1,349 +1,196 @@
-/// BoseManager: Observable state manager for Bose QC Ultra 2 headphones.
-/// Handles polling, auto-reconnect, and all BMAP command dispatch.
+/// BoseManager: Observable state for the windowed Bose app.
+///
+/// This is a THIN FRONT-END over `bose-ctl` — exactly like the Raycast commands and
+/// the Hammerspoon module. It holds NO RFCOMM channel, imports NO IOBluetooth, and
+/// runs NO timer. Every read shells `bose-ctl info --json`; every write shells the
+/// matching verb. Reads happen only on explicit events (window open, window focus,
+/// after a write, manual ⌘R) — never on a poll. The v1 BoseManager's 10 s poll
+/// timer was the audio-dropout root cause (#69-era); this design makes that class of
+/// bug structurally impossible here, and inherits every CLI fix (incl. #83) for free.
 
 import Foundation
 import Combine
-import IOBluetooth
 
-class BoseManager: ObservableObject {
+final class BoseManager: ObservableObject {
 
-    // MARK: - Published State
+    // MARK: - Published State (bound by ContentView)
 
     @Published var isConnected: Bool = false
     @Published var batteryLevel: Int = 0
     @Published var batteryCharging: Bool = false
-    @Published var ancMode: Int = 0  // 0=quiet, 1=aware, 2=custom1, 3=custom2
+    @Published var ancMode: Int = 0          // 0=quiet 1=aware 2=custom1 3=custom2
     @Published var volume: Int = 0
     @Published var volumeMax: Int = 31
     @Published var deviceName: String = "verBosita"
     @Published var firmware: String = ""
-    @Published var serialNumber: String = ""
-    @Published var productName: String = ""
-    @Published var platform: String = ""
-    @Published var codename: String = ""
-    @Published var audioCodec: String = ""
     @Published var multipointEnabled: Bool = false
-    @Published var autoOffTimer: String = ""
-    @Published var immersionLevel: String = ""
-    @Published var cncLevel: Int = 0
+    @Published var cncLevel: Int = 0         // ANC depth 0–10
     @Published var onHead: Bool = false
     @Published var eq: (bass: Int, mid: Int, treble: Int) = (0, 0, 0)
-
-    // Device connection states: "active", "connected", "offline"
-    @Published var deviceStates: [String: String] = [
-        "phone": "offline",
-        "mac": "offline",
-        "ipad": "offline",
-        "iphone": "offline",
-        "tv": "offline",
-        "quest": "offline",
-    ]
-
     @Published var isRefreshing: Bool = false
+
+    // Device routing states: "active" / "connected" / "offline"
+    @Published var deviceStates: [String: String] = [
+        "mac": "offline", "phone": "offline", "ipad": "offline",
+        "iphone": "offline", "tv": "offline", "quest": "offline",
+    ]
 
     // MARK: - Private
 
-    private var bose: BoseRFCOMM?
-    private var boseReady = false
-    private let rfcommQueue = DispatchQueue(label: "com.jamesdowzard.bose-control.rfcomm")
-    private var pollTimer: Timer?
-    private let pollInterval: TimeInterval = 10.0
+    /// Serial queue: one `bose-ctl` invocation at a time (RFCOMM is single-session;
+    /// serialising here mirrors the CLI's own serial channel discipline).
+    private let queue = DispatchQueue(label: "com.jamesdowzard.bose-control.cli")
 
-    private let boseMac = "E4:58:BC:C0:2F:72"
-
-    // MARK: - Polling
-
-    func startPolling() {
-        // Init BoseRFCOMM off main thread (BTReadyWaiter + SDP warmup blocks for ~6s)
-        rfcommQueue.async { [weak self] in
-            guard let self = self else { return }
-            self.bose = BoseRFCOMM()
-            self.boseReady = true
+    /// Resolve the engine: $BOSE_CTL → ~/bin/bose-ctl → repo cli/build/bose-ctl.
+    private static func resolveBinary() -> String {
+        let fm = FileManager.default
+        if let env = ProcessInfo.processInfo.environment["BOSE_CTL"], fm.isExecutableFile(atPath: env) {
+            return env
         }
-
-        // Initial check
-        checkConnectionAndRefresh()
-
-        // Poll every 10 seconds
-        pollTimer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
-            self?.checkConnectionAndRefresh()
-        }
+        let home = fm.homeDirectoryForCurrentUser.path
+        let candidates = [
+            "\(home)/bin/bose-ctl",
+            "\(home)/code/personal/bose/cli/build/bose-ctl",
+        ]
+        return candidates.first { fm.isExecutableFile(atPath: $0) } ?? "\(home)/bin/bose-ctl"
     }
 
-    func stopPolling() {
-        pollTimer?.invalidate()
-        pollTimer = nil
-    }
+    private lazy var binary: String = Self.resolveBinary()
 
-    // MARK: - Connection Check
+    // MARK: - Process runner
 
-    private func checkConnectionAndRefresh() {
-        rfcommQueue.async { [weak self] in
-            guard let self = self else { return }
-            let connected = self.isBluetoothConnected()
-
-            if connected && self.boseReady, let bose = self.bose {
-                let state = bose.getAllState()
-                DispatchQueue.main.async {
-                    self.isConnected = true
-                    self.applyState(state)
-                }
-            } else {
-                DispatchQueue.main.async {
-                    self.isConnected = connected
-                    if !connected {
-                        for key in self.deviceStates.keys {
-                            self.deviceStates[key] = "offline"
-                        }
-                    }
-                }
-            }
+    /// Run `bose-ctl <args>` synchronously (caller is already off the main thread).
+    /// Returns (exitCode, stdout). A spawn failure returns (-1, "").
+    @discardableResult
+    private func run(_ args: [String]) -> (code: Int32, out: String) {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: binary)
+        proc.arguments = args
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = Pipe()
+        do {
+            try proc.run()
+        } catch {
+            return (-1, "")
         }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        return (proc.terminationStatus, String(data: data, encoding: .utf8) ?? "")
     }
 
-    // MARK: - State Refresh
+    // MARK: - Read
 
+    /// Read full state via `info --json` and publish it. Event-driven only.
     func refreshState() {
         DispatchQueue.main.async { self.isRefreshing = true }
-        rfcommQueue.async { [weak self] in
+        queue.async { [weak self] in
             guard let self = self else { return }
-
-            let connected = self.isBluetoothConnected()
-            if connected && self.boseReady {
-                // fetchAllState dispatches to rfcommQueue — but we're already on it,
-                // so inline the work here to avoid deadlock
-                guard let bose = self.bose else {
-                    DispatchQueue.main.async { self.isRefreshing = false }
-                    return
-                }
-                let state = bose.getAllState()
-                DispatchQueue.main.async {
-                    self.applyState(state)
-                }
-            } else {
-                DispatchQueue.main.async {
-                    self.isConnected = connected
-                    if !connected {
-                        for key in self.deviceStates.keys {
-                            self.deviceStates[key] = "offline"
-                        }
-                    }
-                    self.isRefreshing = false
-                }
+            let (_, out) = self.run(["info", "--json"])
+            let parsed = Self.parse(out)
+            DispatchQueue.main.async {
+                self.apply(parsed)
+                self.isRefreshing = false
             }
         }
     }
 
-    /// Apply headphone state snapshot to published properties. Must be called on main thread.
-    private func applyState(_ state: BoseRFCOMM.HeadphoneState?) {
-        guard let bose = self.bose else {
-            self.isRefreshing = false
+    /// Decode the `info --json` payload. Returns nil-equivalent (connected=false) on
+    /// any failure so the UI shows the disconnected state rather than stale values.
+    private static func parse(_ out: String) -> [String: Any] {
+        guard let data = out.data(using: .utf8),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return ["connected": false] }
+        return obj
+    }
+
+    /// Apply a decoded snapshot to published properties. Must run on the main thread.
+    private func apply(_ s: [String: Any]) {
+        let connected = (s["connected"] as? Bool) ?? false
+        isConnected = connected
+        guard connected else {
+            for k in deviceStates.keys { deviceStates[k] = "offline" }
             return
         }
-
-        if let s = state {
-            self.batteryLevel = s.batteryLevel
-            self.batteryCharging = s.batteryCharging
-            self.ancMode = s.ancMode
-            self.volume = s.volume
-            self.volumeMax = s.volumeMax
-            self.firmware = s.firmware
-            self.serialNumber = s.serialNumber
-            self.productName = s.productName
-            self.platform = s.platform
-            self.codename = s.codename
-            self.audioCodec = s.audioCodec
-            self.deviceName = s.deviceName.isEmpty ? "verBosita" : s.deviceName
-            self.multipointEnabled = s.multipointEnabled
-            self.onHead = s.onHead
-            self.eq = s.eq
-            self.isConnected = true
-
-            // Parse auto-off timer
-            if !s.autoOffTimer.isEmpty {
-                let minutes = s.autoOffTimer.count >= 2
-                    ? Int(s.autoOffTimer[0]) * 256 + Int(s.autoOffTimer[1])
-                    : Int(s.autoOffTimer[0])
-                if minutes == 0 {
-                    self.autoOffTimer = "Never"
-                } else {
-                    self.autoOffTimer = "\(minutes) min"
-                }
-            }
-
-            // Parse immersion level
-            if !s.immersionLevel.isEmpty {
-                self.immersionLevel = s.immersionLevel
-                    .map { String(format: "%02X", $0) }.joined(separator: " ")
-            }
-
-            // Build device states: audio-connected = active, ACL-only = connected
-            var newStates: [String: String] = [:]
-            for key in self.deviceStates.keys {
-                newStates[key] = "offline"
-            }
-
-            let audioMacs = Set(s.connectedDevices.map { bose.macToString($0) })
-            let aclMacs = Set(s.aclConnectedDevices.map { bose.macToString($0) })
-
-            for (name, mac) in boseKnownDevices {
-                let macStr = bose.macToString(mac)
-                if audioMacs.contains(macStr) {
-                    newStates[name] = "active"
-                } else if aclMacs.contains(macStr) {
-                    newStates[name] = "connected"
-                } else {
-                    newStates[name] = "offline"
-                }
-            }
-            self.deviceStates = newStates
-        } else {
-            self.isConnected = false
+        batteryLevel = (s["batteryLevel"] as? Int) ?? batteryLevel
+        batteryCharging = (s["batteryCharging"] as? Bool) ?? false
+        ancMode = (s["ancMode"] as? Int) ?? ancMode
+        cncLevel = (s["ancDepth"] as? Int) ?? cncLevel
+        volume = (s["volume"] as? Int) ?? volume
+        volumeMax = (s["volumeMax"] as? Int) ?? volumeMax
+        multipointEnabled = (s["multipoint"] as? Bool) ?? false
+        onHead = (s["onHead"] as? Bool) ?? false
+        if let name = s["deviceName"] as? String, !name.isEmpty { deviceName = name }
+        if let fw = s["firmware"] as? String { firmware = fw }
+        if let e = s["eq"] as? [String: Any] {
+            eq = (bass: (e["bass"] as? Int) ?? 0,
+                  mid: (e["mid"] as? Int) ?? 0,
+                  treble: (e["treble"] as? Int) ?? 0)
         }
-
-        self.isRefreshing = false
+        if let d = s["devices"] as? [String: String] {
+            for (name, state) in d { deviceStates[name] = state }
+        }
     }
 
-    // MARK: - Commands
+    // MARK: - Write (each: run verb, optimistic local update, then re-read)
 
     func setAncMode(_ mode: Int) {
-        let modeNames = ["quiet", "aware", "custom1", "custom2"]
-        guard mode >= 0 && mode < modeNames.count else { return }
-        rfcommQueue.async { [weak self] in
-            guard let self = self, let bose = self.bose else { return }
-            let success = bose.setAncMode(modeNames[mode])
-            if success {
-                DispatchQueue.main.async {
-                    self.ancMode = mode
-                }
-            }
-        }
+        let names = ["quiet", "aware", "custom1", "custom2"]
+        guard names.indices.contains(mode) else { return }
+        ancMode = mode
+        write(["anc", names[mode]])
     }
 
     func setVolume(_ level: Int) {
-        rfcommQueue.async { [weak self] in
-            guard let self = self, let bose = self.bose else { return }
-            let success = bose.setVolume(level)
-            if success {
-                DispatchQueue.main.async {
-                    self.volume = level
-                }
-            }
-        }
-    }
-
-    func connectDevice(_ name: String) {
-        rfcommQueue.async { [weak self] in
-            guard let self = self, let bose = self.bose else { return }
-            guard let mac = bose.macForName(name) else { return }
-
-            // If connecting Mac, blueutil connect first for A2DP
-            if name == "mac" {
-                runBlueutil(["--connect", self.boseMac])
-                Thread.sleep(forTimeInterval: 1.5)
-            }
-
-            let success = bose.connectDevice(mac)
-            if success {
-                Thread.sleep(forTimeInterval: 0.5)
-                DispatchQueue.main.async {
-                    self.refreshState()
-                }
-            }
-        }
-    }
-
-    func disconnectDevice(_ name: String) {
-        rfcommQueue.async { [weak self] in
-            guard let self = self, let bose = self.bose else { return }
-            guard let mac = bose.macForName(name) else { return }
-
-            let success = bose.disconnectDevice(mac)
-            if success {
-                if name == "mac" {
-                    runBlueutil(["--disconnect", self.boseMac])
-                }
-                Thread.sleep(forTimeInterval: 0.5)
-                DispatchQueue.main.async {
-                    self.refreshState()
-                }
-            }
-        }
-    }
-
-    func sendMediaControl(_ action: UInt8) {
-        rfcommQueue.async { [weak self] in
-            guard let bose = self?.bose else { return }
-            _ = bose.sendMediaControl(action)
-        }
-    }
-
-    func setDeviceName(_ name: String) {
-        rfcommQueue.async { [weak self] in
-            guard let self = self, let bose = self.bose else { return }
-            let success = bose.setDeviceName(name)
-            if success {
-                DispatchQueue.main.async {
-                    self.deviceName = name
-                }
-            }
-        }
+        let clamped = max(0, min(volumeMax, level))
+        volume = clamped
+        write(["volume", String(clamped)])
     }
 
     func setEQ(bass: Int, mid: Int, treble: Int) {
-        rfcommQueue.async { [weak self] in
-            guard let self = self, let bose = self.bose else { return }
-            let success = bose.setEQ(bass: bass, mid: mid, treble: treble)
-            if success {
-                DispatchQueue.main.async {
-                    self.eq = (bass: bass, mid: mid, treble: treble)
-                }
-            }
-        }
+        eq = (bass: bass, mid: mid, treble: treble)
+        write(["eq", String(bass), String(mid), String(treble)])
     }
 
     func setMultipoint(_ enabled: Bool) {
-        rfcommQueue.async { [weak self] in
-            guard let self = self, let bose = self.bose else { return }
-            let success = bose.setMultipoint(enabled)
-            if success {
-                DispatchQueue.main.async {
-                    self.multipointEnabled = enabled
-                }
-            }
-        }
+        multipointEnabled = enabled
+        write(["multipoint", enabled ? "on" : "off"])
     }
 
+    /// ANC depth (CNC level 0–10). Note: exercises the #83 RMW path on hardware.
     func setCncLevel(_ level: Int) {
-        rfcommQueue.async { [weak self] in
-            guard let self = self, let bose = self.bose else { return }
-            let success = bose.setCncLevel(level)
-            if success {
-                DispatchQueue.main.async {
-                    self.cncLevel = level
-                }
-            }
+        let clamped = max(0, min(10, level))
+        cncLevel = clamped
+        write(["anc-depth", String(clamped)])
+    }
+
+    func connectDevice(_ name: String) {
+        write(["connect", name])
+    }
+
+    func applyProfile(_ name: String) {
+        write(["profile", name])
+    }
+
+    /// Run a write verb off the main thread, then refresh to reflect the device's
+    /// real post-write state (the optimistic update above is just for snappiness).
+    private func write(_ args: [String]) {
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            _ = self.run(args)
+            self.refreshState()
         }
     }
 
-    // MARK: - Bluetooth Helpers
-
-    private func isBluetoothConnected() -> Bool {
-        // Native IOBluetooth — no subprocess spawn needed for polling
-        let dashMac = boseMac.replacingOccurrences(of: ":", with: "-")
-        guard let device = IOBluetoothDevice(addressString: dashMac) else { return false }
-        return device.isConnected()
-    }
-
-    // MARK: - Computed Properties
+    // MARK: - Computed
 
     var ancModeName: String {
-        switch ancMode {
-        case 0: return "Quiet"
-        case 1: return "Aware"
-        case 2: return "Custom 1"
-        case 3: return "Custom 2"
-        default: return "Unknown"
-        }
+        ["Quiet", "Aware", "Custom 1", "Custom 2"][safe: ancMode] ?? "Unknown"
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -1,0 +1,349 @@
+/// BoseManager: Observable state manager for Bose QC Ultra 2 headphones.
+/// Handles polling, auto-reconnect, and all BMAP command dispatch.
+
+import Foundation
+import Combine
+import IOBluetooth
+
+class BoseManager: ObservableObject {
+
+    // MARK: - Published State
+
+    @Published var isConnected: Bool = false
+    @Published var batteryLevel: Int = 0
+    @Published var batteryCharging: Bool = false
+    @Published var ancMode: Int = 0  // 0=quiet, 1=aware, 2=custom1, 3=custom2
+    @Published var volume: Int = 0
+    @Published var volumeMax: Int = 31
+    @Published var deviceName: String = "verBosita"
+    @Published var firmware: String = ""
+    @Published var serialNumber: String = ""
+    @Published var productName: String = ""
+    @Published var platform: String = ""
+    @Published var codename: String = ""
+    @Published var audioCodec: String = ""
+    @Published var multipointEnabled: Bool = false
+    @Published var autoOffTimer: String = ""
+    @Published var immersionLevel: String = ""
+    @Published var cncLevel: Int = 0
+    @Published var onHead: Bool = false
+    @Published var eq: (bass: Int, mid: Int, treble: Int) = (0, 0, 0)
+
+    // Device connection states: "active", "connected", "offline"
+    @Published var deviceStates: [String: String] = [
+        "phone": "offline",
+        "mac": "offline",
+        "ipad": "offline",
+        "iphone": "offline",
+        "tv": "offline",
+        "quest": "offline",
+    ]
+
+    @Published var isRefreshing: Bool = false
+
+    // MARK: - Private
+
+    private var bose: BoseRFCOMM?
+    private var boseReady = false
+    private let rfcommQueue = DispatchQueue(label: "com.jamesdowzard.bose-control.rfcomm")
+    private var pollTimer: Timer?
+    private let pollInterval: TimeInterval = 10.0
+
+    private let boseMac = "E4:58:BC:C0:2F:72"
+
+    // MARK: - Polling
+
+    func startPolling() {
+        // Init BoseRFCOMM off main thread (BTReadyWaiter + SDP warmup blocks for ~6s)
+        rfcommQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.bose = BoseRFCOMM()
+            self.boseReady = true
+        }
+
+        // Initial check
+        checkConnectionAndRefresh()
+
+        // Poll every 10 seconds
+        pollTimer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            self?.checkConnectionAndRefresh()
+        }
+    }
+
+    func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    // MARK: - Connection Check
+
+    private func checkConnectionAndRefresh() {
+        rfcommQueue.async { [weak self] in
+            guard let self = self else { return }
+            let connected = self.isBluetoothConnected()
+
+            if connected && self.boseReady, let bose = self.bose {
+                let state = bose.getAllState()
+                DispatchQueue.main.async {
+                    self.isConnected = true
+                    self.applyState(state)
+                }
+            } else {
+                DispatchQueue.main.async {
+                    self.isConnected = connected
+                    if !connected {
+                        for key in self.deviceStates.keys {
+                            self.deviceStates[key] = "offline"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - State Refresh
+
+    func refreshState() {
+        DispatchQueue.main.async { self.isRefreshing = true }
+        rfcommQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            let connected = self.isBluetoothConnected()
+            if connected && self.boseReady {
+                // fetchAllState dispatches to rfcommQueue — but we're already on it,
+                // so inline the work here to avoid deadlock
+                guard let bose = self.bose else {
+                    DispatchQueue.main.async { self.isRefreshing = false }
+                    return
+                }
+                let state = bose.getAllState()
+                DispatchQueue.main.async {
+                    self.applyState(state)
+                }
+            } else {
+                DispatchQueue.main.async {
+                    self.isConnected = connected
+                    if !connected {
+                        for key in self.deviceStates.keys {
+                            self.deviceStates[key] = "offline"
+                        }
+                    }
+                    self.isRefreshing = false
+                }
+            }
+        }
+    }
+
+    /// Apply headphone state snapshot to published properties. Must be called on main thread.
+    private func applyState(_ state: BoseRFCOMM.HeadphoneState?) {
+        guard let bose = self.bose else {
+            self.isRefreshing = false
+            return
+        }
+
+        if let s = state {
+            self.batteryLevel = s.batteryLevel
+            self.batteryCharging = s.batteryCharging
+            self.ancMode = s.ancMode
+            self.volume = s.volume
+            self.volumeMax = s.volumeMax
+            self.firmware = s.firmware
+            self.serialNumber = s.serialNumber
+            self.productName = s.productName
+            self.platform = s.platform
+            self.codename = s.codename
+            self.audioCodec = s.audioCodec
+            self.deviceName = s.deviceName.isEmpty ? "verBosita" : s.deviceName
+            self.multipointEnabled = s.multipointEnabled
+            self.onHead = s.onHead
+            self.eq = s.eq
+            self.isConnected = true
+
+            // Parse auto-off timer
+            if !s.autoOffTimer.isEmpty {
+                let minutes = s.autoOffTimer.count >= 2
+                    ? Int(s.autoOffTimer[0]) * 256 + Int(s.autoOffTimer[1])
+                    : Int(s.autoOffTimer[0])
+                if minutes == 0 {
+                    self.autoOffTimer = "Never"
+                } else {
+                    self.autoOffTimer = "\(minutes) min"
+                }
+            }
+
+            // Parse immersion level
+            if !s.immersionLevel.isEmpty {
+                self.immersionLevel = s.immersionLevel
+                    .map { String(format: "%02X", $0) }.joined(separator: " ")
+            }
+
+            // Build device states: audio-connected = active, ACL-only = connected
+            var newStates: [String: String] = [:]
+            for key in self.deviceStates.keys {
+                newStates[key] = "offline"
+            }
+
+            let audioMacs = Set(s.connectedDevices.map { bose.macToString($0) })
+            let aclMacs = Set(s.aclConnectedDevices.map { bose.macToString($0) })
+
+            for (name, mac) in boseKnownDevices {
+                let macStr = bose.macToString(mac)
+                if audioMacs.contains(macStr) {
+                    newStates[name] = "active"
+                } else if aclMacs.contains(macStr) {
+                    newStates[name] = "connected"
+                } else {
+                    newStates[name] = "offline"
+                }
+            }
+            self.deviceStates = newStates
+        } else {
+            self.isConnected = false
+        }
+
+        self.isRefreshing = false
+    }
+
+    // MARK: - Commands
+
+    func setAncMode(_ mode: Int) {
+        let modeNames = ["quiet", "aware", "custom1", "custom2"]
+        guard mode >= 0 && mode < modeNames.count else { return }
+        rfcommQueue.async { [weak self] in
+            guard let self = self, let bose = self.bose else { return }
+            let success = bose.setAncMode(modeNames[mode])
+            if success {
+                DispatchQueue.main.async {
+                    self.ancMode = mode
+                }
+            }
+        }
+    }
+
+    func setVolume(_ level: Int) {
+        rfcommQueue.async { [weak self] in
+            guard let self = self, let bose = self.bose else { return }
+            let success = bose.setVolume(level)
+            if success {
+                DispatchQueue.main.async {
+                    self.volume = level
+                }
+            }
+        }
+    }
+
+    func connectDevice(_ name: String) {
+        rfcommQueue.async { [weak self] in
+            guard let self = self, let bose = self.bose else { return }
+            guard let mac = bose.macForName(name) else { return }
+
+            // If connecting Mac, blueutil connect first for A2DP
+            if name == "mac" {
+                runBlueutil(["--connect", self.boseMac])
+                Thread.sleep(forTimeInterval: 1.5)
+            }
+
+            let success = bose.connectDevice(mac)
+            if success {
+                Thread.sleep(forTimeInterval: 0.5)
+                DispatchQueue.main.async {
+                    self.refreshState()
+                }
+            }
+        }
+    }
+
+    func disconnectDevice(_ name: String) {
+        rfcommQueue.async { [weak self] in
+            guard let self = self, let bose = self.bose else { return }
+            guard let mac = bose.macForName(name) else { return }
+
+            let success = bose.disconnectDevice(mac)
+            if success {
+                if name == "mac" {
+                    runBlueutil(["--disconnect", self.boseMac])
+                }
+                Thread.sleep(forTimeInterval: 0.5)
+                DispatchQueue.main.async {
+                    self.refreshState()
+                }
+            }
+        }
+    }
+
+    func sendMediaControl(_ action: UInt8) {
+        rfcommQueue.async { [weak self] in
+            guard let bose = self?.bose else { return }
+            _ = bose.sendMediaControl(action)
+        }
+    }
+
+    func setDeviceName(_ name: String) {
+        rfcommQueue.async { [weak self] in
+            guard let self = self, let bose = self.bose else { return }
+            let success = bose.setDeviceName(name)
+            if success {
+                DispatchQueue.main.async {
+                    self.deviceName = name
+                }
+            }
+        }
+    }
+
+    func setEQ(bass: Int, mid: Int, treble: Int) {
+        rfcommQueue.async { [weak self] in
+            guard let self = self, let bose = self.bose else { return }
+            let success = bose.setEQ(bass: bass, mid: mid, treble: treble)
+            if success {
+                DispatchQueue.main.async {
+                    self.eq = (bass: bass, mid: mid, treble: treble)
+                }
+            }
+        }
+    }
+
+    func setMultipoint(_ enabled: Bool) {
+        rfcommQueue.async { [weak self] in
+            guard let self = self, let bose = self.bose else { return }
+            let success = bose.setMultipoint(enabled)
+            if success {
+                DispatchQueue.main.async {
+                    self.multipointEnabled = enabled
+                }
+            }
+        }
+    }
+
+    func setCncLevel(_ level: Int) {
+        rfcommQueue.async { [weak self] in
+            guard let self = self, let bose = self.bose else { return }
+            let success = bose.setCncLevel(level)
+            if success {
+                DispatchQueue.main.async {
+                    self.cncLevel = level
+                }
+            }
+        }
+    }
+
+    // MARK: - Bluetooth Helpers
+
+    private func isBluetoothConnected() -> Bool {
+        // Native IOBluetooth — no subprocess spawn needed for polling
+        let dashMac = boseMac.replacingOccurrences(of: ":", with: "-")
+        guard let device = IOBluetoothDevice(addressString: dashMac) else { return false }
+        return device.isConnected()
+    }
+
+    // MARK: - Computed Properties
+
+    var ancModeName: String {
+        switch ancMode {
+        case 0: return "Quiet"
+        case 1: return "Aware"
+        case 2: return "Custom 1"
+        case 3: return "Custom 2"
+        default: return "Unknown"
+        }
+    }
+}

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -1,0 +1,403 @@
+/// ContentView: Frosted-dark two-panel layout for Bose headphone control.
+/// Left panel = status sidebar (220px), right panel = device grid + EQ.
+/// Uses NSVisualEffectView for macOS vibrancy/translucency.
+
+import SwiftUI
+
+// MARK: - Theme Colors
+
+/// No neon green. White/light grey for active, warm grey for secondary, 40% opacity grey for offline.
+private let activeColor = Color.white
+private let secondaryColor = Color(white: 0.55)
+private let offlineColor = Color(white: 0.4)
+private let cardColor = Color.white.opacity(0.06)
+private let dividerColor = Color.white.opacity(0.08)
+
+// MARK: - Device Button Model
+
+private struct DeviceButton: Identifiable {
+    let id: String  // name key
+    let label: String
+    let symbol: String
+}
+
+private let deviceButtons: [DeviceButton] = [
+    DeviceButton(id: "mac", label: "Mac", symbol: "laptopcomputer"),
+    DeviceButton(id: "phone", label: "Phone", symbol: "iphone"),
+    DeviceButton(id: "ipad", label: "iPad", symbol: "ipad"),
+    DeviceButton(id: "iphone", label: "iPhone", symbol: "iphone"),
+    DeviceButton(id: "tv", label: "TV", symbol: "tv"),
+    DeviceButton(id: "quest", label: "Quest", symbol: "visionpro"),
+]
+
+// MARK: - Visual Effect Background
+
+/// NSViewRepresentable wrapping NSVisualEffectView with .hudWindow material
+/// for macOS dark vibrancy/translucency.
+struct VisualEffectBackground: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = .hudWindow
+        view.blendingMode = .behindWindow
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}
+
+// MARK: - Main View
+
+struct ContentView: View {
+    @ObservedObject var manager: BoseManager
+
+    @State private var volumeSlider: Double = 0
+    @State private var eqBass: Double = 0
+    @State private var eqMid: Double = 0
+    @State private var eqTreble: Double = 0
+
+    var body: some View {
+        Group {
+            if manager.isConnected {
+                connectedLayout
+            } else {
+                disconnectedView
+            }
+        }
+        .frame(width: 640, height: 360)
+        .background(VisualEffectBackground())
+        .onAppear {
+            manager.refreshState()
+            syncSliders()
+            installCmdMShortcut()
+        }
+        .onReceive(manager.objectWillChange) { _ in
+            DispatchQueue.main.async { syncSliders() }
+        }
+    }
+
+    private func syncSliders() {
+        volumeSlider = Double(manager.volume)
+        eqBass = Double(manager.eq.bass)
+        eqMid = Double(manager.eq.mid)
+        eqTreble = Double(manager.eq.treble)
+    }
+
+    private func installCmdMShortcut() {
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "m" {
+                manager.connectDevice("mac")
+                return nil
+            }
+            return event
+        }
+    }
+
+    // MARK: - Connected Layout
+
+    private var connectedLayout: some View {
+        HStack(spacing: 0) {
+            // Left panel — status sidebar
+            leftPanel
+                .frame(width: 220)
+
+            // Divider
+            Rectangle()
+                .fill(dividerColor)
+                .frame(width: 1)
+
+            // Right panel — device grid + EQ
+            rightPanel
+                .frame(maxWidth: .infinity)
+        }
+        .padding(.top, 28)  // clear transparent title bar
+    }
+
+    // MARK: - Left Panel (Status Sidebar)
+
+    private var leftPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Device name + battery
+            VStack(alignment: .leading, spacing: 4) {
+                Text(manager.deviceName)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(activeColor)
+
+                HStack(spacing: 6) {
+                    Image(systemName: batteryIcon)
+                        .font(.system(size: 11))
+                        .foregroundColor(batteryColor)
+                    Text("\(manager.batteryLevel)%")
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        .foregroundColor(batteryColor)
+                    if manager.batteryCharging {
+                        Image(systemName: "bolt.fill")
+                            .font(.system(size: 10))
+                            .foregroundColor(.orange)
+                    }
+                }
+            }
+
+            // ANC mode
+            VStack(alignment: .leading, spacing: 6) {
+                Text("NOISE CONTROL")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(secondaryColor)
+                    .tracking(1)
+                HStack(spacing: 4) {
+                    ancButton("Quiet", 0)
+                    ancButton("Aware", 1)
+                    ancButton("C1", 2)
+                    ancButton("C2", 3)
+                }
+            }
+
+            // Volume
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("VOLUME")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(secondaryColor)
+                        .tracking(1)
+                    Spacer()
+                    Text("\(Int(volumeSlider))")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundColor(secondaryColor)
+                }
+                Slider(
+                    value: $volumeSlider,
+                    in: 0...Double(manager.volumeMax),
+                    onEditingChanged: { editing in
+                        if !editing {
+                            manager.setVolume(Int(volumeSlider))
+                        }
+                    }
+                )
+                .tint(activeColor)
+            }
+
+            // Wear detection
+            VStack(alignment: .leading, spacing: 4) {
+                Text("STATUS")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(secondaryColor)
+                    .tracking(1)
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(manager.onHead ? Color.green : Color.orange)
+                        .frame(width: 6, height: 6)
+                    Text(manager.onHead ? "On head" : "Off head")
+                        .font(.system(size: 12))
+                        .foregroundColor(activeColor)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(16)
+    }
+
+    // MARK: - Right Panel (Device Grid + EQ)
+
+    private var rightPanel: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("DEVICES")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(secondaryColor)
+                .tracking(1)
+
+            deviceGrid
+
+            Text("EQUALIZER")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(secondaryColor)
+                .tracking(1)
+                .padding(.top, 4)
+
+            eqPresets
+            eqSliders
+        }
+        .padding(16)
+    }
+
+    private var deviceGrid: some View {
+        let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
+        return LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(deviceButtons) { button in
+                deviceButton(button)
+            }
+        }
+    }
+
+    private func deviceButton(_ button: DeviceButton) -> some View {
+        let state = manager.deviceStates[button.id] ?? "offline"
+        let isActive = state == "active"
+        let isConnected = state == "connected"
+
+        let textColor: Color = isActive ? activeColor : (isConnected ? secondaryColor : offlineColor)
+        let bg: Color = isActive ? Color.white.opacity(0.14) : cardColor
+        let borderColor: Color = isActive ? activeColor.opacity(0.7) : Color.white.opacity(0.04)
+
+        return Button(action: { manager.connectDevice(button.id) }) {
+            VStack(spacing: 3) {
+                Image(systemName: button.symbol)
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundColor(textColor)
+                Text(button.label)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(textColor)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 52)
+            .background(bg)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(borderColor, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .opacity(state == "offline" ? 0.6 : 1.0)
+    }
+
+    private struct EqPreset {
+        let name: String
+        let bass: Int
+        let mid: Int
+        let treble: Int
+    }
+
+    private let eqPresetList: [EqPreset] = [
+        EqPreset(name: "Flat", bass: 0, mid: 0, treble: 0),
+        EqPreset(name: "Bass+", bass: 6, mid: 0, treble: -2),
+        EqPreset(name: "Treble+", bass: -2, mid: 0, treble: 6),
+        EqPreset(name: "Vocal", bass: -2, mid: 4, treble: 2),
+    ]
+
+    private var eqPresets: some View {
+        HStack(spacing: 6) {
+            ForEach(eqPresetList, id: \.name) { preset in
+                let selected = manager.eq.bass == preset.bass &&
+                    manager.eq.mid == preset.mid &&
+                    manager.eq.treble == preset.treble
+                Button(action: {
+                    eqBass = Double(preset.bass)
+                    eqMid = Double(preset.mid)
+                    eqTreble = Double(preset.treble)
+                    manager.setEQ(bass: preset.bass, mid: preset.mid, treble: preset.treble)
+                }) {
+                    Text(preset.name)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(selected ? .black : secondaryColor)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 5)
+                        .background(selected ? activeColor : cardColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var eqSliders: some View {
+        VStack(spacing: 4) {
+            eqBandSlider("Bass", value: $eqBass) {
+                manager.setEQ(bass: Int(eqBass), mid: Int(eqMid), treble: Int(eqTreble))
+            }
+            eqBandSlider("Mid", value: $eqMid) {
+                manager.setEQ(bass: Int(eqBass), mid: Int(eqMid), treble: Int(eqTreble))
+            }
+            eqBandSlider("Treble", value: $eqTreble) {
+                manager.setEQ(bass: Int(eqBass), mid: Int(eqMid), treble: Int(eqTreble))
+            }
+        }
+    }
+
+    private func eqBandSlider(_ label: String, value: Binding<Double>, onCommit: @escaping () -> Void) -> some View {
+        HStack(spacing: 8) {
+            Text(label)
+                .font(.system(size: 10))
+                .foregroundColor(secondaryColor)
+                .frame(width: 38, alignment: .leading)
+            Slider(
+                value: value,
+                in: -10...10,
+                step: 1,
+                onEditingChanged: { editing in
+                    if !editing { onCommit() }
+                }
+            )
+            .tint(activeColor)
+            Text("\(Int(value.wrappedValue))")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(secondaryColor)
+                .frame(width: 22, alignment: .trailing)
+        }
+    }
+
+    private func ancButton(_ label: String, _ mode: Int) -> some View {
+        let isActive = manager.ancMode == mode
+        return Button(action: { manager.setAncMode(mode) }) {
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(isActive ? .black : secondaryColor)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 5)
+                .background(isActive ? activeColor : cardColor)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Disconnected View
+
+    private var disconnectedView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "headphones")
+                .font(.system(size: 48, weight: .thin))
+                .foregroundColor(offlineColor)
+
+            Text("Not Connected")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(secondaryColor)
+
+            Button(action: {
+                manager.connectDevice("mac")
+            }) {
+                Text("Connect")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.black)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 8)
+                    .background(activeColor)
+                    .cornerRadius(8)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, 28)
+    }
+
+    // MARK: - Helpers
+
+    private var batteryIcon: String {
+        switch manager.batteryLevel {
+        case 0..<10: return "battery.0"
+        case 10..<35: return "battery.25"
+        case 35..<65: return "battery.50"
+        case 65..<90: return "battery.75"
+        default: return "battery.100"
+        }
+    }
+
+    private var batteryColor: Color {
+        if manager.batteryCharging { return .green }
+        if manager.batteryLevel < 15 { return .red }
+        if manager.batteryLevel < 30 { return .orange }
+        return activeColor
+    }
+}

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -52,6 +52,7 @@ struct ContentView: View {
     @ObservedObject var manager: BoseManager
 
     @State private var volumeSlider: Double = 0
+    @State private var ancDepthSlider: Double = 0
     @State private var eqBass: Double = 0
     @State private var eqMid: Double = 0
     @State private var eqTreble: Double = 0
@@ -69,7 +70,7 @@ struct ContentView: View {
         .onAppear {
             manager.refreshState()
             syncSliders()
-            installCmdMShortcut()
+            installShortcuts()
         }
         .onReceive(manager.objectWillChange) { _ in
             DispatchQueue.main.async { syncSliders() }
@@ -78,18 +79,31 @@ struct ContentView: View {
 
     private func syncSliders() {
         volumeSlider = Double(manager.volume)
+        ancDepthSlider = Double(manager.cncLevel)
         eqBass = Double(manager.eq.bass)
         eqMid = Double(manager.eq.mid)
         eqTreble = Double(manager.eq.treble)
     }
 
-    private func installCmdMShortcut() {
+    /// In-window keyboard shortcuts (only while the app is focused — global hotkeys
+    /// stay in Hammerspoon). ⌘1/2/3/4 ANC modes, ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M Mac.
+    private func installShortcuts() {
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "m" {
-                manager.connectDevice("mac")
-                return nil
+            guard event.modifierFlags.contains(.command) else { return event }
+            switch event.charactersIgnoringModifiers {
+            case "1": manager.setAncMode(0); return nil
+            case "2": manager.setAncMode(1); return nil
+            case "3": manager.setAncMode(2); return nil
+            case "4": manager.setAncMode(3); return nil
+            case "r": manager.refreshState(); return nil
+            case "m": manager.connectDevice("mac"); return nil
+            default: break
             }
-            return event
+            switch event.keyCode {
+            case 126: manager.setVolume(manager.volume + 1); return nil  // ↑
+            case 125: manager.setVolume(manager.volume - 1); return nil  // ↓
+            default: return event
+            }
         }
     }
 
@@ -150,6 +164,26 @@ struct ContentView: View {
                     ancButton("C1", 2)
                     ancButton("C2", 3)
                 }
+                // ANC depth (CNC level 0–10). NB: exercises the #83 RMW path.
+                HStack(spacing: 8) {
+                    Text("Depth")
+                        .font(.system(size: 10))
+                        .foregroundColor(secondaryColor)
+                        .frame(width: 38, alignment: .leading)
+                    Slider(
+                        value: $ancDepthSlider,
+                        in: 0...10,
+                        step: 1,
+                        onEditingChanged: { editing in
+                            if !editing { manager.setCncLevel(Int(ancDepthSlider)) }
+                        }
+                    )
+                    .tint(activeColor)
+                    Text("\(Int(ancDepthSlider))")
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(secondaryColor)
+                        .frame(width: 22, alignment: .trailing)
+                }
             }
 
             // Volume
@@ -175,6 +209,19 @@ struct ContentView: View {
                 )
                 .tint(activeColor)
             }
+
+            // Multipoint
+            Toggle(isOn: Binding(
+                get: { manager.multipointEnabled },
+                set: { manager.setMultipoint($0) }
+            )) {
+                Text("MULTIPOINT")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(secondaryColor)
+                    .tracking(1)
+            }
+            .toggleStyle(.switch)
+            .tint(activeColor)
 
             // Wear detection
             VStack(alignment: .leading, spacing: 4) {

--- a/macos/BoseControl/Info.plist
+++ b/macos/BoseControl/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Bose Control</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>com.jamesdowzard.bose-control</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Bose</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<!-- Dock app (not LSUIElement) -->
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Bose needs Bluetooth to communicate with your Bose QC Ultra headphones.</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Bose needs Bluetooth to communicate with your Bose QC Ultra headphones.</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -1,71 +1,72 @@
 #!/bin/bash
-# Build Bose Control.app — native macOS windowed app
-# Requires: Xcode command line tools (xcode-select --install)
+# Build "Bose Control.app" — the windowed macOS controller.
+#
+# The app is a THIN FRONT-END over `bose-ctl`: it shells the CLI for every read
+# (`info --json`) and write (anc/volume/eq/multipoint/anc-depth/connect/profile).
+# It holds NO RFCOMM channel and links NO IOBluetooth — so it can't reintroduce the
+# polling/transport bugs, and it inherits every CLI fix for free. That's why this
+# build compiles ONLY the four SwiftUI files (pure SwiftUI + Foundation) and links
+# no Bluetooth frameworks. There is intentionally NO LaunchAgent — the app is
+# user-launched and event-driven.
+#
+# Requires: Xcode command line tools (xcode-select --install).
+# Optional: a Developer ID Application identity for a persistent signature.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="$SCRIPT_DIR/build"
 APP_NAME="Bose Control"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
 RESOURCES_DIR="$APP_BUNDLE/Contents/Resources"
+SRC="$SCRIPT_DIR/BoseControl"
 
 echo "Building $APP_NAME..."
 
-# Clean previous build
 rm -rf "$BUILD_DIR"
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
 
-# Copy Info.plist
-cp "$SCRIPT_DIR/BoseControl/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
+cp "$SRC/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
 
-# Compile
-# Sources: BoseRFCOMM.swift from repo root + app files from BoseControl/
+# Pure SwiftUI/Foundation — no IOBluetooth, no protocol sources. The app shells
+# `bose-ctl`, which owns all RFCOMM.
 swiftc -O \
     -target arm64-apple-macos13.0 \
     -sdk "$(xcrun --show-sdk-path)" \
-    "$REPO_ROOT/BoseRFCOMM.swift" \
-    "$SCRIPT_DIR/BoseControl/BoseApp.swift" \
-    "$SCRIPT_DIR/BoseControl/AppDelegate.swift" \
-    "$SCRIPT_DIR/BoseControl/BoseManager.swift" \
-    "$SCRIPT_DIR/BoseControl/ContentView.swift" \
-    -framework IOBluetooth \
-    -framework CoreBluetooth \
+    "$SRC/BoseApp.swift" \
+    "$SRC/AppDelegate.swift" \
+    "$SRC/BoseManager.swift" \
+    "$SRC/ContentView.swift" \
     -framework SwiftUI \
     -framework AppKit \
-    -o "$MACOS_DIR/$APP_NAME" \
-    -Xlinker -rpath -Xlinker @executable_path/../Frameworks
+    -o "$MACOS_DIR/$APP_NAME"
 
 echo "Built: $APP_BUNDLE"
 
-# Install to /Applications
+# Sign: Developer ID if available (persistent), else ad-hoc (works locally).
+SIGN_ID="${BOSE_SIGN_ID:-Developer ID Application}"
+if security find-identity -v -p codesigning 2>/dev/null | grep -q "$SIGN_ID"; then
+    echo "Signing with: $SIGN_ID"
+    codesign --force --deep --options runtime \
+        --entitlements "$SRC/BoseControl.entitlements" \
+        --sign "$SIGN_ID" "$APP_BUNDLE"
+else
+    echo "No Developer ID found — ad-hoc signing (local use)."
+    codesign --force --deep \
+        --entitlements "$SRC/BoseControl.entitlements" \
+        --sign - "$APP_BUNDLE"
+fi
+codesign --verify --verbose "$APP_BUNDLE" 2>&1 | sed 's/^/  /' || true
+
+# Install to /Applications (no LaunchAgent — user-launched, event-driven).
 if [ "${1:-}" = "--install" ]; then
     echo "Installing to /Applications..."
     if [ -d "/Applications/$APP_NAME.app" ]; then
-        mv "/Applications/$APP_NAME.app" ~/.Trash/
+        mv "/Applications/$APP_NAME.app" "$HOME/.Trash/Bose Control.app.$(date +%s)" 2>/dev/null || \
+        rm -rf "/Applications/$APP_NAME.app"
     fi
     cp -R "$APP_BUNDLE" "/Applications/"
     echo "Installed: /Applications/$APP_NAME.app"
-
-    # Install LaunchAgent
-    LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
-    mkdir -p "$LAUNCH_AGENTS_DIR"
-    PLIST_NAME="com.jamesdowzard.bose-control.plist"
-    if launchctl list | grep -q "com.jamesdowzard.bose-control" 2>/dev/null; then
-        launchctl unload "$LAUNCH_AGENTS_DIR/$PLIST_NAME" 2>/dev/null || true
-    fi
-    cp "$SCRIPT_DIR/$PLIST_NAME" "$LAUNCH_AGENTS_DIR/"
-    launchctl load "$LAUNCH_AGENTS_DIR/$PLIST_NAME"
-    echo "LaunchAgent installed and loaded"
-
-    # Remove old bosed LaunchAgent if present
-    OLD_PLIST="$LAUNCH_AGENTS_DIR/com.jamesdowzard.bosed.plist"
-    if [ -f "$OLD_PLIST" ]; then
-        launchctl unload "$OLD_PLIST" 2>/dev/null || true
-        mv "$OLD_PLIST" ~/.Trash/
-        echo "Old bosed LaunchAgent removed"
-    fi
 fi
 
 echo "Done."

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Build Bose Control.app — native macOS windowed app
+# Requires: Xcode command line tools (xcode-select --install)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+BUILD_DIR="$SCRIPT_DIR/build"
+APP_NAME="Bose Control"
+APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
+MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
+RESOURCES_DIR="$APP_BUNDLE/Contents/Resources"
+
+echo "Building $APP_NAME..."
+
+# Clean previous build
+rm -rf "$BUILD_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+
+# Copy Info.plist
+cp "$SCRIPT_DIR/BoseControl/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
+
+# Compile
+# Sources: BoseRFCOMM.swift from repo root + app files from BoseControl/
+swiftc -O \
+    -target arm64-apple-macos13.0 \
+    -sdk "$(xcrun --show-sdk-path)" \
+    "$REPO_ROOT/BoseRFCOMM.swift" \
+    "$SCRIPT_DIR/BoseControl/BoseApp.swift" \
+    "$SCRIPT_DIR/BoseControl/AppDelegate.swift" \
+    "$SCRIPT_DIR/BoseControl/BoseManager.swift" \
+    "$SCRIPT_DIR/BoseControl/ContentView.swift" \
+    -framework IOBluetooth \
+    -framework CoreBluetooth \
+    -framework SwiftUI \
+    -framework AppKit \
+    -o "$MACOS_DIR/$APP_NAME" \
+    -Xlinker -rpath -Xlinker @executable_path/../Frameworks
+
+echo "Built: $APP_BUNDLE"
+
+# Install to /Applications
+if [ "${1:-}" = "--install" ]; then
+    echo "Installing to /Applications..."
+    if [ -d "/Applications/$APP_NAME.app" ]; then
+        mv "/Applications/$APP_NAME.app" ~/.Trash/
+    fi
+    cp -R "$APP_BUNDLE" "/Applications/"
+    echo "Installed: /Applications/$APP_NAME.app"
+
+    # Install LaunchAgent
+    LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+    mkdir -p "$LAUNCH_AGENTS_DIR"
+    PLIST_NAME="com.jamesdowzard.bose-control.plist"
+    if launchctl list | grep -q "com.jamesdowzard.bose-control" 2>/dev/null; then
+        launchctl unload "$LAUNCH_AGENTS_DIR/$PLIST_NAME" 2>/dev/null || true
+    fi
+    cp "$SCRIPT_DIR/$PLIST_NAME" "$LAUNCH_AGENTS_DIR/"
+    launchctl load "$LAUNCH_AGENTS_DIR/$PLIST_NAME"
+    echo "LaunchAgent installed and loaded"
+
+    # Remove old bosed LaunchAgent if present
+    OLD_PLIST="$LAUNCH_AGENTS_DIR/com.jamesdowzard.bosed.plist"
+    if [ -f "$OLD_PLIST" ]; then
+        launchctl unload "$OLD_PLIST" 2>/dev/null || true
+        mv "$OLD_PLIST" ~/.Trash/
+        echo "Old bosed LaunchAgent removed"
+    fi
+fi
+
+echo "Done."


### PR DESCRIPTION
Restores the deleted SwiftUI windowed controller (from f0b71d7) and re-wires it as a third thin front-end over `bose-ctl` — no RFCOMM, no IOBluetooth, no polling.

## What
- **`bose-ctl info --json`** new read seam (`cli/main.swift` `cmdInfoJSON`) — pure formatting over `getAllState` + `getDeviceStates`.
- **BoseManager** rewritten to shell `bose-ctl` via `Process`; dropped `BoseRFCOMM`/`pollTimer`/`startPolling`/auto-reconnect/IOBluetooth. Event-driven reads only (open, focus, post-write, ⌘R).
- **ContentView**: restored + ANC depth slider, multipoint toggle, in-window keys (⌘1/2/3/4 ANC, ⌘↑/↓ volume, ⌘R refresh, ⌘M Mac).
- **macos/build.sh**: pure-SwiftUI build, Developer-ID signed, no LaunchAgent.
- **CLAUDE.md** updated.

## Why this can't cause the old dropout
The app never holds an RFCOMM channel and never polls — it shells the CLI on explicit events only. Inherits every CLI fix (incl. #83) automatically.

## Verified
- `protocol make check` — 29 golden tests pass, no drift
- `cli/run-tests.sh` — all pass
- `bose-ctl info --json` — valid JSON against live hardware (fw 8.2.20)
- App builds, Developer-ID signs, launch-smoke renders all controls with live state

## Known limitation
Multipoint toggle + custom ANC depth exercise the open #83 flight/CNC-RMW path; the window surfaces but does not fix it (fix lands in the CLI; app inherits it).