### PR TITLE
fix: Android ANC mode buttons reach the real custom slots (4/5)

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Port 1F,06 anc-level RMW to Kotlin, replace Android depth slider, closes 90
-Port 1F,06 anc-level RMW to Kotlin, replace Android depth slider, closes 90
+Fix Android AncMode UI enum to 6 real slots so customs reach 4/5
+Fix Android AncMode UI enum to 6 real slots so customs reach 4/5
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - android-noise-slider
+# Agent Progress - android-mode-slots
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-09T04:27:42Z
+# Created: 2026-06-09T04:57:37Z
 
-feature=android-noise-slider
-name=Port 1F,06 anc-level RMW to Kotlin, replace Android depth slider, closes 90
+feature=android-mode-slots
+name=Fix Android AncMode UI enum to 6 real slots so customs reach 4/5
 status=pending
 step=0
 step_name=Not started
-created=2026-06-09T04:27:42Z
+created=2026-06-09T04:57:37Z

--- a/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
@@ -45,12 +45,20 @@ object BoseProtocol {
 
     // ── ANC ──────────────────────────────────────────────────────────────────────
 
-    /** UI-facing ANC mode (label-carrying). Wire values match generated `AncMode`. */
+    /**
+     * UI-facing ANC mode (label-carrying). Wire values are the real hardware slots
+     * (verBosita, fw 8.2.20, #91): 0 Quiet, 1 Aware, 2 Immersion, 3 Cinema (all fixed),
+     * 4/5 the adjustable custom slots whose noise level `anc-level` (1F,06) can set.
+     * Keep in sync with generated `AncMode` (custom1=4, custom2=5). `off` (255) is
+     * decode-only and intentionally NOT a settable mode/button.
+     */
     enum class AncMode(val value: Int, val label: String) {
         QUIET(0, "Quiet"),
         AWARE(1, "Aware"),
-        CUSTOM1(2, "Custom 1"),
-        CUSTOM2(3, "Custom 2");
+        IMMERSION(2, "Immersion"),
+        CINEMA(3, "Cinema"),
+        CUSTOM1(4, "Custom 1"),
+        CUSTOM2(5, "Custom 2");
 
         companion object {
             fun fromInt(v: Int): AncMode = entries.find { it.value == v } ?: QUIET

--- a/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
+++ b/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
@@ -577,30 +577,39 @@ fun AncSection(
     state: BoseViewModel.UiState,
     onSetAnc: (BoseProtocol.AncMode) -> Unit,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        for (mode in BoseProtocol.AncMode.entries) {
-            val isActive = state.ancMode == mode
-            Surface(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(44.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .clickable { onSetAnc(mode) },
-                color = if (isActive) BoseGreen else BoseCardBg,
-                shape = RoundedCornerShape(10.dp),
+    // Six hardware slots (Quiet/Aware/Immersion/Cinema fixed, C1/C2 adjustable) laid out
+    // 3-per-row so the longer labels fit on a phone. The customs (slots 4/5) are what the
+    // Noise Level slider needs — they were unreachable while this enum mislabelled 2/3.
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        BoseProtocol.AncMode.entries.chunked(3).forEach { rowModes ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Text(
-                        text = mode.label,
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = if (isActive) BoseBg else BoseDim,
-                        textAlign = TextAlign.Center,
-                    )
+                for (mode in rowModes) {
+                    val isActive = state.ancMode == mode
+                    Surface(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(44.dp)
+                            .clip(RoundedCornerShape(10.dp))
+                            .clickable { onSetAnc(mode) },
+                        color = if (isActive) BoseGreen else BoseCardBg,
+                        shape = RoundedCornerShape(10.dp),
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Text(
+                                text = mode.label,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1,
+                                color = if (isActive) BoseBg else BoseDim,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                    }
                 }
+                repeat(3 - rowModes.size) { Spacer(modifier = Modifier.weight(1f)) }
             }
         }
     }


### PR DESCRIPTION
On-device verification of #93 (the Android noise-slider port) surfaced that the app's hand-rolled `BoseProtocol.AncMode` UI enum still mislabelled `Custom1→slot2` / `Custom2→slot3` — the **same** bug fixed on macOS in #92. So the new slider was correct but **unreachable** from the Android UI (tapping "Custom 1" landed on Immersion, a fixed mode).

## Fix
- `BoseProtocol.AncMode`: corrected to the real 6 hardware slots (0 Quiet, 1 Aware, 2 Immersion, 3 Cinema, 4 Custom 1, 5 Custom 2).
- `AncSection`: laid the 6 mode buttons out 3-per-row so the longer labels fit on a phone.

## Verified live on the S21 (wireless ADB)
- Tapping "Custom 1" now selects slot 4 (`modeIndex:4`, `noiseAdjustable:true`) — cross-checked from the Mac CLI.
- On a fixed mode (Aware) the slider greys with the "level is fixed" hint; on Custom 1 it goes live.
- Dragging the slider set the level 0→6 with ANC anchored to the mode (`modeIndex` stayed 4, never 255/off).

Closes #94