### PR TITLE
feat: bose v2 follow-ups (docs, Android mode-refresh, immersion cycle, profile noiseLevel)

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Fix Android AncMode UI enum to 6 real slots so customs reach 4/5
-Fix Android AncMode UI enum to 6 real slots so customs reach 4/5
+bose v2 followups issue 96
+bose v2 followups issue 96
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - android-mode-slots
+# Agent Progress - bose-v2-followups
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-09T04:57:37Z
+# Created: 2026-06-09T05:30:56Z
 
-feature=android-mode-slots
-name=Fix Android AncMode UI enum to 6 real slots so customs reach 4/5
+feature=bose-v2-followups
+name=bose v2 followups issue 96
 status=pending
 step=0
 step_name=Not started
-created=2026-06-09T04:57:37Z
+created=2026-06-09T05:30:56Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,8 @@ explicit user action.
 - `raycast/bose-connect.sh` / `bose-disconnect.sh` -- Raycast script commands with a device dropdown → `bose-ctl connect|disconnect <device>`
 - `raycast/bose-status.sh` / `bose-full-status.sh` -- `bose-ctl status` / `bose-ctl info`
 - `raycast/bose-anc-level.sh` / `bose-profile.sh` -- `bose-ctl anc-level [0-10]` (active mode's noise level, custom modes only) / `bose-ctl profile [name]` (text arg)
-- `profiles.json` (repo root) -- settings presets ({ANC mode, depth, EQ, multipoint, volume}) applied by `bose-ctl profile`; versioned + hand-editable, ships flight/office/music. ANC depth is applied ONLY for custom1/custom2 modes (named modes set mode only — depth over quiet/aware disables ANC, #83). flight = {quiet, multipoint off}. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
-- `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B toggles Mac ↔ phone** (+ one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→custom1), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
+- `profiles.json` (repo root) -- settings presets ({ANC mode, noise level, EQ, multipoint, volume}) applied by `bose-ctl profile`; versioned + hand-editable, ships flight/office/music. A profile's `noiseLevel` is applied via the `anc-level` (1F,06) RMW and ONLY takes effect on the adjustable custom modes (4/5, `cncMutable`) — named modes set the mode only (a level over quiet/aware/spatial is a no-op; the old 1F,0A depth write disabled ANC, #83). flight = {quiet, multipoint off}. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
+- `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B toggles Mac ↔ phone** (+ one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→immersion), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
 - The Swift core that does the actual RFCOMM work lives in `cli/` (see below). The macOS app target (`macos/BoseControl/`) is pure SwiftUI/Foundation and does NO RFCOMM — it shells `bose-ctl`, so the two never drift and the app can't reintroduce a transport/poll bug.
 
 ### Android (`android/`) — regenerated protocol on the kept architecture
@@ -313,12 +313,12 @@ surface. Keep this in sync when adding a verb or control.
 | On-head / wear | 08,07 | 👁 `info` (yes/no; `unknown` if no RESP) | 👁 (full status) | 👁 state |
 
 **Profiles** compose several of these capabilities at once — a `bose-ctl profile`
-applies {ANC mode, ANC depth, EQ, multipoint, volume} in one session (CLI +
+applies {ANC mode, noise level, EQ, multipoint, volume} in one session (CLI +
 `bose-profile.sh` Raycast; drivable from macOS Focus via a Shortcut, see README).
 
 **Notable gaps (intentional):** Hammerspoon now does Opt+B (toggle), Opt+N (ANC
 cycle), Opt+J (connect → Mac), and a call-app launch hook — still all event-driven, no timers. Raycast
-covers the common dropdowns plus full-status / anc-depth / profile; deeper config
+covers the common dropdowns plus full-status / anc-level / profile; deeper config
 (EQ/name/multipoint) is CLI- or Android-only by design. The macOS surface has
 **no resident process** — every reading is on-demand, never polled.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ See `CLAUDE.md` for the protocol tables, device map, and hard-won lessons.
 |------|------|
 | `protocol/` | `bmap.toml` + `devices.toml` spec, Python codegen, golden byte tests. `make gen` regenerates `protocol/generated/{BMAP,Devices}.generated.{swift,kt}`. |
 | `cli/` | `bose-ctl` CLI + the Swift core (`Transport`/`Parsers`/`Composites`) + generated Swift. The on-demand RFCOMM engine the Mac front-ends call. |
-| `raycast/` | Raycast script commands (connect / disconnect / status / full-status / anc-depth / profile) → `bose-ctl`. |
+| `raycast/` | Raycast script commands (connect / disconnect / status / full-status / anc-level / profile) → `bose-ctl`. |
 | `hammerspoon/` | `bose.lua` — Opt+B toggles Mac ↔ phone, Opt+N cycles ANC, call-app launch → ANC aware, low-battery warning on toggle. All event-driven. |
-| `profiles.json` | Settings presets ({ANC, depth, EQ, multipoint, volume}) applied via `bose-ctl profile`. Versioned + editable. |
+| `profiles.json` | Settings presets ({ANC mode, noise level, EQ, multipoint, volume}) applied via `bose-ctl profile`. Versioned + editable. |
 | `android/` | Jetpack Compose app + foreground service (package `au.com.jd.bose`). |
 
 The Mac has **no resident app** — Raycast + Hammerspoon shell out to `bose-ctl` on demand (a background poller was the original audio-dropout cause).
@@ -48,7 +48,7 @@ bose-ctl connect <device>     Route audio to device (poll-confirmed)
 bose-ctl disconnect <device>  Disconnect a device
 bose-ctl swap <device>        Route audio to device (multipoint; keeps others)
 bose-ctl anc [mode]           Get/set ANC (quiet/aware/custom1/custom2)
-bose-ctl anc-depth [0-10]     Get/set ANC depth (0=min … 10=max)
+bose-ctl anc-level [0-10]     Get/set active mode noise level (0=max cancel … 10=transparent; custom modes only)
 bose-ctl name [new name]      Get/set headphone name (max 30 UTF-8 bytes)
 bose-ctl volume [0-31]        Get/set volume
 bose-ctl multipoint [on|off]  Get/set multipoint
@@ -60,7 +60,7 @@ bose-ctl raw <hex>            Send raw BMAP bytes
 
 ## Profiles
 
-A profile is a named bundle of settings — ANC mode, ANC depth, EQ, multipoint, volume —
+A profile is a named bundle of settings — ANC mode, noise level, EQ, multipoint, volume —
 applied in one RFCOMM session. They live in `profiles.json` (versioned, hand-editable);
 ships with `flight`, `office`, `music`. A profile only sets the fields it defines.
 
@@ -80,7 +80,7 @@ keypress or an OS event, then make one on-demand `bose-ctl` call.
 
 **Hammerspoon** (`hammerspoon/bose.lua`, reload Hammerspoon after editing):
 - `Opt+B` — toggle audio Mac ↔ phone (also warns if battery ≤ 20%, piggybacking the press).
-- `Opt+N` — cycle ANC quiet → aware → custom1.
+- `Opt+N` — cycle ANC quiet → aware → immersion.
 - Launching a call app (Teams / Zoom / Meet) switches ANC to aware. Edit `AWARE_ON_LAUNCH`
   / the chords at the top of `bose.lua` to taste.
 

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -168,10 +168,35 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    fun setAncMode(mode: BoseProtocol.AncMode) = command("Failed to set ANC",
-        action = { BoseProtocol.setAncMode(mode) },
-        onSuccess = { _state.value = _state.value.copy(ancMode = mode) },
-    )
+    /**
+     * Set the ANC mode, then re-read the active mode's config in the SAME warm session
+     * so the noise slider's enabled state + level update immediately. A mode change can
+     * flip `cncMutable`/`cncLevel` (e.g. quiet → custom1), and without this re-read the
+     * slider stayed stale until a manual Refresh (#96). Falls back to the optimistic
+     * `ancMode` copy if the config read is unreachable.
+     */
+    fun setAncMode(mode: BoseProtocol.AncMode) {
+        viewModelScope.launch {
+            try {
+                val cfg = BoseProtocol.withConnection {
+                    BoseProtocol.setAncMode(mode)
+                    Composites.readActiveModeConfig()
+                }
+                _state.value = if (cfg != null) {
+                    _state.value.copy(
+                        ancMode = mode,
+                        noiseLevel = cfg.cncLevel,
+                        noiseAdjustable = cfg.cncMutable,
+                        modeName = cfg.displayName,
+                    )
+                } else {
+                    _state.value.copy(ancMode = mode)
+                }
+            } catch (e: Exception) {
+                _state.value = _state.value.copy(error = "Failed to set ANC: ${e.message}")
+            }
+        }
+    }
 
     fun setVolume(level: Int) = command("Failed to set volume",
         action = { BoseProtocol.setVolume(level) },

--- a/cli/Composites.swift
+++ b/cli/Composites.swift
@@ -15,7 +15,6 @@ extension Transport {
     // Composite GET frames are not emitted by the generator (commands are marked
     // `composite = true`), so the trivial [block, func, GET, 0] query bytes live here.
     private static let connectedDevicesGet: [UInt8] = [0x05, 0x01, 0x01, 0x00]
-    private static let cncLevelGet: [UInt8] = [0x1F, 0x0A, 0x01, 0x00]
 
     /// GET the audio-active device MACs (05,01) — composite ground truth.
     func getConnectedDevices() -> [[UInt8]] {
@@ -59,21 +58,25 @@ extension Transport {
         }
     }
 
-    /// Apply a profile in ONE RFCOMM session. Reads the live CNC config first (only
-    /// if the profile sets ancDepth — that's a read-modify-write), then sends every
-    /// SET the profile defines. Returns false if the session can't open or the
-    /// profile sets nothing.
+    /// Apply a profile in ONE RFCOMM session: send every static SET the profile defines
+    /// (mode, volume, multipoint, EQ), then — if it carries a `noiseLevel` — apply that
+    /// level to the now-active mode via the 1F,06 RMW. The ANC-mode frame switches the
+    /// active mode BEFORE the RMW reads it, so the level lands on the profile's mode. A
+    /// named/spatial mode legitimately can't take a level, so a `.fixed` result is a
+    /// no-op (not a failure); only an unreachable session — or a profile that sets
+    /// nothing — fails the apply.
     @discardableResult
     func applyProfile(_ p: Profile) -> Bool {
         session { ch, t in
-            var cnc: CncConfig? = nil
-            if p.ancDepth != nil, let cur = t.send(ch, Transport.cncLevelGet) {
-                cnc = parseCncLevel(cur)
-            }
-            let frames = profileFrames(p, currentCnc: cnc)
-            guard !frames.isEmpty else { return false }
+            let frames = profileFrames(p, currentCnc: nil)
+            guard !frames.isEmpty || p.noiseLevel != nil else { return false }
+            _ = t.send(ch, [0x02, 0x02, 0x01, 0x00], timeout: 2.0)  // prime warm (1F,03/06 need it)
             var ok = true
             for f in frames where t.send(ch, f) == nil { ok = false }
+            if let lvl = p.noiseLevel,
+               case .unreachable = rmwActiveModeLevel(lvl, send: { t.send(ch, $0, timeout: 2.0) }) {
+                ok = false
+            }
             return ok
         } ?? false
     }
@@ -91,20 +94,29 @@ extension Transport {
 
     enum AncLevelResult { case ok(name: String, level: Int), fixed(name: String), unreachable }
 
-    /// Set the ACTIVE mode's CNC noise level (0 = max cancellation … 10 = transparency)
-    /// via the 1F,06 read-modify-write — the correct, ANC-anchored path (#83). Refuses
-    /// on a mode whose level is fixed (cncMutable == false: Quiet/Aware/spatial modes),
-    /// so a level write can never disable ANC. Returns the device's post-write level.
+    /// In-session RMW of the active mode's CNC noise level (0 = max cancellation … 10 =
+    /// transparency). `send` issues one BMAP frame and returns the RESPONSE bytes — the
+    /// CALLER owns the warm session (prime with a 02,02 read first; 1F,03/06 only answer
+    /// warm). Resolves the active mode (1F,03), reads its config (1F,06), writes the new
+    /// level back, and re-reads. Refuses on a mode whose level is fixed (cncMutable ==
+    /// false: Quiet/Aware/spatial), so a level write can never disable ANC (#83). Shared
+    /// by `setActiveModeLevel` (the `anc-level` verb) and `applyProfile`.
+    private func rmwActiveModeLevel(_ level: Int, send: (_ frame: [UInt8]) -> [UInt8]?) -> AncLevelResult {
+        guard let cur = send([0x1F, 0x03, 0x01, 0x00]), cur.count >= 5,
+              let r1 = send([0x1F, 0x06, 0x01, 0x01, cur[4]]),
+              let cfg = parseModeConfig(r1) else { return .unreachable }
+        guard cfg.cncMutable else { return .fixed(name: cfg.displayName) }
+        _ = send(buildModeConfigSet(cfg, newLevel: level))
+        let after = send([0x1F, 0x06, 0x01, 0x01, cur[4]]).flatMap(parseModeConfig)
+        return .ok(name: cfg.displayName, level: Int(after?.cncLevel ?? cfg.cncLevel))
+    }
+
+    /// Set the ACTIVE mode's CNC noise level via the 1F,06 RMW — the correct, ANC-anchored
+    /// path (#83). Refuses on a fixed-level mode. Returns the device's post-write level.
     func setActiveModeLevel(_ level: Int) -> AncLevelResult {
         session { ch, t in
             _ = t.send(ch, [0x02, 0x02, 0x01, 0x00], timeout: 2.0)  // prime warm
-            guard let cur = t.send(ch, [0x1F, 0x03, 0x01, 0x00], timeout: 2.0), cur.count >= 5,
-                  let r1 = t.send(ch, [0x1F, 0x06, 0x01, 0x01, cur[4]], timeout: 2.0),
-                  let cfg = parseModeConfig(r1) else { return .unreachable }
-            guard cfg.cncMutable else { return .fixed(name: cfg.displayName) }
-            _ = t.send(ch, buildModeConfigSet(cfg, newLevel: level), timeout: 2.0)
-            let after = t.send(ch, [0x1F, 0x06, 0x01, 0x01, cur[4]], timeout: 2.0).flatMap(parseModeConfig)
-            return .ok(name: cfg.displayName, level: Int(after?.cncLevel ?? cfg.cncLevel))
+            return rmwActiveModeLevel(level) { t.send(ch, $0, timeout: 2.0) }
         } ?? .unreachable
     }
 }

--- a/cli/Profiles.swift
+++ b/cli/Profiles.swift
@@ -1,4 +1,4 @@
-/// Profiles: named bundles of settings ({ANC mode, ANC depth, EQ, multipoint,
+/// Profiles: named bundles of settings ({ANC mode, noise level, EQ, multipoint,
 /// volume}) saved and applied as a unit. Foundation-only (no IOBluetooth): the
 /// pure frame-building + JSON load/save live here and unit-test without hardware;
 /// the live-session apply is `Transport.applyProfile` in Composites.swift.
@@ -20,12 +20,15 @@ struct EqValues: Codable, Equatable {
 struct Profile: Codable, Equatable {
     var name: String
     var ancMode: String? = nil      // quiet / aware / custom1 / custom2
-    var ancDepth: Int? = nil        // 0-10
+    var noiseLevel: Int? = nil      // 0 = max cancel … 10 = transparency; applied via the
+                                    // 1F,06 RMW, only takes effect on adjustable custom modes (4/5)
+    var ancDepth: Int? = nil        // DEPRECATED (inert): retained only so old profiles.json
+                                    // files with the removed 1F,0A depth still decode (#83)
     var eq: EqValues? = nil
     var multipoint: Bool? = nil
     var volume: Int? = nil          // 0-31
 
-    enum CodingKeys: String, CodingKey { case name, ancMode, ancDepth, eq, multipoint, volume }
+    enum CodingKeys: String, CodingKey { case name, ancMode, noiseLevel, ancDepth, eq, multipoint, volume }
 
     // Custom encode so unset fields are omitted (clean, human-editable JSON) rather
     // than written as nulls.
@@ -33,6 +36,7 @@ struct Profile: Codable, Equatable {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(name, forKey: .name)
         try c.encodeIfPresent(ancMode, forKey: .ancMode)
+        try c.encodeIfPresent(noiseLevel, forKey: .noiseLevel)
         try c.encodeIfPresent(ancDepth, forKey: .ancDepth)
         try c.encodeIfPresent(eq, forKey: .eq)
         try c.encodeIfPresent(multipoint, forKey: .multipoint)
@@ -43,7 +47,7 @@ struct Profile: Codable, Equatable {
     var summary: String {
         var parts: [String] = []
         if let m = ancMode { parts.append("anc \(m)") }
-        if let d = ancDepth { parts.append("depth \(d)") }
+        if let n = noiseLevel { parts.append("noise \(n)") }
         if let e = eq { parts.append("eq \(e.bass)/\(e.mid)/\(e.treble)") }
         if let mp = multipoint { parts.append("mp \(mp ? "on" : "off")") }
         if let v = volume { parts.append("vol \(v)") }
@@ -54,15 +58,18 @@ struct Profile: Codable, Equatable {
     init(capturing s: HeadphoneState, name: String) {
         self.name = name
         self.ancMode = AncMode(rawValue: UInt8(truncatingIfNeeded: s.ancMode)).map { "\($0)" }
-        self.ancDepth = s.cncLevel
+        // Capture the live noise level into the active `noiseLevel` field (not the inert
+        // `ancDepth`). On replay it applies via the 1F,06 RMW where the mode is custom;
+        // on a named/spatial mode `applyProfile` treats it as a no-op.
+        self.noiseLevel = s.cncLevel
         self.eq = EqValues(bass: s.eq.bass, mid: s.eq.mid, treble: s.eq.treble)
         self.multipoint = s.multipointEnabled
         self.volume = s.volume
     }
 
-    init(name: String, ancMode: String? = nil, ancDepth: Int? = nil,
+    init(name: String, ancMode: String? = nil, noiseLevel: Int? = nil, ancDepth: Int? = nil,
          eq: EqValues? = nil, multipoint: Bool? = nil, volume: Int? = nil) {
-        self.name = name; self.ancMode = ancMode; self.ancDepth = ancDepth
+        self.name = name; self.ancMode = ancMode; self.noiseLevel = noiseLevel; self.ancDepth = ancDepth
         self.eq = eq; self.multipoint = multipoint; self.volume = volume
     }
 }

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -173,6 +173,11 @@ let pfc = profileFrames(customP, currentCnc: cnc2)
 check(!pfc.contains(where: { $0.count >= 2 && $0[0] == 0x1F && $0[1] == 0x0A }),
       "profileFrames: ancDepth profile emits no CNC frame")
 check(pfc.count == 1, "profileFrames: custom1+depth -> just the mode-select frame")
+// noiseLevel is applied via the live 1F,06 RMW in applyProfile, NOT as a static frame —
+// so a custom-mode profile carrying a noiseLevel still emits only the mode-select frame.
+let nlP = profileFrames(Profile(name: "nl", ancMode: "custom1", noiseLevel: 3), currentCnc: nil)
+check(nlP.count == 1 && nlP[0] == [0x1F, 0x03, 0x05, 0x02, 0x04, 0x01],
+      "profileFrames: noiseLevel adds no static frame (RMW lives in applyProfile)")
 check(profileFrames(Profile(name: "empty"), currentCnc: nil).isEmpty, "profileFrames: empty profile -> none")
 // EQ values clamp into -10...10.
 let clampP = profileFrames(Profile(name: "c", eq: EqValues(bass: 99, mid: -99, treble: 0)), currentCnc: nil)
@@ -185,11 +190,18 @@ let store = try! JSONDecoder().decode(ProfileStore.self, from: Data(pjson.utf8))
 check(store.profiles.count == 1, "profileStore: decodes 1")
 check(store.profile(named: "FLIGHT")?.ancDepth == 10, "profileStore: case-insensitive lookup")
 check(store.profile(named: "flight")?.volume == nil, "profile: absent field stays nil")
+// New noiseLevel field decodes; legacy inert ancDepth still decodes alongside it.
+let njson = "{\"profiles\":[{\"name\":\"c\",\"ancMode\":\"custom1\",\"noiseLevel\":3}]}"
+let nstore = try! JSONDecoder().decode(ProfileStore.self, from: Data(njson.utf8))
+check(nstore.profile(named: "c")?.noiseLevel == 3, "profile: decodes noiseLevel")
+check(nstore.profile(named: "c")?.ancDepth == nil, "profile: noiseLevel-only profile has nil ancDepth")
 
 // Encode omits unset fields (clean human-editable JSON).
 let encoded = String(data: try! JSONEncoder().encode(Profile(name: "x", ancMode: "quiet")), encoding: .utf8)!
 check(encoded.contains("ancMode"), "profile encode: keeps set field")
 check(!encoded.contains("volume"), "profile encode: omits nil fields")
+let encN = String(data: try! JSONEncoder().encode(Profile(name: "x", noiseLevel: 4)), encoding: .utf8)!
+check(encN.contains("noiseLevel"), "profile encode: keeps noiseLevel")
 
 // upsert replaces by name (case-insensitive), doesn't duplicate.
 var st = ProfileStore(profiles: [Profile(name: "a", volume: 5)])
@@ -204,9 +216,14 @@ snap.ancMode = 1; snap.cncLevel = 8; snap.eq = (bass: 2, mid: -1, treble: 4)
 snap.multipointEnabled = true; snap.volume = 12
 let cap = Profile(capturing: snap, name: "now")
 check(cap.ancMode == "aware", "profile capture: ancMode name")
-check(cap.ancDepth == 8 && cap.volume == 12, "profile capture: depth + volume")
+check(cap.noiseLevel == 8 && cap.volume == 12, "profile capture: noise level + volume")
+check(cap.ancDepth == nil, "profile capture: inert ancDepth left nil (level → noiseLevel)")
 check(cap.eq == EqValues(bass: 2, mid: -1, treble: 4), "profile capture: eq")
 check(cap.multipoint == true, "profile capture: multipoint")
+
+// summary surfaces the noise level (not the inert depth).
+check(Profile(name: "s", ancMode: "custom1", noiseLevel: 3).summary == " — anc custom1, noise 3",
+      "profile summary: shows noise level")
 
 // ── summary ─────────────────────────────────────────────────────────────────────
 

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -103,7 +103,7 @@ func cmdInfo() {
 
     // Audio
     row("ANC:", ancModeName(s.ancMode))
-    row("ANC depth:", "\(s.cncLevel)/10")
+    row("Noise level:", "\(s.cncLevel)/10")
     row("Volume:", "\(s.volume)/\(s.volumeMax)")
     row("EQ:", "bass \(s.eq.bass)  mid \(s.eq.mid)  treble \(s.eq.treble)")
     if !s.audioCodec.isEmpty { row("Codec:", s.audioCodec) }
@@ -273,7 +273,7 @@ func cmdName(_ newName: String?) {
 }
 
 /// profile [name | save <name> | rm <name>] — list, apply, save, or remove a settings
-/// preset. A preset bundles {ANC mode, ANC depth, EQ, multipoint, volume}; applying
+/// preset. A preset bundles {ANC mode, noise level, EQ, multipoint, volume}; applying
 /// sends only the fields a preset defines, in ONE RFCOMM session. Presets live in a
 /// git-tracked JSON file (see Profiles.swift); `save` snapshots the current state.
 func cmdProfile(_ a: [String]) {

--- a/hammerspoon/bose.lua
+++ b/hammerspoon/bose.lua
@@ -33,7 +33,7 @@ local TO_PHONE     = "phone"
 -- ANC cycle (Opt+N). Rebind freely — these are personal-config defaults.
 local ANC_MODS     = { "alt" }
 local ANC_KEY      = "n"
-local ANC_CYCLE    = { "quiet", "aware", "custom1" }
+local ANC_CYCLE    = { "quiet", "aware", "immersion" }
 
 -- Connect hotkey (Opt+J): always bring the headphones to THIS Mac, no toggle
 -- guessing. `connect mac` does the A2DP bring-up + BMAP route + poll-confirm.


### PR DESCRIPTION
Closes #96 — the four non-blocking polish items from the v2 work.

## Changes
1. **Docs** — every stale `anc-depth`/"ANC depth" → `anc-level`/"noise level" (README + CLAUDE.md profile descriptions, the `info` "Noise level:" label).
2. **Android mode-refresh** — `setAncMode` now re-reads `readActiveModeConfig()` in the **same** RFCOMM session, so `noiseAdjustable`/`noiseLevel`/`modeName` update immediately on a mode change. The noise slider no longer stays stale until a manual Refresh.
3. **Hammerspoon** — Opt+N cycle is now quiet→aware→**immersion** (`custom1` became slot 4 after #92, so the old third stop had shifted).
4. **Profile `noiseLevel`** — profiles gain an optional `noiseLevel`, applied via the 1F,06 RMW when the profile selects a custom mode. No-op on fixed modes (never disables ANC, #83). `ancDepth` kept inert for old-JSON decode. Shared RMW core extracted (`rmwActiveModeLevel`).

## Verification
- CLI: builds clean; **74 unit tests pass** (new noiseLevel encode/decode/summary/capture/frame-contract coverage).
- Android: compiles; **22 unit tests pass**.
- **Hardware-verified on verBosita:**
  - Profile apply: `custom1 + noiseLevel 3` → ANC custom1, level 3; `aware + noiseLevel 5` → ANC stayed on (level a safe no-op).
  - Android slider: tapping **Custom 1** enabled the Noise Level slider (level 3) with **no Refresh**; tapping **Aware** disabled it ("—", "level is fixed") — both live.

Out of scope (untouched, per the issue): the 1F,06 slider logic, the `AncMode` enum, the protocol spec. No `1F,0A`/anc-depth write path reintroduced.