### PR TITLE
feat: Android noise slider on 1F,06 RMW (replace 1F,0A depth footgun)

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-macOS app noise slider via anc-level
-macOS app noise slider via anc-level
+Port 1F,06 anc-level RMW to Kotlin, replace Android depth slider, closes 90
+Port 1F,06 anc-level RMW to Kotlin, replace Android depth slider, closes 90
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - app-noise-slider
+# Agent Progress - android-noise-slider
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-08T07:20:53Z
+# Created: 2026-06-09T04:27:42Z
 
-feature=app-noise-slider
-name=macOS app noise slider via anc-level
+feature=android-noise-slider
+name=Port 1F,06 anc-level RMW to Kotlin, replace Android depth slider, closes 90
 status=pending
 step=0
 step_name=Not started
-created=2026-06-08T07:20:53Z
+created=2026-06-09T04:27:42Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ surface. Keep this in sync when adding a verb or control.
 | Capability | Block,Func | `bose-ctl` | Raycast | Hammerspoon | Android |
 |------------|-----------|-----------|---------|-------------|---------|
 | ANC mode | 1F,03 | ✅ `anc` | 👁 (in status) | ✅ Opt+N cycle + call-app hook | ✅ mode selector |
-| Noise level (CNC) | **1F,06** | ✅ `anc-level` (custom modes) | ✅ `bose-anc-level` | — | ⚠️ slider still on 1F,0A — FIX PENDING |
+| Noise level (CNC) | **1F,06** | ✅ `anc-level` (custom modes) | ✅ `bose-anc-level` | — | ✅ slider (1F,06 RMW, custom modes only) |
 | Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
 | EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
 | Multipoint | 01,0A | ✅ `multipoint` | — | — | ✅ toggle |

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -35,7 +35,11 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
 
         // Settings
         val multipointEnabled: Boolean = false,
-        val cncLevel: Int = 0,
+        // Noise level (1F,06) — the active mode's CNC level + whether it's adjustable
+        // (firmware cncMutable: only the custom slots 4/5). modeName labels the hint.
+        val noiseLevel: Int = 0,
+        val noiseAdjustable: Boolean = false,
+        val modeName: String = "",
         val autoOffTimer: String = "",
         val immersionLevel: IntArray? = null,
         val wearDetected: Boolean = false,
@@ -95,7 +99,9 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                     BoseProtocol.getFirmwareVersion()?.let { s = s.copy(firmwareVersion = it) }
                     BoseProtocol.getDeviceName()?.let { s = s.copy(deviceName = it) }
                     BoseProtocol.getMultipoint()?.let { s = s.copy(multipointEnabled = it) }
-                    Composites.getCncLevel()?.let { s = s.copy(cncLevel = it) }
+                    Composites.readActiveModeConfig()?.let {
+                        s = s.copy(noiseLevel = it.cncLevel, noiseAdjustable = it.cncMutable, modeName = it.displayName)
+                    }
                     BoseProtocol.getAutoOffTimer()?.let { s = s.copy(autoOffTimer = BoseProtocol.autoOffTimerDescription(it)) }
                     BoseProtocol.getWearState()?.let { s = s.copy(wearDetected = it) }
                     BoseProtocol.getSerialNumber()?.let { s = s.copy(serialNumber = it) }
@@ -187,10 +193,18 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
         onSuccess = { _state.value = _state.value.copy(eqBass = bass, eqMid = mid, eqTreble = treble) },
     )
 
-    fun setCncLevel(level: Int) = command("Failed to set ANC depth",
-        action = { Composites.setCncLevel(level) },
-        onSuccess = { _state.value = _state.value.copy(cncLevel = level) },
-    )
+    /**
+     * Set the active mode's noise level via the 1F,06 RMW. No-op on a fixed mode (the
+     * slider is disabled there anyway, and `setActiveModeLevel` refuses) so it can never
+     * disable ANC (#83).
+     */
+    fun setNoiseLevel(level: Int) {
+        if (!_state.value.noiseAdjustable) return
+        command("Failed to set noise level",
+            action = { Composites.setActiveModeLevel(level) },
+            onSuccess = { _state.value = _state.value.copy(noiseLevel = level) },
+        )
+    }
 
     fun toggleSettings() {
         _state.value = _state.value.copy(

--- a/android/app/src/main/java/au/com/jd/bose/Composites.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Composites.kt
@@ -8,8 +8,9 @@ import android.util.Log
  * These need read-modify-write, multi-frame list parsing, or poll-confirm loops, so
  * they can't be a single generated builder. They orchestrate over `Transport` (the
  * RFCOMM channel), construct frames via generated `BMAP` where a primitive exists,
- * and decode with the pure `Parsers`. Kept to ~3 (CNC RMW, connected-devices list,
- * bulk getAllState) plus connectDevice's poll-confirm — same split as macOS.
+ * and decode with the pure `Parsers`. Kept to ~3 (noise-level 1F,06 RMW,
+ * connected-devices list, bulk getAllState) plus connectDevice's poll-confirm — same
+ * split as macOS.
  */
 object Composites {
 
@@ -21,7 +22,6 @@ object Composites {
     // bmap.toml (variable-length / RMW response shapes the codegen DSL can't express),
     // so the GET frame is the plain header here and the response is parsed by Parsers.
     private val GET_CONNECTED_DEVICES = intArrayOf(0x05, 0x01, 0x01, 0x00)
-    private val GET_CNC_LEVEL = intArrayOf(0x1F, 0x0A, 0x01, 0x00)
 
     /** GET connected devices (05,01) — the audio-active ground truth. */
     fun getConnectedDevices(): List<IntArray> {
@@ -29,22 +29,43 @@ object Composites {
         return Parsers.parseConnectedDevices(resp)
     }
 
-    /** GET CNC level (custom ANC depth) — first byte of the SettingsConfig (1F,0A). */
-    fun getCncLevel(): Int? {
-        val resp = Transport.send(GET_CNC_LEVEL) ?: return null
-        return Parsers.parseCncLevel(resp)?.level
+    /** Outcome of a noise-level write — mirrors macOS `AncLevelResult`. */
+    sealed class AncLevelResult {
+        data class Ok(val name: String, val level: Int) : AncLevelResult()
+        data class Fixed(val name: String) : AncLevelResult()
+        object Unreachable : AncLevelResult()
     }
 
     /**
-     * SET CNC level (read-modify-write). Reads the current SettingsConfig, changes only
-     * `level`, preserves autoCNC/spatial/windBlock/ancToggle, writes it back via SET_GET.
+     * Read the ACTIVE mode's full AudioModesModeConfig (1F,06). Resolves the current mode
+     * index (1F,03) first, after priming with a 02,02 read — the 1F,06 GET only answers
+     * inside a warm session. Caller must be inside `Transport.withConnection { }`. null if
+     * unreachable.
      */
-    fun setCncLevel(level: Int): Boolean {
-        if (level !in 0..10) return false
-        val current = Transport.send(GET_CNC_LEVEL) ?: return false
-        val cfg = Parsers.parseCncLevel(current) ?: return false
-        val resp = Transport.send(Parsers.buildCncSet(level, cfg)) ?: return false
-        return resp.size >= 4 && resp[2] == 0x03 // RESP
+    fun readActiveModeConfig(): Parsers.ModeConfig? {
+        Transport.send(intArrayOf(0x02, 0x02, 0x01, 0x00)) // prime warm session
+        val cur = Transport.send(intArrayOf(0x1F, 0x03, 0x01, 0x00)) ?: return null
+        if (cur.size < 5) return null
+        val resp = Transport.send(intArrayOf(0x1F, 0x06, 0x01, 0x01, cur[4])) ?: return null
+        return Parsers.parseModeConfig(resp)
+    }
+
+    /**
+     * Set the ACTIVE mode's CNC noise level (0 = max cancellation … 10 = transparency) via
+     * the 1F,06 read-modify-write — the correct, ANC-anchored path (#83). Refuses on a mode
+     * whose level is fixed (`cncMutable == false`: Quiet/Aware/spatial), so a level write
+     * can never disable ANC. Caller must be inside `Transport.withConnection { }`.
+     */
+    fun setActiveModeLevel(level: Int): AncLevelResult {
+        Transport.send(intArrayOf(0x02, 0x02, 0x01, 0x00)) // prime warm session
+        val cur = Transport.send(intArrayOf(0x1F, 0x03, 0x01, 0x00)) ?: return AncLevelResult.Unreachable
+        if (cur.size < 5) return AncLevelResult.Unreachable
+        val r1 = Transport.send(intArrayOf(0x1F, 0x06, 0x01, 0x01, cur[4])) ?: return AncLevelResult.Unreachable
+        val cfg = Parsers.parseModeConfig(r1) ?: return AncLevelResult.Unreachable
+        if (!cfg.cncMutable) return AncLevelResult.Fixed(cfg.displayName)
+        Transport.send(Parsers.buildModeConfigSet(cfg, level))
+        val after = Transport.send(intArrayOf(0x1F, 0x06, 0x01, 0x01, cur[4]))?.let { Parsers.parseModeConfig(it) }
+        return AncLevelResult.Ok(cfg.displayName, after?.cncLevel ?: cfg.cncLevel)
     }
 
     /**

--- a/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
+++ b/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
@@ -351,7 +351,7 @@ fun BoseApp(vm: BoseViewModel = viewModel()) {
                         state = state,
                         onSetName = { vm.setDeviceName(it) },
                         onSetMultipoint = { vm.setMultipoint(it) },
-                        onSetCncLevel = { vm.setCncLevel(it) },
+                        onSetNoiseLevel = { vm.setNoiseLevel(it) },
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
@@ -811,7 +811,7 @@ fun SettingsSection(
     state: BoseViewModel.UiState,
     onSetName: (String) -> Unit,
     onSetMultipoint: (Boolean) -> Unit,
-    onSetCncLevel: (Int) -> Unit = {},
+    onSetNoiseLevel: (Int) -> Unit = {},
 ) {
     // Device name
     var editingName by remember { mutableStateOf(false) }
@@ -873,29 +873,43 @@ fun SettingsSection(
 
     Spacer(modifier = Modifier.height(12.dp))
 
-    // CNC Level (custom ANC depth)
-    var cncValue by remember(state.cncLevel) { mutableStateOf(state.cncLevel.toFloat()) }
-    SettingRow("ANC Depth") {
+    // Noise level (1F,06) — adjustable ONLY on custom modes (firmware cncMutable);
+    // greys out on Quiet/Aware/Immersion/Cinema. Drives anc-level, NEVER the 1F,0A depth
+    // (that disables ANC, #83). 0 = max cancellation … 10 = transparency.
+    var noiseValue by remember(state.noiseLevel) { mutableStateOf(state.noiseLevel.toFloat()) }
+    SettingRow("Noise Level") {
         Slider(
-            value = cncValue,
-            onValueChange = { cncValue = it },
-            onValueChangeFinished = { onSetCncLevel(cncValue.toInt()) },
+            value = noiseValue,
+            onValueChange = { noiseValue = it },
+            onValueChangeFinished = { onSetNoiseLevel(noiseValue.toInt()) },
             valueRange = 0f..10f,
             steps = 9,
+            enabled = state.noiseAdjustable,
             modifier = Modifier.weight(1f),
             colors = SliderDefaults.colors(
                 thumbColor = BoseGreen,
                 activeTrackColor = BoseGreen,
                 inactiveTrackColor = Color(0xFF333333),
+                disabledThumbColor = BoseDim,
+                disabledActiveTrackColor = Color(0xFF333333),
+                disabledInactiveTrackColor = Color(0xFF333333),
             ),
         )
         Text(
-            "${cncValue.toInt()}",
+            if (state.noiseAdjustable) "${noiseValue.toInt()}" else "—",
             fontSize = 14.sp,
-            color = BoseGreen,
+            color = if (state.noiseAdjustable) BoseGreen else BoseDim,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.width(28.dp),
             textAlign = TextAlign.End,
+        )
+    }
+    if (!state.noiseAdjustable) {
+        Text(
+            text = "${state.modeName.ifEmpty { "This mode" }}'s level is fixed — pick a custom mode",
+            fontSize = 11.sp,
+            color = BoseDim,
+            modifier = Modifier.padding(top = 2.dp),
         )
     }
 

--- a/android/app/src/main/java/au/com/jd/bose/Parsers.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Parsers.kt
@@ -32,21 +32,38 @@ object Parsers {
         var deviceName: String = "",
         var multipointEnabled: Boolean = false,
         var autoOffTimer: IntArray = IntArray(0),
-        var cncLevel: Int = 0,
         var onHead: Boolean = false,
         var eqBass: Int = 0,
         var eqMid: Int = 0,
         var eqTreble: Int = 0,
     )
 
-    /** The 5-byte AudioModes SettingsConfig tuple (1F,0A RESP): payload from byte 4. */
-    data class CncConfig(
-        val level: Int, // 0-10
+    /**
+     * One AudioModes mode slot, from the 1F,06 (AudioModesModeConfig) RESPONSE — the
+     * CORRECT noise-level axis. Changing `cncLevel` via a 1F,06 read-modify-write keeps
+     * ANC anchored to the mode (unlike the 1F,0A global write that detaches it → 255/off,
+     * #83). Level semantics (fw 8.2.20): 0 = max cancellation (Quiet), 10 = full
+     * transparency (Aware). Mirrors macOS `ModeConfig` byte-for-byte.
+     */
+    data class ModeConfig(
+        val index: Int,
+        val promptB1: Int,
+        val promptB2: Int,
+        val userConfigurable: Boolean,
+        val name: IntArray, // 32 bytes, null-padded UTF-8
+        val cncMutable: Boolean, // response[41] bit 0 — is the CNC level editable?
+        val cncLevel: Int,
         val autoCNC: Int,
         val spatial: Int,
         val windBlock: Int,
         val ancToggle: Int,
-    )
+    ) {
+        val displayName: String
+            get() {
+                val end = name.indexOfFirst { it == 0 }.let { if (it < 0) name.size else it }
+                return String(ByteArray(end) { name[it].toByte() }, Charsets.UTF_8)
+            }
+    }
 
     /**
      * Parse the connected-devices RESPONSE (05,01). Layout:
@@ -68,23 +85,39 @@ object Parsers {
     }
 
     /**
-     * Parse the CNC/ANC-depth RESPONSE (1F,0A). Needs the full 5-byte payload
-     * (bytes 4..8). Returns null on a short/non-RESP frame.
+     * Parse a 1F,06 AudioModesModeConfig RESPONSE. Payload (resp[4..]) offsets, confirmed
+     * live + against the decompiled AudioModesModeConfigResponse: [0]=index, [1..2]=prompt,
+     * [3]=userConfigurable, [6..37]=32-byte name, [41]=mutability bitfield (bit0=cncMutable),
+     * [42]=cncLevel, [43]=autoCNC, [44]=spatial, [46]=windBlock, [47]=ancToggle. (The
+     * RESPONSE layout differs from the SET payload — see buildModeConfigSet.)
      */
-    fun parseCncLevel(resp: IntArray): CncConfig? {
-        if (resp.size < 9 || resp[2] != OP_RESP) return null
-        return CncConfig(resp[4], resp[5], resp[6], resp[7], resp[8])
+    fun parseModeConfig(resp: IntArray): ModeConfig? {
+        if (resp.size < 4 + 48 || resp[0] != 0x1F || resp[1] != 0x06 || resp[2] != OP_RESP) return null
+        val p = resp.copyOfRange(4, resp.size)
+        return ModeConfig(
+            index = p[0], promptB1 = p[1], promptB2 = p[2],
+            userConfigurable = p[3] == 1,
+            name = p.copyOfRange(6, 38), // [6..37] inclusive = 32 bytes
+            cncMutable = (p[41] and 0x01) == 1,
+            cncLevel = p[42], autoCNC = p[43], spatial = p[44],
+            windBlock = p[46], ancToggle = p[47],
+        )
     }
 
     /**
-     * Build the CNC SET_GET frame that changes `level` and preserves the rest.
-     * `1F,0A,02,05,{level},{autoCNC},{spatial},{windBlock},{ancToggle}`.
+     * Build a 1F,06 AudioModesModeConfig SET_GET frame, changing ONLY `cncLevel` and
+     * forcing `ancToggle = 1` (so a level change can't disable ANC). SET payload layout
+     * (distinct from the response): [0]=index, [1..2]=prompt, [3..34]=32-byte name,
+     * [35]=cncLevel, [36]=autoCNC, [37]=spatial, [38]=windBlock, [39]=ancToggle. Pass
+     * newLevel=null for an unchanged round-trip.
      */
-    fun buildCncSet(level: Int, cfg: CncConfig): IntArray =
-        intArrayOf(
-            0x1F, 0x0A, 0x02, 0x05, level.coerceIn(0, 10),
-            cfg.autoCNC, cfg.spatial, cfg.windBlock, cfg.ancToggle,
-        )
+    fun buildModeConfigSet(cfg: ModeConfig, newLevel: Int?): IntArray {
+        val level = (newLevel ?: cfg.cncLevel).coerceIn(0, 10)
+        val name = IntArray(32) { if (it < cfg.name.size) cfg.name[it] else 0 }
+        val payload = intArrayOf(cfg.index, cfg.promptB1, cfg.promptB2) + name +
+            intArrayOf(level, cfg.autoCNC, cfg.spatial, cfg.windBlock, 0x01) // ancToggle forced on
+        return intArrayOf(0x1F, 0x06, 0x02, payload.size) + payload
+    }
 
     /** Decode a UTF-8 string field response from a given payload offset. */
     fun parseString(resp: IntArray, from: Int = 4): String {
@@ -122,7 +155,6 @@ object Parsers {
         resp(0x05, 0x05)?.let { if (it.size >= 6) { s.volumeMax = it[4]; s.volume = it[5] } }
 
         provide.response(0x05, 0x01)?.let { s.connectedDevices = parseConnectedDevices(it) }
-        provide.response(0x1F, 0x0A)?.let { r -> parseCncLevel(r)?.let { s.cncLevel = it.level } }
 
         resp(0x00, 0x05)?.let { s.firmware = parseString(it) }
         resp(0x00, 0x07)?.let { s.serialNumber = parseString(it) }

--- a/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
+++ b/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
@@ -2,6 +2,7 @@ package au.com.jd.bose
 
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -55,34 +56,50 @@ class ParsersTest {
         assertTrue(Parsers.parseConnectedDevices(intArrayOf()).isEmpty())
     }
 
-    // ── parseCncLevel (1F,0A) + buildCncSet ───────────────────────────────────
+    // ── parseModeConfig (1F,06) + buildModeConfigSet ──────────────────────────
+    // The CORRECT noise-level path (1F,06 RMW), replacing the 1F,0A footgun (#83).
+    // Mirrors macOS `cli/Tests/main.swift` byte-for-byte (52-byte response).
 
-    private val cncResp = intArrayOf(0x1F, 0x0A, 0x03, 0x05, 0x07, 0x01, 0x00, 0x01, 0x01)
-
-    @Test
-    fun cncLevel_parsesAndPreservesFields() {
-        val cfg = Parsers.parseCncLevel(cncResp)!!
-        assertEquals(7, cfg.level)
-        assertEquals(1, cfg.autoCNC)
-        assertEquals(0, cfg.spatial)
-        assertEquals(1, cfg.windBlock)
-        assertEquals(1, cfg.ancToggle)
+    private fun mc(index: Int, name: String, mutability: Int, level: Int, anc: Int): IntArray {
+        val p = IntArray(48)
+        p[0] = index; p[3] = 1 // userConfigurable
+        name.toByteArray(Charsets.UTF_8).forEachIndexed { i, b -> if (i < 32) p[6 + i] = b.toInt() and 0xFF }
+        p[41] = mutability; p[42] = level; p[47] = anc
+        return intArrayOf(0x1F, 0x06, 0x03, 0x30) + p
     }
 
     @Test
-    fun cncLevel_shortOrNonRespIsNull() {
-        assertNull(Parsers.parseCncLevel(intArrayOf(0x1F, 0x0A, 0x03, 0x01, 0x05)))
-        assertNull(Parsers.parseCncLevel(intArrayOf(0x1F, 0x0A, 0x01, 0x00)))
+    fun modeConfig_parsesAdjustableCustom() {
+        val cfg = Parsers.parseModeConfig(mc(5, "None", 0x1D, 7, 1))!!
+        assertTrue(cfg.cncMutable) // 0x1D bit0 → adjustable
+        assertEquals(7, cfg.cncLevel)
+        assertEquals("None", cfg.displayName)
     }
 
     @Test
-    fun buildCncSet_changesLevelPreservesRest() {
-        val cfg = Parsers.parseCncLevel(cncResp)!!
-        assertArrayEquals(
-            intArrayOf(0x1F, 0x0A, 0x02, 0x05, 0x03, 0x01, 0x00, 0x01, 0x01),
-            Parsers.buildCncSet(3, cfg),
-        )
-        assertEquals(10, Parsers.buildCncSet(99, cfg)[4]) // clamps to 10
+    fun modeConfig_fixedModeNotMutable() {
+        val cfg = Parsers.parseModeConfig(mc(0, "Quiet", 0x00, 0, 1))!!
+        assertFalse(cfg.cncMutable) // Quiet/Aware/spatial → fixed
+    }
+
+    @Test
+    fun modeConfig_shortOrNonRespIsNull() {
+        assertNull(Parsers.parseModeConfig(intArrayOf(0x1F, 0x06, 0x03, 0x05, 0, 0)))
+        assertNull(Parsers.parseModeConfig(intArrayOf(0x1F, 0x06, 0x01, 0x00)))
+    }
+
+    @Test
+    fun buildModeConfigSet_changesLevelForcesAnc() {
+        val cfg = Parsers.parseModeConfig(mc(5, "None", 0x1D, 7, 1))!!
+        val f = Parsers.buildModeConfigSet(cfg, 3)
+        assertArrayEquals(intArrayOf(0x1F, 0x06, 0x02, 0x28), f.copyOfRange(0, 4)) // SET_GET len 40
+        val sp = f.copyOfRange(4, f.size)
+        assertEquals(5, sp[0]) // modeIndex @0
+        assertArrayEquals("None".map { it.code }.toIntArray(), sp.copyOfRange(3, 7)) // name @3
+        assertEquals(3, sp[35]) // new cncLevel @35
+        assertEquals(1, sp[39]) // ancToggle forced ON @39 (level change can't disable ANC)
+        assertEquals(7, Parsers.buildModeConfigSet(cfg, null).copyOfRange(4, 4 + 40)[35]) // nil keeps current
+        assertEquals(10, Parsers.buildModeConfigSet(cfg, 99).copyOfRange(4, 4 + 40)[35]) // clamps to 10
     }
 
     // ── parseAllState (bulk session) ──────────────────────────────────────────
@@ -94,7 +111,6 @@ class ParsersTest {
             (0x1F to 0x03) to intArrayOf(0x1F, 0x03, 0x03, 0x01, 0x01),                   // ANC aware
             (0x05 to 0x05) to intArrayOf(0x05, 0x05, 0x03, 0x02, 0x1F, 0x14),             // volMax 31, vol 20
             (0x05 to 0x01) to twoDevices,
-            (0x1F to 0x0A) to cncResp,                                                    // cnc level 7
             (0x01 to 0x0A) to intArrayOf(0x01, 0x0A, 0x03, 0x01, 0x07),                   // multipoint on
             (0x08 to 0x07) to intArrayOf(0x08, 0x07, 0x03, 0x01, 0x04),                   // on head
             (0x00 to 0x05) to (intArrayOf(0x00, 0x05, 0x03, 0x05) + "1.2.3".map { it.code }.toIntArray()),
@@ -113,7 +129,6 @@ class ParsersTest {
         assertEquals(20, s.volume)
         assertEquals(31, s.volumeMax)
         assertEquals(2, s.connectedDevices.size)
-        assertEquals(7, s.cncLevel)
         assertTrue(s.multipointEnabled)
         assertTrue(s.onHead)
         assertEquals("1.2.3", s.firmware)


### PR DESCRIPTION
Completes #90 — ports the macOS `anc-level` (1F,06) path to Kotlin so the Android app's noise slider stops using the `1F,0A` global write that disables ANC (#83).

## Changes
- **Parsers.kt**: `ModeConfig` + `parseModeConfig` + `buildModeConfigSet`, mirroring the Swift byte layouts 1:1 (response: name@6, mutability bit0@41, level@42; SET: name@3, level@35, ancToggle@39 forced on). Removed the `1F,0A` `CncConfig`/`parseCncLevel`/`buildCncSet` footgun and the dead `HeadphoneState.cncLevel`.
- **Composites.kt**: `readActiveModeConfig` + `setActiveModeLevel` (warm-session RMW, refuses on fixed modes via `cncMutable`) + `AncLevelResult`; removed `getCncLevel`/`setCncLevel`.
- **BoseViewModel**: `noiseLevel`/`noiseAdjustable`/`modeName` state; `setNoiseLevel` gated on adjustable so it can never disable ANC.
- **MainActivity**: "Noise Level" slider enabled only on the custom slots, greyed with a "level is fixed — pick a custom mode" hint otherwise.
- **ParsersTest**: 1F,06 mode-config tests mirroring `cli/Tests/main.swift`; dropped the 1F,0A tests.
- **CLAUDE.md**: Android noise-level row now ✅ (1F,06 RMW).

This builds on #92, which already corrected the shared `AncMode` enum + regenerated the Kotlin layer.

## Verification
- `./gradlew testDebugUnitTest` (ParsersTest) passes; `assembleDebug` builds the APK.
- **On-device smoke deferred**: the S21 isn't ADB-connected and the headphones are at 10%. The live phone check (slider greys on fixed modes, drives level on a custom slot, ANC stays on) is the one remaining step.

Closes #90