### PR TITLE
fix #83: flight ANC disabled + multipoint readback

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-restore windowed Mac app on v2 core (event-driven, no polling)
-restore windowed Mac app on v2 core (event-driven, no polling)
+fix #83 flight ANC + multipoint
+fix #83 flight ANC + multipoint
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - restore-windowed-mac-app
+# Agent Progress - fix-83-flight-anc-mp
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-08T04:05:35Z
+# Created: 2026-06-08T04:37:40Z
 
-feature=restore-windowed-mac-app
-name=restore windowed Mac app on v2 core (event-driven, no polling)
+feature=fix-83-flight-anc-mp
+name=fix #83 flight ANC + multipoint
 status=pending
 step=0
 step_name=Not started
-created=2026-06-08T04:05:35Z
+created=2026-06-08T04:37:40Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ is three thin front-ends that shell out to the `cli/` binary (`~/bin/bose-ctl`),
 nothing runs in the background and the Mac only touches the headphones on an
 explicit user action.
 - `macos/BoseControl/` -- **Bose Control.app**: a windowed SwiftUI app (frosted-dark
-  two-panel: battery/ANC mode+depth/volume/multipoint/on-head + device grid + EQ).
+  two-panel: battery/ANC mode/volume/multipoint/on-head + device grid + EQ). No depth
+  slider — ANC is mode-based and a raw depth disables it (#83); modes only.
   It is a **thin front-end that shells `bose-ctl`** — NO RFCOMM, NO IOBluetooth, NO
   protocol code — reading via `bose-ctl info --json` and writing via the verbs. It is
   **user-launched and event-driven**: reads on window-open, on app-focus, after each
@@ -41,7 +42,7 @@ explicit user action.
 - `raycast/bose-connect.sh` / `bose-disconnect.sh` -- Raycast script commands with a device dropdown → `bose-ctl connect|disconnect <device>`
 - `raycast/bose-status.sh` / `bose-full-status.sh` -- `bose-ctl status` / `bose-ctl info`
 - `raycast/bose-anc-depth.sh` / `bose-profile.sh` -- `bose-ctl anc-depth [0-10]` / `bose-ctl profile [name]` (text arg)
-- `profiles.json` (repo root) -- settings presets ({ANC mode, depth, EQ, multipoint, volume}) applied by `bose-ctl profile`; versioned + hand-editable, ships flight/office/music. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
+- `profiles.json` (repo root) -- settings presets ({ANC mode, depth, EQ, multipoint, volume}) applied by `bose-ctl profile`; versioned + hand-editable, ships flight/office/music. ANC depth is applied ONLY for custom1/custom2 modes (named modes set mode only — depth over quiet/aware disables ANC, #83). flight = {quiet, multipoint off}. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
 - `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B toggles Mac ↔ phone** (+ one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→custom1), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
 - The Swift core that does the actual RFCOMM work lives in `cli/` (see below). The macOS app target (`macos/BoseControl/`) is pure SwiftUI/Foundation and does NO RFCOMM — it shells `bose-ctl`, so the two never drift and the app can't reintroduce a transport/poll bug.
 
@@ -227,15 +228,15 @@ BMAP operator (SET/0x06 instead of SET_GET/0x02).
 
 | Setting | Block,Func | Operator | Bytes | Notes |
 |---------|-----------|----------|-------|-------|
-| ANC mode | 1F,03 | START | `1F,03,05,02,{mode},01` | 0=quiet 1=aware 2=custom1 3=custom2; reads 255=off when disabled (decode-only, not settable) |
+| ANC mode | 1F,03 | START | `1F,03,05,02,{mode},01` | 0=quiet 1=aware 2=custom1 3=custom2; reads 255 = OFF (genuinely disabled — confirmed audibly #83). 255 is REACHABLE: writing a raw CNC depth (1F,0A) over a named mode knocks 1F,03 to 255. ANC here is mode-based; depth is the same axis. |
 | Volume | 05,05 | SET_GET | `05,05,02,01,{level}` | 0-31 |
 | Device name | 01,02 | SET | `01,02,06,{len},00,{utf8}` | max 30 UTF-8 bytes |
-| Multipoint | 01,0A | SET_GET | `01,0A,02,01,{07/00}` | 07=on, 00=off |
+| Multipoint | 01,0A | SET_GET | `01,0A,02,01,{07/00}` | SET 07=on/00=off. RESPONSE is a bitfield — bit 0 = enable; fw 8.2.20: on→0x07, off→0x06 (slot bits persist). Parse `& 0x01`, NOT `!= 0` (that misread 0x06 as on, #83). |
 | Connect device | 04,01 | START | `04,01,05,07,00,{MAC}` | Also routes audio |
 | Disconnect | 04,02 | START | `04,02,05,06,{MAC}` | |
 | Media control | 05,03 | START | `05,03,05,01,{action}` | 01=play 02=pause 03=next 04=prev |
 | **EQ band** | 01,07 | **SET_GET** | `01,07,02,02,{value},{band}` | band: 0=bass 1=mid 2=treble, value: signed -10 to +10 |
-| **ANC depth** | 1F,0A | **SET_GET** | `1F,0A,02,05,{level},{autoCNC},{spatial},{windBlock},{ancToggle}` | level 0-10. Read current first, change level, preserve others. |
+| **ANC depth** | 1F,0A | **SET_GET** | `1F,0A,02,05,{level},{autoCNC},{spatial},{windBlock},{ancToggle}` | level 0-10. **SAME axis as ANC mode** — writing depth over a named mode (quiet/aware) sets 1F,03 to 255 = OFF (#83). Only meaningful inside a CUSTOM mode. Profiles + app set named-mode → mode only; never depth alongside quiet/aware. |
 
 **Not supported on QC Ultra 2:** StandbyTimer SET (01,04), MotionAutoOff (01,14), OnHeadDetection SET (01,10).
 Auto-off timer (01,0B) is read-only over RFCOMM — distinct from StandbyTimer (01,04).

--- a/cli/Parsers.swift
+++ b/cli/Parsers.swift
@@ -62,6 +62,13 @@ struct CncConfig: Equatable {
     var ancToggle: UInt8
 }
 
+/// Multipoint enable from the 01,0A state byte. Bit 0 is the live enable flag; the
+/// higher bits are slot/capability bits the firmware retains across toggles, so a
+/// disabled-but-paired device reads 0x06, not 0x00 (#83). Mask the enable bit — the
+/// old `!= 0` was the bug (0x06 != 0 misread "off" as "on"). Verified live on
+/// fw 8.2.20: multipoint on → 0x07, off → 0x06.
+func parseMultipointEnabled(_ stateByte: UInt8) -> Bool { (stateByte & 0x01) != 0 }
+
 /// Parse the CNC/ANC-depth RESPONSE (1F,0A). Needs the full 5-byte payload
 /// (bytes 4..8). Returns nil on a short/non-RESP frame.
 func parseCncLevel(_ resp: [UInt8]) -> CncConfig? {
@@ -148,7 +155,7 @@ func parseAllState(_ provide: ResponseProvider) -> HeadphoneState {
             : str
     }
 
-    if let r = resp(0x01, 0x0A) { s.multipointEnabled = r[4] != 0 }
+    if let r = resp(0x01, 0x0A) { s.multipointEnabled = parseMultipointEnabled(r[4]) }
     if let r = resp(0x01, 0x0B) { s.autoOffTimer = Array(r[4...]) }
     // 08,07 answers within the warm bulk session (it's silent on a cold standalone
     // channel, e.g. `raw 08 07`). With resp() now matching block/func, this binds to

--- a/cli/Profiles.swift
+++ b/cli/Profiles.swift
@@ -141,8 +141,19 @@ func profileFrames(_ p: Profile, currentCnc: CncConfig?) -> [[UInt8]] {
         frames.append(BMAP.setEqBand(value: clamp(e.mid), band: EqBand.mid.rawValue))
         frames.append(BMAP.setEqBand(value: clamp(e.treble), band: EqBand.treble.rawValue))
     }
-    if let d = p.ancDepth, let cnc = currentCnc {
+    // ANC depth (CNC level, 1F,0A) is the SAME axis as the named ANC mode on this
+    // firmware: writing a raw depth alongside quiet/aware knocks ANC into 255 = OFF
+    // (confirmed audibly, #83 — the flight profile literally disabled cancellation).
+    // So only apply depth for CUSTOM modes (custom1/custom2), where the level IS the
+    // mode; for quiet/aware the named mode already defines cancellation, so skip it.
+    if let d = p.ancDepth, let cnc = currentCnc, let m = p.ancMode, isCustomAncMode(m) {
         frames.append(buildCncSet(level: d, preserving: cnc))
     }
     return frames
+}
+
+/// True for the user-tunable custom ANC modes (the only ones where a CNC depth is
+/// meaningful). quiet/aware are fixed presets — writing a depth over them breaks ANC.
+func isCustomAncMode(_ mode: String) -> Bool {
+    ["custom1", "custom2"].contains(mode.lowercased())
 }

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -56,6 +56,14 @@ check(cfg?.autoCNC == 1 && cfg?.spatial == 0 && cfg?.windBlock == 1 && cfg?.ancT
 check(parseCncLevel([0x1F, 0x0A, 0x03, 0x01, 0x05]) == nil, "cncLevel: short payload -> nil")
 check(parseCncLevel([0x1F, 0x0A, 0x01, 0x00]) == nil, "cncLevel: non-RESP -> nil")
 
+// ── parseMultipointEnabled (01,0A state byte) ──────────────────────────────────
+// fw 8.2.20 live: on -> 0x07, off -> 0x06 (slot bits retained). Bit 0 is the live
+// enable flag; the old `!= 0` misread 0x06 as "on" (#83).
+check(parseMultipointEnabled(0x07), "multipoint: 0x07 -> on")
+check(!parseMultipointEnabled(0x06), "multipoint: 0x06 (off-with-slots) -> off")
+check(!parseMultipointEnabled(0x00), "multipoint: 0x00 -> off")
+check(parseMultipointEnabled(0x01), "multipoint: 0x01 (bare enable bit) -> on")
+
 // buildCncSet preserves the other four and clamps level into 0...10.
 let set = buildCncSet(level: 3, preserving: cfg!)
 check(set == [0x1F, 0x0A, 0x02, 0x05, 0x03, 0x01, 0x00, 0x01, 0x01],
@@ -122,20 +130,28 @@ check(parseDeviceInfo([0x04, 0x05, 0x01, 0x06, 0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x2
 
 // ── profiles ─────────────────────────────────────────────────────────────────────
 
-// profileFrames: full profile → ordered SET frames (anc, vol, mp, 3x eq, depth).
+// profileFrames: full profile → ordered SET frames (anc, vol, mp, 3x eq[, depth]).
+// #83: ANC depth is the SAME axis as a named mode, so a NAMED-mode profile (aware)
+// must NOT emit the depth frame even when ancDepth is set — writing it disables ANC.
 let cnc2 = CncConfig(level: 7, autoCNC: 1, spatial: 0, windBlock: 1, ancToggle: 1)
 let full = Profile(name: "t", ancMode: "aware", ancDepth: 5,
                    eq: EqValues(bass: 3, mid: 0, treble: -3), multipoint: true, volume: 20)
 let pf = profileFrames(full, currentCnc: cnc2)
-check(pf.count == 7, "profileFrames: 7 frames")
+check(pf.count == 6, "profileFrames: named-mode profile skips depth (6 frames, #83)")
 check(pf[0] == [0x1F, 0x03, 0x05, 0x02, 0x01, 0x01], "profileFrames: anc aware (START)")
 check(pf[1] == [0x05, 0x05, 0x02, 0x01, 0x14], "profileFrames: volume 20 (SET_GET)")
 check(pf[2] == [0x01, 0x0A, 0x02, 0x01, 0x07], "profileFrames: multipoint on")
 check(pf[3] == [0x01, 0x07, 0x02, 0x02, 0x03, 0x00], "profileFrames: eq bass +3")
 check(pf[5] == [0x01, 0x07, 0x02, 0x02, 0xFD, 0x02], "profileFrames: eq treble -3 (signed)")
-check(pf[6] == [0x1F, 0x0A, 0x02, 0x05, 0x05, 0x01, 0x00, 0x01, 0x01], "profileFrames: cnc depth 5 preserves rest")
-// nil currentCnc → depth frame skipped; empty profile → no frames.
-check(profileFrames(full, currentCnc: nil).count == 6, "profileFrames: nil cnc skips depth")
+check(!pf.contains([0x1F, 0x0A, 0x02, 0x05, 0x05, 0x01, 0x00, 0x01, 0x01]),
+      "profileFrames: no cnc frame for aware+depth (#83)")
+// A CUSTOM-mode profile DOES apply depth (the level IS the mode).
+let customP = Profile(name: "c1", ancMode: "custom1", ancDepth: 5)
+let pfc = profileFrames(customP, currentCnc: cnc2)
+check(pfc.last == [0x1F, 0x0A, 0x02, 0x05, 0x05, 0x01, 0x00, 0x01, 0x01],
+      "profileFrames: custom-mode applies cnc depth 5 preserving rest")
+// nil currentCnc → depth frame skipped even for custom; empty profile → no frames.
+check(profileFrames(customP, currentCnc: nil).count == 1, "profileFrames: nil cnc skips depth")
 check(profileFrames(Profile(name: "empty"), currentCnc: nil).isEmpty, "profileFrames: empty profile -> none")
 // EQ values clamp into -10...10.
 let clampP = profileFrames(Profile(name: "c", eq: EqValues(bass: 99, mid: -99, treble: 0)), currentCnc: nil)

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -411,12 +411,12 @@ func cmdMultipoint(_ arg: String?) {
         // intermittently returns nil — the false "query failed" seen on-device).
         guard let r = transport.oneShot(BMAP.setMultipoint(state: on ? 0x07 : 0x00)),
               r.count >= 5, r[2] == OP_RESP_BYTE else { fail("multipoint set failed") }
-        print((r[4] & 0xFF) != 0 ? "on" : "off")
+        print(parseMultipointEnabled(r[4]) ? "on" : "off")
         return
     }
     guard let r = transport.oneShot(BMAP.getMultipoint()),
           r.count >= 5, r[2] == OP_RESP_BYTE else { fail("multipoint query failed") }
-    print((r[4] & 0xFF) != 0 ? "on" : "off")
+    print(parseMultipointEnabled(r[4]) ? "on" : "off")
 }
 
 /// play / pause / next / prev — generated mediaControl builder.

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -24,7 +24,6 @@ final class BoseManager: ObservableObject {
     @Published var deviceName: String = "verBosita"
     @Published var firmware: String = ""
     @Published var multipointEnabled: Bool = false
-    @Published var cncLevel: Int = 0         // ANC depth 0–10
     @Published var onHead: Bool = false
     @Published var eq: (bass: Int, mid: Int, treble: Int) = (0, 0, 0)
     @Published var isRefreshing: Bool = false
@@ -115,7 +114,6 @@ final class BoseManager: ObservableObject {
         batteryLevel = (s["batteryLevel"] as? Int) ?? batteryLevel
         batteryCharging = (s["batteryCharging"] as? Bool) ?? false
         ancMode = (s["ancMode"] as? Int) ?? ancMode
-        cncLevel = (s["ancDepth"] as? Int) ?? cncLevel
         volume = (s["volume"] as? Int) ?? volume
         volumeMax = (s["volumeMax"] as? Int) ?? volumeMax
         multipointEnabled = (s["multipoint"] as? Bool) ?? false
@@ -155,13 +153,6 @@ final class BoseManager: ObservableObject {
     func setMultipoint(_ enabled: Bool) {
         multipointEnabled = enabled
         write(["multipoint", enabled ? "on" : "off"])
-    }
-
-    /// ANC depth (CNC level 0–10). Note: exercises the #83 RMW path on hardware.
-    func setCncLevel(_ level: Int) {
-        let clamped = max(0, min(10, level))
-        cncLevel = clamped
-        write(["anc-depth", String(clamped)])
     }
 
     func connectDevice(_ name: String) {

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -52,7 +52,6 @@ struct ContentView: View {
     @ObservedObject var manager: BoseManager
 
     @State private var volumeSlider: Double = 0
-    @State private var ancDepthSlider: Double = 0
     @State private var eqBass: Double = 0
     @State private var eqMid: Double = 0
     @State private var eqTreble: Double = 0
@@ -79,7 +78,6 @@ struct ContentView: View {
 
     private func syncSliders() {
         volumeSlider = Double(manager.volume)
-        ancDepthSlider = Double(manager.cncLevel)
         eqBass = Double(manager.eq.bass)
         eqMid = Double(manager.eq.mid)
         eqTreble = Double(manager.eq.treble)
@@ -158,31 +156,14 @@ struct ContentView: View {
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(secondaryColor)
                     .tracking(1)
+                // No depth slider: ANC on this firmware is mode-based (Quiet/Aware/
+                // Custom). Writing a raw CNC depth knocks ANC to off (#83), so the
+                // window exposes modes only — depth is not a safe standalone control.
                 HStack(spacing: 4) {
                     ancButton("Quiet", 0)
                     ancButton("Aware", 1)
                     ancButton("C1", 2)
                     ancButton("C2", 3)
-                }
-                // ANC depth (CNC level 0–10). NB: exercises the #83 RMW path.
-                HStack(spacing: 8) {
-                    Text("Depth")
-                        .font(.system(size: 10))
-                        .foregroundColor(secondaryColor)
-                        .frame(width: 38, alignment: .leading)
-                    Slider(
-                        value: $ancDepthSlider,
-                        in: 0...10,
-                        step: 1,
-                        onEditingChanged: { editing in
-                            if !editing { manager.setCncLevel(Int(ancDepthSlider)) }
-                        }
-                    )
-                    .tint(activeColor)
-                    Text("\(Int(ancDepthSlider))")
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundColor(secondaryColor)
-                        .frame(width: 22, alignment: .trailing)
                 }
             }
 

--- a/profiles.json
+++ b/profiles.json
@@ -1,7 +1,6 @@
 {
   "profiles" : [
     {
-      "ancDepth" : 10,
       "ancMode" : "quiet",
       "multipoint" : false,
       "name" : "flight"

--- a/protocol/spec/bmap.toml
+++ b/protocol/spec/bmap.toml
@@ -83,6 +83,12 @@ composite = true
 summary = "ANC/CNC depth level 0-10 (read-modify-write, preserve other fields)."
 # `1F,0A,02,05,{level},{autoCNC},{spatial},{windBlock},{ancToggle}` — SET_GET.
 # No verified_bytes: the payload depends on a prior read of live device state.
+# DANGER (#83, confirmed audibly fw 8.2.20): CNC depth is the SAME axis as the named
+# ANC mode (1F,03). Writing a raw depth over a named mode (quiet/aware) knocks 1F,03
+# to 0xFF (255 = genuinely OFF — ANC stops cancelling; the `ancToggle` byte still
+# reads 1 but is NOT the real radio state). So depth is only meaningful inside a
+# CUSTOM mode (custom1/custom2). Never write depth alongside quiet/aware — profiles
+# and the macOS app enforce this (named mode → mode only).
 
 
 # ── Block 0x01 — Settings / Device ─────────────────────────────────────────────
@@ -129,7 +135,11 @@ get = {}
 [commands.multipoint]
 block = 0x01
 function = 0x0A
-summary = "Toggle 2-device multipoint (07=on, 00=off)."
+# SET sends 07=on / 00=off. The RESPONSE state byte is a bitfield: bit 0 is the live
+# enable flag; higher bits are slot/capability bits the firmware retains. Verified
+# live on fw 8.2.20: on -> 0x07, off -> 0x06 (NOT 0x00 — slot bits persist). Parse the
+# enable bit (`& 0x01`), never `!= 0` — that misread 0x06 as "on" (#83).
+summary = "Toggle 2-device multipoint (SET 07=on/00=off; RESP enable bit: 0x07=on, 0x06=off)."
 
 [commands.multipoint.set]
 operator = "SET_GET"        # CLAUDE.md: multipoint REQUIRES SET_GET (0x02)


### PR DESCRIPTION
Root-caused on live hardware (fw 8.2.20). Both halves of #83:

**ANC:** CNC depth (1F,0A) is the same axis as the named ANC mode (1F,03). Writing a raw depth over quiet/aware sets 1F,03 to 255 = genuinely OFF (confirmed audibly — flight was disabling cancellation). Fix: profiles apply depth only for custom1/custom2; named modes set mode only. flight is now {quiet, multipoint off}. Verified: applying flight leaves ANC quiet, not off.

**Multipoint:** readback parse bug. Device replies 0x07=on / 0x06=off (slot bits persist, not 0x00). The old `r[4] != 0` misread 0x06 as on. Fix: parseMultipointEnabled masks bit 0. Verified live.

**App:** removed the depth slider (footgun that disabled ANC); ANC is mode-based.

Tested: 29 protocol golden tests + CLI unit tests (new multipoint-parse + profile depth-gating cases) pass; both builds Developer-ID sign; flight + multipoint hardware-verified.

Closes #83
for #84 (doc correction done here; manual Focus/shortcut items remain James-only)