### PR TITLE
connect/swap: report connected-idle under multipoint instead of failing

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-fix #83 flight ANC + multipoint
-fix #83 flight ANC + multipoint
+connect reports idle under multipoint
+connect reports idle under multipoint
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - fix-83-flight-anc-mp
+# Agent Progress - fix-connect-idle-multipoint
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-08T04:37:40Z
+# Created: 2026-06-08T05:22:00Z
 
-feature=fix-83-flight-anc-mp
-name=fix #83 flight ANC + multipoint
+feature=fix-connect-idle-multipoint
+name=connect reports idle under multipoint
 status=pending
 step=0
 step_name=Not started
-created=2026-06-08T04:37:40Z
+created=2026-06-08T05:22:00Z

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -324,10 +324,10 @@ func cmdConnect(_ deviceName: String) {
 
     _ = transport.oneShot(BMAP.connectDevice(mac: mac), timeout: 5.0)
 
-    if pollConfirmConnected(mac) {
-        print("Connected \(deviceName)")
-    } else {
-        fail("connect \(deviceName) not confirmed within timeout")
+    switch confirmConnect(mac) {
+    case .active: print("Connected \(deviceName)")
+    case .idle:   print("Connected \(deviceName) (idle — audio stayed on the active device; multipoint)")
+    case .none:   fail("connect \(deviceName) not confirmed within timeout")
     }
 }
 
@@ -344,24 +344,37 @@ func cmdSwap(_ targetName: String) {
 
     _ = transport.oneShot(BMAP.connectDevice(mac: mac), timeout: 5.0)
 
-    if pollConfirmConnected(mac) {
-        print("Swapped to \(targetName)")
-    } else {
-        fail("swap to \(targetName) not confirmed within timeout")
+    switch confirmConnect(mac) {
+    case .active: print("Swapped to \(targetName)")
+    case .idle:   print("Connected \(targetName) (idle — audio stayed on the active device; multipoint)")
+    case .none:   fail("swap to \(targetName) not confirmed within timeout")
     }
 }
 
-/// Poll getConnectedDevices until `mac` is audio-active (~16s budget). Offline
-/// devices page slowly. Mirrors the macOS BoseManager poll-confirm.
-func pollConfirmConnected(_ mac: [UInt8]) -> Bool {
+/// Outcome of a connect/swap. `active` = audio routed here (05,01); `idle` = ACL up
+/// under multipoint but audio stayed on the prior sink (04,05 connected, not 05,01);
+/// `none` = never connected. The idle case is a real connection — not a failure —
+/// and must not exit non-zero (it spuriously broke the macOS app / scripts, surfaced
+/// while testing multipoint: paging a 2nd device joins it idle, not active).
+enum ConnectOutcome { case active, idle, none }
+
+/// Poll `getDeviceStates` (one session per tick: 05,01 active + 04,05 ACL) until the
+/// target is audio-active, or the ~16s budget expires. Offline devices page slowly,
+/// and under multipoint a paged device settles into connected-idle a beat AFTER the
+/// command returns — so we must keep polling for BOTH states, not snapshot once.
+/// Returns `.active` the instant it's the sink; `.idle` if it only ever reached ACL
+/// (a real connection, exit 0); `.none` if it never appeared.
+func confirmConnect(_ mac: [UInt8]) -> ConnectOutcome {
     let target = macString(mac)
     let deadline = Date().addingTimeInterval(16.0)
+    var sawIdle = false
     while Date() < deadline {
         Thread.sleep(forTimeInterval: 1.5)
-        let active = transport.getConnectedDevices().map { macString($0) }
-        if active.contains(target) { return true }
+        guard let st = transport.getDeviceStates(query: [mac]) else { continue }
+        if st.active.contains(where: { macString($0) == target }) { return .active }
+        if st.connected.contains(where: { macString($0) == target }) { sawIdle = true }
     }
-    return false
+    return sawIdle ? .idle : .none
 }
 
 /// disconnect / d <device>


### PR DESCRIPTION
Surfaced while hardware-testing multipoint. Paging a 2nd device under multipoint joins it as connected-idle (04,05 ACL up) without becoming the audio-active sink (05,01), and it settles a beat after the command returns. The old poll watched only 05,01 and snapshotted once → exited 1 'not confirmed' even though the device connected.

`confirmConnect` now polls `getDeviceStates` each tick for active OR idle across the 16s budget: active = audio routed; idle = connected but audio stayed put (exit 0); none = never appeared. Verified live: `connect phone` (mac active, multipoint on) prints 'Connected phone (idle …)' exit 0.

CLI tests pass.