### PR TITLE
feat: macOS noise slider + correct AncMode to true 6-slot mapping

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-connect reports idle under multipoint
-connect reports idle under multipoint
+macOS app noise slider via anc-level
+macOS app noise slider via anc-level
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - fix-connect-idle-multipoint
+# Agent Progress - app-noise-slider
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-08T05:22:00Z
+# Created: 2026-06-08T07:20:53Z
 
-feature=fix-connect-idle-multipoint
-name=connect reports idle under multipoint
+feature=app-noise-slider
+name=macOS app noise slider via anc-level
 status=pending
 step=0
 step_name=Not started
-created=2026-06-08T05:22:00Z
+created=2026-06-08T07:20:53Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,14 +28,17 @@ is three thin front-ends that shell out to the `cli/` binary (`~/bin/bose-ctl`),
 nothing runs in the background and the Mac only touches the headphones on an
 explicit user action.
 - `macos/BoseControl/` -- **Bose Control.app**: a windowed SwiftUI app (frosted-dark
-  two-panel: battery/ANC mode/volume/multipoint/on-head + device grid + EQ). No depth
-  slider — ANC is mode-based and a raw depth disables it (#83); modes only.
+  two-panel: battery/ANC mode/volume/multipoint/on-head + device grid + EQ). Six ANC
+  mode buttons (Quiet/Aware/Immersion/Cinema/C1/C2 = slots 0-5) + a **noise-level
+  slider** driven by `anc-level` (1F,06) — NOT a raw depth (1F,0A disables ANC, #83).
+  The slider is enabled only on the adjustable custom slots (4/5, firmware `cncMutable`)
+  and greys out with a "level is fixed" hint on Quiet/Aware/Immersion/Cinema.
   It is a **thin front-end that shells `bose-ctl`** — NO RFCOMM, NO IOBluetooth, NO
   protocol code — reading via `bose-ctl info --json` and writing via the verbs. It is
   **user-launched and event-driven**: reads on window-open, on app-focus, after each
   write, and on ⌘R — never on a timer. Build `bash macos/build.sh [--install]`
-  (Developer-ID signed → `/Applications`; no LaunchAgent). In-window keys: ⌘1/2/3/4
-  ANC modes, ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M connect Mac. Global hotkeys stay in
+  (Developer-ID signed → `/Applications`; no LaunchAgent). In-window keys: ⌘1-6
+  ANC modes (slots 0-5), ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M connect Mac. Global hotkeys stay in
   Hammerspoon. The `--json` read seam lives in `cli/main.swift` (`cmdInfoJSON`, pure
   formatting over `getAllState` + `getDeviceStates`). It surfaces — but does not fix —
   the #83 flight/ancDepth behaviour; that fix lands in the CLI and the app inherits it.
@@ -228,7 +231,7 @@ BMAP operator (SET/0x06 instead of SET_GET/0x02).
 
 | Setting | Block,Func | Operator | Bytes | Notes |
 |---------|-----------|----------|-------|-------|
-| ANC mode | 1F,03 | START | `1F,03,05,02,{mode},01` | 0=quiet 1=aware 2=custom1 3=custom2; reads 255 = OFF (genuinely disabled — confirmed audibly #83). 255 is REACHABLE: writing a raw CNC depth (1F,0A) over a named mode knocks 1F,03 to 255. ANC here is mode-based; depth is the same axis. |
+| ANC mode | 1F,03 | START | `1F,03,05,02,{mode},01` | slots: 0=quiet 1=aware 2=immersion 3=cinema (fixed) 4=custom1 5=custom2 (adjustable); reads 255 = OFF (genuinely disabled — confirmed audibly #83). 255 is REACHABLE: writing a raw CNC depth (1F,0A) over a named mode knocks 1F,03 to 255. ANC here is mode-based; depth is the same axis. |
 | Volume | 05,05 | SET_GET | `05,05,02,01,{level}` | 0-31 |
 | Device name | 01,02 | SET | `01,02,06,{len},00,{utf8}` | max 30 UTF-8 bytes |
 | Multipoint | 01,0A | SET_GET | `01,0A,02,01,{07/00}` | SET 07=on/00=off. RESPONSE is a bitfield — bit 0 = enable; fw 8.2.20: on→0x07, off→0x06 (slot bits persist). Parse `& 0x01`, NOT `!= 0` (that misread 0x06 as on, #83). |
@@ -252,7 +255,7 @@ ancToggle. **Level semantics: 0 = max cancellation (Quiet end), 10 = full transp
 
 | Func | Name | Use |
 |------|------|-----|
-| 1F,03 | AudioModesCurrentMode | select/activate a mode by **slot index** (START). Our `anc` command: 0-3 named + `anc <0-5>` for any slot. Reads 255 = "no mode" = ANC off. |
+| 1F,03 | AudioModesCurrentMode | select/activate a mode by **slot index** (START). Our `anc` command: 6 named (quiet/aware/immersion/cinema/custom1/custom2) + `anc <0-5>` for any slot. custom1/custom2 = slots 4/5 (the adjustable ones). Reads 255 = "no mode" = ANC off. |
 | 1F,06 | **AudioModesModeConfig** | read/define a mode (index, prompt, name[32], …, cncLevel, …, ancToggle). The CORRECT level command — RMW it. **GET only answers inside a warm bulk session** (prime with a 02,02 read first). |
 | 1F,0A | AudioModesSettingsConfig | GLOBAL live tuning. **Footgun** — detaches the active mode → 255/off (#83). Never use. |
 

--- a/cli/Parsers.swift
+++ b/cli/Parsers.swift
@@ -17,7 +17,7 @@ let OP_RESP_BYTE: UInt8 = 0x03
 struct HeadphoneState {
     var batteryLevel: Int = 0
     var batteryCharging: Bool = false
-    var ancMode: Int = 0           // 0=quiet 1=aware 2=custom1 3=custom2
+    var ancMode: Int = 0           // 0=quiet 1=aware 2=immersion 3=cinema 4=custom1 5=custom2
     var volume: Int = 0
     var volumeMax: Int = 31
     var connectedDevices: [[UInt8]] = []   // audio-active (05,01) — ground truth

--- a/cli/Profiles.swift
+++ b/cli/Profiles.swift
@@ -121,6 +121,8 @@ func ancModeByte(_ name: String) -> UInt8? {
     switch name.lowercased() {
     case "quiet": return AncMode.quiet.rawValue
     case "aware": return AncMode.aware.rawValue
+    case "immersion": return AncMode.immersion.rawValue
+    case "cinema": return AncMode.cinema.rawValue
     case "custom1": return AncMode.custom1.rawValue
     case "custom2": return AncMode.custom2.rawValue
     default: return nil

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -203,13 +203,15 @@ func cmdAnc(_ mode: String?) {
         switch mode.lowercased() {
         case "quiet": modeByte = AncMode.quiet.rawValue
         case "aware": modeByte = AncMode.aware.rawValue
+        case "immersion": modeByte = AncMode.immersion.rawValue
+        case "cinema": modeByte = AncMode.cinema.rawValue
         case "custom1": modeByte = AncMode.custom1.rawValue
         case "custom2": modeByte = AncMode.custom2.rawValue
-        // Bare mode slot index (0-5). Slots beyond the named four are the device's
-        // own modes (e.g. Immersion/Cinema) and the adjustable custom slots — the
-        // ones whose noise level `anc-level` can set. `info`/`anc-level` show names.
+        // Bare mode slot index (0-5): 0 quiet, 1 aware, 2 immersion, 3 cinema (fixed),
+        // 4/5 custom (adjustable — the slots whose noise level `anc-level` can set).
+        // `info`/`anc-level` show names.
         case let s where UInt8(s).map({ $0 <= 5 }) == true: modeByte = UInt8(s)!
-        default: fail("unknown ANC mode: \(mode) (quiet/aware/custom1/custom2, or a slot index 0-5)")
+        default: fail("unknown ANC mode: \(mode) (quiet/aware/immersion/cinema/custom1/custom2, or a slot index 0-5)")
         }
         // Set + read-back in ONE session. A separate oneShot for the verify-GET
         // would open a second channel back-to-back and intermittently return nil
@@ -537,7 +539,7 @@ func usage() {
       bose-ctl connect <device>     Route audio to device (poll-confirmed)
       bose-ctl disconnect <device>  Disconnect a device
       bose-ctl swap <device>        Route audio to device (multipoint; keeps others)
-      bose-ctl anc [mode]           Get/set ANC (quiet/aware/custom1/custom2)
+      bose-ctl anc [mode]           Get/set ANC (quiet/aware/immersion/cinema/custom1/custom2, or slot 0-5)
       bose-ctl anc-level [0-10]     Get/set active mode's noise level (0=max cancel … 10=transparent; custom modes only)
       bose-ctl name [new name]      Get/set headphone name (max 30 UTF-8 bytes)
       bose-ctl volume [0-31]        Get/set volume

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -151,21 +151,35 @@ func cmdInfoJSON() {
         }
     }
 
-    emit([
+    // Active mode's noise config (1F,06) — drives the app's noise slider. Its own warm
+    // session (event-driven read, not polled). `noiseAdjustable` (cncMutable) gates the
+    // slider so a level write can never disable ANC (#83). nil → slider hidden/disabled.
+    var mode: [String: Any] = ["noiseAdjustable": false]
+    if let cfg = transport.readActiveModeConfig() {
+        mode = [
+            "modeName": cfg.displayName,
+            "modeIndex": Int(cfg.index),
+            "noiseLevel": Int(cfg.cncLevel),
+            "noiseAdjustable": cfg.cncMutable,
+        ]
+    }
+
+    var out: [String: Any] = [
         "connected": true,
         "deviceName": s.deviceName.isEmpty ? "verBosita" : s.deviceName,
         "firmware": s.firmware,
         "batteryLevel": s.batteryLevel,
         "batteryCharging": s.batteryCharging,
         "ancMode": s.ancMode,
-        "ancDepth": s.cncLevel,
         "volume": s.volume,
         "volumeMax": s.volumeMax,
         "eq": ["bass": s.eq.bass, "mid": s.eq.mid, "treble": s.eq.treble],
         "multipoint": s.multipointEnabled,
         "onHead": s.onHead.map { $0 as Any } ?? NSNull(),
         "devices": deviceStates,
-    ])
+    ]
+    out.merge(mode) { _, new in new }
+    emit(out)
 }
 
 func ancModeName(_ mode: Int) -> String {

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -28,6 +28,14 @@ final class BoseManager: ObservableObject {
     @Published var eq: (bass: Int, mid: Int, treble: Int) = (0, 0, 0)
     @Published var isRefreshing: Bool = false
 
+    // Active mode's noise level (1F,06): 0 = max cancellation … 10 = transparency.
+    // `noiseAdjustable` (the firmware cncMutable bit) gates the slider — only custom
+    // modes are tunable; Quiet/Aware/spatial modes are fixed. Writing is via the CLI
+    // `anc-level`, which refuses on fixed modes, so the slider can't disable ANC (#83).
+    @Published var noiseLevel: Int = 0
+    @Published var noiseAdjustable: Bool = false
+    @Published var modeName: String = ""
+
     // Device routing states: "active" / "connected" / "offline"
     @Published var deviceStates: [String: String] = [
         "mac": "offline", "phone": "offline", "ipad": "offline",
@@ -128,6 +136,9 @@ final class BoseManager: ObservableObject {
         if let d = s["devices"] as? [String: String] {
             for (name, state) in d { deviceStates[name] = state }
         }
+        noiseLevel = (s["noiseLevel"] as? Int) ?? noiseLevel
+        noiseAdjustable = (s["noiseAdjustable"] as? Bool) ?? false
+        modeName = (s["modeName"] as? String) ?? modeName
     }
 
     // MARK: - Write (each: run verb, optimistic local update, then re-read)
@@ -153,6 +164,16 @@ final class BoseManager: ObservableObject {
     func setMultipoint(_ enabled: Bool) {
         multipointEnabled = enabled
         write(["multipoint", enabled ? "on" : "off"])
+    }
+
+    /// Set the active mode's noise level (0 = max cancel … 10 = transparency) via the
+    /// CLI `anc-level` (the 1F,06 RMW). No-op unless the active mode is adjustable —
+    /// the CLI refuses on fixed modes anyway, so ANC can never be disabled here.
+    func setNoiseLevel(_ level: Int) {
+        guard noiseAdjustable else { return }
+        let clamped = max(0, min(10, level))
+        noiseLevel = clamped
+        write(["anc-level", String(clamped)])
     }
 
     func connectDevice(_ name: String) {

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -18,7 +18,7 @@ final class BoseManager: ObservableObject {
     @Published var isConnected: Bool = false
     @Published var batteryLevel: Int = 0
     @Published var batteryCharging: Bool = false
-    @Published var ancMode: Int = 0          // 0=quiet 1=aware 2=custom1 3=custom2
+    @Published var ancMode: Int = 0          // hardware slot: 0=quiet 1=aware 2=immersion 3=cinema 4=custom1 5=custom2
     @Published var volume: Int = 0
     @Published var volumeMax: Int = 31
     @Published var deviceName: String = "verBosita"
@@ -143,11 +143,14 @@ final class BoseManager: ObservableObject {
 
     // MARK: - Write (each: run verb, optimistic local update, then re-read)
 
+    /// Activate an ANC mode by hardware slot index (0-5): 0 quiet, 1 aware,
+    /// 2 immersion, 3 cinema (fixed), 4/5 custom (adjustable). Passes the bare
+    /// slot to `bose-ctl anc <n>` so app and CLI share one numbering; `ancMode`
+    /// (read back from `info`) is the same slot index, so button highlighting matches.
     func setAncMode(_ mode: Int) {
-        let names = ["quiet", "aware", "custom1", "custom2"]
-        guard names.indices.contains(mode) else { return }
+        guard (0...5).contains(mode) else { return }
         ancMode = mode
-        write(["anc", names[mode]])
+        write(["anc", String(mode)])
     }
 
     func setVolume(_ level: Int) {
@@ -197,7 +200,7 @@ final class BoseManager: ObservableObject {
     // MARK: - Computed
 
     var ancModeName: String {
-        ["Quiet", "Aware", "Custom 1", "Custom 2"][safe: ancMode] ?? "Unknown"
+        ["Quiet", "Aware", "Immersion", "Cinema", "Custom 1", "Custom 2"][safe: ancMode] ?? "Unknown"
     }
 }
 

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -86,7 +86,7 @@ struct ContentView: View {
     }
 
     /// In-window keyboard shortcuts (only while the app is focused — global hotkeys
-    /// stay in Hammerspoon). ⌘1/2/3/4 ANC modes, ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M Mac.
+    /// stay in Hammerspoon). ⌘1-6 ANC modes (slots 0-5), ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M Mac.
     private func installShortcuts() {
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             guard event.modifierFlags.contains(.command) else { return event }
@@ -95,6 +95,8 @@ struct ContentView: View {
             case "2": manager.setAncMode(1); return nil
             case "3": manager.setAncMode(2); return nil
             case "4": manager.setAncMode(3); return nil
+            case "5": manager.setAncMode(4); return nil
+            case "6": manager.setAncMode(5); return nil
             case "r": manager.refreshState(); return nil
             case "m": manager.connectDevice("mac"); return nil
             default: break
@@ -158,11 +160,19 @@ struct ContentView: View {
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(secondaryColor)
                     .tracking(1)
-                HStack(spacing: 4) {
-                    ancButton("Quiet", 0)
-                    ancButton("Aware", 1)
-                    ancButton("C1", 2)
-                    ancButton("C2", 3)
+                // Hardware slots 0-5: Quiet/Aware/Immersion/Cinema are fixed-level;
+                // C1/C2 (slots 4/5) are the adjustable custom modes the Level slider drives.
+                VStack(spacing: 4) {
+                    HStack(spacing: 4) {
+                        ancButton("Quiet", 0)
+                        ancButton("Aware", 1)
+                        ancButton("Immersion", 2)
+                    }
+                    HStack(spacing: 4) {
+                        ancButton("Cinema", 3)
+                        ancButton("C1", 4)
+                        ancButton("C2", 5)
+                    }
                 }
                 // Noise level (1F,06): 0 = max cancellation … 10 = transparency.
                 // Adjustable ONLY on custom modes (firmware cncMutable bit) — disabled
@@ -397,9 +407,12 @@ struct ContentView: View {
         return Button(action: { manager.setAncMode(mode) }) {
             Text(label)
                 .font(.system(size: 10, weight: .semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
                 .foregroundColor(isActive ? .black : secondaryColor)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 5)
+                .padding(.horizontal, 2)
                 .background(isActive ? activeColor : cardColor)
                 .clipShape(RoundedRectangle(cornerRadius: 6))
         }

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -52,6 +52,7 @@ struct ContentView: View {
     @ObservedObject var manager: BoseManager
 
     @State private var volumeSlider: Double = 0
+    @State private var noiseSlider: Double = 0
     @State private var eqBass: Double = 0
     @State private var eqMid: Double = 0
     @State private var eqTreble: Double = 0
@@ -78,6 +79,7 @@ struct ContentView: View {
 
     private func syncSliders() {
         volumeSlider = Double(manager.volume)
+        noiseSlider = Double(manager.noiseLevel)
         eqBass = Double(manager.eq.bass)
         eqMid = Double(manager.eq.mid)
         eqTreble = Double(manager.eq.treble)
@@ -156,14 +158,41 @@ struct ContentView: View {
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(secondaryColor)
                     .tracking(1)
-                // No depth slider: ANC on this firmware is mode-based (Quiet/Aware/
-                // Custom). Writing a raw CNC depth knocks ANC to off (#83), so the
-                // window exposes modes only — depth is not a safe standalone control.
                 HStack(spacing: 4) {
                     ancButton("Quiet", 0)
                     ancButton("Aware", 1)
                     ancButton("C1", 2)
                     ancButton("C2", 3)
+                }
+                // Noise level (1F,06): 0 = max cancellation … 10 = transparency.
+                // Adjustable ONLY on custom modes (firmware cncMutable bit) — disabled
+                // on Quiet/Aware/spatial modes. The CLI `anc-level` refuses on fixed
+                // modes, so dragging this can never disable ANC (#83).
+                HStack(spacing: 8) {
+                    Text("Level")
+                        .font(.system(size: 10))
+                        .foregroundColor(manager.noiseAdjustable ? secondaryColor : offlineColor)
+                        .frame(width: 38, alignment: .leading)
+                    Slider(
+                        value: $noiseSlider,
+                        in: 0...10,
+                        step: 1,
+                        onEditingChanged: { editing in
+                            if !editing { manager.setNoiseLevel(Int(noiseSlider)) }
+                        }
+                    )
+                    .tint(activeColor)
+                    .disabled(!manager.noiseAdjustable)
+                    Text(manager.noiseAdjustable ? "\(Int(noiseSlider))" : "—")
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(manager.noiseAdjustable ? secondaryColor : offlineColor)
+                        .frame(width: 22, alignment: .trailing)
+                }
+                .opacity(manager.noiseAdjustable ? 1.0 : 0.5)
+                if !manager.noiseAdjustable {
+                    Text("\(manager.modeName.isEmpty ? "This mode" : manager.modeName)'s level is fixed — pick a custom mode")
+                        .font(.system(size: 9))
+                        .foregroundColor(offlineColor)
                 }
             }
 

--- a/protocol/generated/BMAP.generated.kt
+++ b/protocol/generated/BMAP.generated.kt
@@ -6,7 +6,7 @@ package au.com.jd.bose
 
 enum class BMAPOperator(val v: Int) { GET(0x01), SET_GET(0x02), RESP(0x03), ERROR(0x04), START(0x05), SET(0x06), ACK(0x07) }
 
-enum class AncMode(val v: Int) { QUIET(0), AWARE(1), CUSTOM1(2), CUSTOM2(3), OFF(255) }
+enum class AncMode(val v: Int) { QUIET(0), AWARE(1), IMMERSION(2), CINEMA(3), CUSTOM1(4), CUSTOM2(5), OFF(255) }
 enum class EqBand(val v: Int) { BASS(0), MID(1), TREBLE(2) }
 enum class MediaAction(val v: Int) { PLAY(1), PAUSE(2), NEXT(3), PREV(4) }
 

--- a/protocol/generated/BMAP.generated.swift
+++ b/protocol/generated/BMAP.generated.swift
@@ -17,8 +17,10 @@ enum BMAPOperator: UInt8 {
 enum AncMode: UInt8 {
     case quiet = 0
     case aware = 1
-    case custom1 = 2
-    case custom2 = 3
+    case immersion = 2
+    case cinema = 3
+    case custom1 = 4
+    case custom2 = 5
     case off = 255
 }
 

--- a/protocol/spec/bmap.toml
+++ b/protocol/spec/bmap.toml
@@ -18,14 +18,20 @@
 # ── Enums ──────────────────────────────────────────────────────────────────────
 
 [enums.AncMode]
-# ANC mode (1F,03). CLAUDE.md: 0=quiet 1=aware 2=custom1 3=custom2.
+# ANC mode (1F,03). Hardware slots (QC Ultra 2, fw 8.2.20, verified live #88/#91):
+#   0=quiet 1=aware 2=immersion 3=cinema  (all fixed-level)
+#   4=custom1 5=custom2                   (the adjustable "None" slots; 1F,06/anc-level)
+# Earlier the enum mislabelled slots 2/3 as the customs; #91 confirmed 2=Immersion,
+# 3=Cinema, and the real adjustable custom slots are 4/5.
 # 255 (0xFF) is the disabled/off sentinel the QC Ultra 2 reports when ANC is off
 # (observed on-device at depth 0). Decode-only — renders reads as "off" instead of
 # "unknown(255)"; NOT offered as a settable mode (setting 0xFF is unverified).
 quiet = 0
 aware = 1
-custom1 = 2
-custom2 = 3
+immersion = 2
+cinema = 3
+custom1 = 4
+custom2 = 5
 off = 255
 
 [enums.EqBand]
@@ -47,7 +53,7 @@ prev = 4
 [commands.anc_mode]
 block = 0x1F
 function = 0x03
-summary = "Set/get active-noise-cancellation mode (quiet/aware/custom1/custom2)."
+summary = "Set/get active-noise-cancellation mode (quiet/aware/immersion/cinema/custom1/custom2)."
 enum = "AncMode"
 
 [commands.anc_mode.set]
@@ -59,18 +65,22 @@ operator = "GET"
 payload = []
 
 [commands.anc_mode.verified_bytes]
-# `1F,03,05,02,{mode},01`
+# `1F,03,05,02,{mode},01` — slot indices verified live on verBosita (#91).
 set_quiet = "1F 03 05 02 00 01"
 set_aware = "1F 03 05 02 01 01"
-set_custom1 = "1F 03 05 02 02 01"
-set_custom2 = "1F 03 05 02 03 01"
+set_immersion = "1F 03 05 02 02 01"
+set_cinema = "1F 03 05 02 03 01"
+set_custom1 = "1F 03 05 02 04 01"
+set_custom2 = "1F 03 05 02 05 01"
 get = "1F 03 01 00"
 
 [commands.anc_mode.test_args]
 set_quiet = { mode = 0 }
 set_aware = { mode = 1 }
-set_custom1 = { mode = 2 }
-set_custom2 = { mode = 3 }
+set_immersion = { mode = 2 }
+set_cinema = { mode = 3 }
+set_custom1 = { mode = 4 }
+set_custom2 = { mode = 5 }
 get = {}
 
 # ANC depth (1F,0A, SET_GET) is a composite: read current state first, change


### PR DESCRIPTION
Finalises the macOS app noise slider and fixes the root cause that left it inert.

## What
- **Restores the noise-level slider** in Bose Control.app, driven by `bose-ctl anc-level` (the correct `1F,06` RMW), enabled only on adjustable custom slots.
- **Corrects the `AncMode` enum** to the true hardware mapping. It mislabelled slots 2/3 as the customs; hardware (verBosita, fw 8.2.20) confirms `2=Immersion, 3=Cinema` (fixed) and the adjustable customs are `4/5`. So the old C1/C2 buttons pointed at fixed modes — the slider could never light up.

## Changes
- `protocol/spec/bmap.toml`: `AncMode = quiet0 aware1 immersion2 cinema3 custom1=4 custom2=5`; golden `verified_bytes` + `test_args` updated; Swift + Kotlin regenerated.
- `cli/`: `anc` accepts `immersion`/`cinema`; help + comments synced.
- macOS app: six mode buttons (Quiet/Aware/Immersion/Cinema/C1/C2), ⌘1–6, slider gated on `noiseAdjustable`; `setAncMode` uses bare slot index.
- `CLAUDE.md`: ANC tables synced.

## Verification
- 29 golden tests + Swift unit tests pass.
- On-hardware: `anc custom1`→slot 4 (adjustable ✓), `anc immersion`→slot 2 (fixed ✓), `anc-level` refuses on fixed modes, ANC stays anchored. App builds, installs, renders 6 buttons; slider correctly greys on Aware.

The Kotlin enum is regenerated correctly here too, which sets up the Android port (the macOS half of #90).

Closes #91