### PR TITLE
feat: warm-paper light theme (Android + macOS) — burnt-orange accent

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-bose v2 followups issue 96
-bose v2 followups issue 96
+Light theme redesign Android and macOS
+Light theme redesign Android and macOS
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - bose-v2-followups
+# Agent Progress - bose-light-theme
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-09T05:30:56Z
+# Created: 2026-06-09T06:26:47Z
 
-feature=bose-v2-followups
-name=bose v2 followups issue 96
+feature=bose-light-theme
+name=Light theme redesign Android and macOS
 status=pending
 step=0
 step_name=Not started
-created=2026-06-09T05:30:56Z
+created=2026-06-09T06:26:47Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,11 @@ poll timer was the original audio-dropout cause — #69-era). The Mac control su
 is three thin front-ends that shell out to the `cli/` binary (`~/bin/bose-ctl`), so
 nothing runs in the background and the Mac only touches the headphones on an
 explicit user action.
-- `macos/BoseControl/` -- **Bose Control.app**: a windowed SwiftUI app (frosted-dark
-  two-panel: battery/ANC mode/volume/multipoint/on-head + device grid + EQ). Six ANC
+- `macos/BoseControl/` -- **Bose Control.app**: a windowed SwiftUI app (warm-paper light
+  two-panel: battery/ANC mode/volume/multipoint/on-head + device grid + EQ). The light
+  theme (burnt-orange `#AF3A03` accent on warm paper, from the Midterm `paper-hc` palette)
+  is shared with the Android app; macOS colours live in `ContentView.swift`, Android in
+  `MainActivity.kt` (`BoseAccent`/`BoseConnected`/…). Six ANC
   mode buttons (Quiet/Aware/Immersion/Cinema/C1/C2 = slots 0-5) + a **noise-level
   slider** driven by `anc-level` (1F,06) — NOT a raw depth (1F,0A disables ANC, #83).
   The slider is enabled only on the adjustable custom slots (4/5, firmware `cncMutable`)

--- a/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
+++ b/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
@@ -48,7 +48,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -241,30 +241,35 @@ class MainActivity : ComponentActivity() {
 // Theme
 // ======================================================================
 
-val BoseGreen = Color(0xFF00FF88)
-val BoseOrange = Color(0xFFFF9500)
-val BoseBg = Color(0xFF0D0D0D)
-val BoseCardBg = Color(0xFF1A1A1A)
-val BoseText = Color(0xFFE0E0E0)
-val BoseDim = Color(0xFF666666)
-val BoseActiveBg = Color(0xFF002211)
+// Palette — Midterm "paper-hc" inspired: warm paper, burnt-orange accent, earthy neutrals.
+val BoseAccent = Color(0xFFAF3A03)      // burnt orange — primary accent (was neon green)
+val BoseAccentSoft = Color(0xFFF3E4D5)  // soft accent tint (active/selected fills)
+val BoseConnected = Color(0xFF1B4A82)   // calm blue — connected-but-not-active (was orange)
+val BoseBg = Color(0xFFF4EEDE)          // warm paper background
+val BoseCardBg = Color(0xFFFCFAF4)      // warm near-white card
+val BoseText = Color(0xFF21201C)        // warm near-black primary text
+val BoseDim = Color(0xFF6E6A5E)         // secondary text
+val BoseFaint = Color(0xFFA8A18E)       // tertiary text / disabled
+val BoseHair = Color(0xFFE6DCC6)        // hairline border / slider track
+val BoseActiveBg = Color(0xFFF6EADC)    // active device fill (subtle warm tint)
+val BoseError = Color(0xFFA82E2E)       // warm red
 
-private val BoseDarkScheme = darkColorScheme(
-    primary = BoseGreen,
-    secondary = BoseOrange,
+private val BoseLightScheme = lightColorScheme(
+    primary = BoseAccent,
+    secondary = BoseConnected,
     background = BoseBg,
     surface = BoseCardBg,
-    onPrimary = BoseBg,
-    onSecondary = BoseBg,
+    onPrimary = Color(0xFFFFFFFF),      // white text on the orange fill
+    onSecondary = Color(0xFFFFFFFF),
     onBackground = BoseText,
     onSurface = BoseText,
-    error = Color(0xFFFF4444),
+    error = BoseError,
 )
 
 @Composable
 fun BoseTheme(content: @Composable () -> Unit) {
     MaterialTheme(
-        colorScheme = BoseDarkScheme,
+        colorScheme = BoseLightScheme,
         content = content,
     )
 }
@@ -298,7 +303,7 @@ fun BoseApp(vm: BoseViewModel = viewModel()) {
                     text = "Bose",
                     fontSize = 28.sp,
                     fontWeight = FontWeight.Bold,
-                    color = BoseGreen,
+                    color = BoseAccent,
                 )
                 Text(
                     text = "QC Ultra Controller",
@@ -310,7 +315,7 @@ fun BoseApp(vm: BoseViewModel = viewModel()) {
                 // Loading indicator
                 if (state.loading) {
                     CircularProgressIndicator(
-                        color = BoseGreen,
+                        color = BoseAccent,
                         modifier = Modifier.size(24.dp),
                         strokeWidth = 2.dp,
                     )
@@ -382,11 +387,11 @@ fun BoseApp(vm: BoseViewModel = viewModel()) {
                         .padding(16.dp),
                     action = {
                         TextButton(onClick = { vm.clearError() }) {
-                            Text("Dismiss", color = BoseGreen)
+                            Text("Dismiss", color = BoseAccent)
                         }
                     },
-                    containerColor = Color(0xFF2A1A1A),
-                    contentColor = Color(0xFFFF4444),
+                    containerColor = Color(0xFFF6E3E0),
+                    contentColor = BoseError,
                 ) {
                     Text(error)
                 }
@@ -437,7 +442,7 @@ fun DashboardCard(state: BoseViewModel.UiState) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_headphones),
                         contentDescription = "Headphones",
-                        tint = BoseGreen,
+                        tint = BoseAccent,
                         modifier = Modifier.size(20.dp),
                     )
                     Spacer(modifier = Modifier.width(8.dp))
@@ -455,16 +460,16 @@ fun DashboardCard(state: BoseViewModel.UiState) {
                             fontSize = 24.sp,
                             fontWeight = FontWeight.Bold,
                             color = when {
-                                state.batteryLevel <= 15 -> Color(0xFFFF4444)
-                                state.batteryLevel <= 30 -> BoseOrange
-                                else -> BoseGreen
+                                state.batteryLevel <= 15 -> BoseError
+                                state.batteryLevel <= 30 -> BoseConnected
+                                else -> BoseAccent
                             },
                         )
                         if (state.batteryCharging) {
                             Text(
                                 text = " +",
                                 fontSize = 18.sp,
-                                color = BoseGreen,
+                                color = BoseAccent,
                             )
                         }
                     }
@@ -527,11 +532,11 @@ fun DevicesSection(
         for ((name, deviceState) in state.deviceStates) {
             val (bgColor, textColor, borderColor) = when (deviceState) {
                 BoseViewModel.DeviceState.ACTIVE ->
-                    Triple(BoseActiveBg, BoseGreen, BoseGreen)
+                    Triple(BoseActiveBg, BoseAccent, BoseAccent)
                 BoseViewModel.DeviceState.CONNECTED ->
-                    Triple(Color(0xFF1A1500), BoseOrange, BoseOrange)
+                    Triple(Color(0xFFE9EFF6), BoseConnected, BoseConnected)
                 BoseViewModel.DeviceState.OFFLINE ->
-                    Triple(BoseCardBg, BoseDim, Color(0xFF333333))
+                    Triple(BoseCardBg, BoseDim, BoseHair)
             }
 
             Surface(
@@ -593,8 +598,9 @@ fun AncSection(
                             .weight(1f)
                             .height(44.dp)
                             .clip(RoundedCornerShape(10.dp))
+                            .border(1.dp, if (isActive) BoseAccent else BoseHair, RoundedCornerShape(10.dp))
                             .clickable { onSetAnc(mode) },
-                        color = if (isActive) BoseGreen else BoseCardBg,
+                        color = if (isActive) BoseAccent else BoseCardBg,
                         shape = RoundedCornerShape(10.dp),
                     ) {
                         Box(contentAlignment = Alignment.Center) {
@@ -603,7 +609,7 @@ fun AncSection(
                                 fontSize = 12.sp,
                                 fontWeight = FontWeight.Bold,
                                 maxLines = 1,
-                                color = if (isActive) BoseBg else BoseDim,
+                                color = if (isActive) Color.White else BoseDim,
                                 textAlign = TextAlign.Center,
                             )
                         }
@@ -641,7 +647,7 @@ fun VolumeSection(
                 Text(
                     "${sliderValue.toInt()}/${state.volumeMax}",
                     fontSize = 14.sp,
-                    color = BoseGreen,
+                    color = BoseAccent,
                     fontWeight = FontWeight.Bold,
                 )
             }
@@ -654,9 +660,9 @@ fun VolumeSection(
                 steps = state.volumeMax - 1,
                 modifier = Modifier.fillMaxWidth(),
                 colors = SliderDefaults.colors(
-                    thumbColor = BoseGreen,
-                    activeTrackColor = BoseGreen,
-                    inactiveTrackColor = Color(0xFF333333),
+                    thumbColor = BoseAccent,
+                    activeTrackColor = BoseAccent,
+                    inactiveTrackColor = BoseHair,
                 ),
             )
         }
@@ -700,9 +706,11 @@ fun EqSection(
                     val selected = state.eqBass == preset.bass &&
                         state.eqMid == preset.mid && state.eqTreble == preset.treble
                     Surface(
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .weight(1f)
+                            .border(1.dp, if (selected) BoseAccent else BoseHair, RoundedCornerShape(8.dp)),
                         shape = RoundedCornerShape(8.dp),
-                        color = if (selected) BoseGreen else Color(0xFF333333),
+                        color = if (selected) BoseAccent else BoseCardBg,
                         onClick = {
                             bass = preset.bass.toFloat()
                             mid = preset.mid.toFloat()
@@ -715,7 +723,7 @@ fun EqSection(
                             modifier = Modifier.padding(vertical = 8.dp),
                             fontSize = 12.sp,
                             fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
-                            color = if (selected) Color.Black else BoseDim,
+                            color = if (selected) Color.White else BoseDim,
                             textAlign = TextAlign.Center,
                         )
                     }
@@ -754,9 +762,9 @@ private fun EqBandSlider(
             steps = 19,
             modifier = Modifier.weight(1f),
             colors = SliderDefaults.colors(
-                thumbColor = BoseGreen,
-                activeTrackColor = BoseGreen,
-                inactiveTrackColor = Color(0xFF333333),
+                thumbColor = BoseAccent,
+                activeTrackColor = BoseAccent,
+                inactiveTrackColor = BoseHair,
             ),
         )
         Text(
@@ -832,10 +840,10 @@ fun SettingsSection(
                 value = nameText,
                 onValueChange = { nameText = it },
                 textStyle = TextStyle(color = BoseText, fontSize = 14.sp),
-                cursorBrush = SolidColor(BoseGreen),
+                cursorBrush = SolidColor(BoseAccent),
                 modifier = Modifier
                     .weight(1f)
-                    .background(Color(0xFF222222), RoundedCornerShape(6.dp))
+                    .background(BoseHair, RoundedCornerShape(6.dp))
                     .padding(horizontal = 8.dp, vertical = 4.dp),
             )
             Spacer(modifier = Modifier.width(8.dp))
@@ -843,7 +851,7 @@ fun SettingsSection(
                 onSetName(nameText)
                 editingName = false
             }) {
-                Text("Save", color = BoseGreen, fontSize = 12.sp)
+                Text("Save", color = BoseAccent, fontSize = 12.sp)
             }
         } else {
             Text(
@@ -865,17 +873,17 @@ fun SettingsSection(
         Text(
             text = if (state.multipointEnabled) "On" else "Off",
             fontSize = 14.sp,
-            color = if (state.multipointEnabled) BoseGreen else BoseDim,
+            color = if (state.multipointEnabled) BoseAccent else BoseDim,
             modifier = Modifier.weight(1f),
         )
         Switch(
             checked = state.multipointEnabled,
             onCheckedChange = { onSetMultipoint(it) },
             colors = SwitchDefaults.colors(
-                checkedThumbColor = BoseGreen,
-                checkedTrackColor = Color(0xFF003322),
+                checkedThumbColor = Color(0xFFFFFFFF),
+                checkedTrackColor = BoseAccent,
                 uncheckedThumbColor = BoseDim,
-                uncheckedTrackColor = Color(0xFF333333),
+                uncheckedTrackColor = BoseHair,
             ),
         )
     }
@@ -896,18 +904,18 @@ fun SettingsSection(
             enabled = state.noiseAdjustable,
             modifier = Modifier.weight(1f),
             colors = SliderDefaults.colors(
-                thumbColor = BoseGreen,
-                activeTrackColor = BoseGreen,
-                inactiveTrackColor = Color(0xFF333333),
-                disabledThumbColor = BoseDim,
-                disabledActiveTrackColor = Color(0xFF333333),
-                disabledInactiveTrackColor = Color(0xFF333333),
+                thumbColor = BoseAccent,
+                activeTrackColor = BoseAccent,
+                inactiveTrackColor = BoseHair,
+                disabledThumbColor = BoseFaint,
+                disabledActiveTrackColor = BoseFaint,
+                disabledInactiveTrackColor = BoseHair,
             ),
         )
         Text(
             if (state.noiseAdjustable) "${noiseValue.toInt()}" else "—",
             fontSize = 14.sp,
-            color = if (state.noiseAdjustable) BoseGreen else BoseDim,
+            color = if (state.noiseAdjustable) BoseAccent else BoseDim,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.width(28.dp),
             textAlign = TextAlign.End,
@@ -953,7 +961,7 @@ fun SettingsSection(
         Text(
             text = if (state.wearDetected) "On Head" else "Off Head",
             fontSize = 14.sp,
-            color = if (state.wearDetected) BoseGreen else BoseDim,
+            color = if (state.wearDetected) BoseAccent else BoseDim,
         )
     }
 }

--- a/macos/BoseControl/AppDelegate.swift
+++ b/macos/BoseControl/AppDelegate.swift
@@ -1,4 +1,4 @@
-/// AppDelegate: Window chrome configuration for frosted-dark redesign.
+/// AppDelegate: Window chrome configuration for the warm-paper light redesign.
 
 import AppKit
 
@@ -13,6 +13,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.styleMask.insert(.fullSizeContentView)
         window.isMovableByWindowBackground = true
         window.backgroundColor = .clear
-        window.appearance = NSAppearance(named: .darkAqua)
+        window.appearance = NSAppearance(named: .aqua)
     }
 }

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -1,17 +1,24 @@
-/// ContentView: Frosted-dark two-panel layout for Bose headphone control.
+/// ContentView: Warm-paper two-panel layout for Bose headphone control.
 /// Left panel = status sidebar (220px), right panel = device grid + EQ.
-/// Uses NSVisualEffectView for macOS vibrancy/translucency.
+/// Light theme — burnt-orange accent on warm paper (drawn from the Midterm "paper-hc"
+/// terminal theme), matching the Android app.
 
 import SwiftUI
 
 // MARK: - Theme Colors
 
-/// No neon green. White/light grey for active, warm grey for secondary, 40% opacity grey for offline.
-private let activeColor = Color.white
-private let secondaryColor = Color(white: 0.55)
-private let offlineColor = Color(white: 0.4)
-private let cardColor = Color.white.opacity(0.06)
-private let dividerColor = Color.white.opacity(0.08)
+/// Midterm "paper-hc" inspired: warm paper, burnt-orange accent, earthy neutrals.
+private let inkColor = Color(red: 0x21 / 255, green: 0x20 / 255, blue: 0x1C / 255)        // primary text
+private let boseAccent = Color(red: 0xAF / 255, green: 0x3A / 255, blue: 0x03 / 255)     // burnt orange — accent
+private let connectedColor = Color(red: 0x1B / 255, green: 0x4A / 255, blue: 0x82 / 255)  // calm blue — connected
+private let secondaryColor = Color(red: 0x6E / 255, green: 0x6A / 255, blue: 0x5E / 255)  // secondary text
+private let offlineColor = Color(red: 0xA8 / 255, green: 0xA1 / 255, blue: 0x8E / 255)    // tertiary / offline
+private let warnColor = Color(red: 0xA8 / 255, green: 0x2E / 255, blue: 0x2E / 255)       // warm red
+private let paperColor = Color(red: 0xF4 / 255, green: 0xEE / 255, blue: 0xDE / 255)      // window background
+private let cardColor = Color(red: 0xFC / 255, green: 0xFA / 255, blue: 0xF4 / 255)       // card / control fill
+private let activeBg = Color(red: 0xF6 / 255, green: 0xEA / 255, blue: 0xDC / 255)        // active device tint
+private let hairColor = Color(red: 0xE6 / 255, green: 0xDC / 255, blue: 0xC6 / 255)       // hairline border / divider
+private let dividerColor = hairColor
 
 // MARK: - Device Button Model
 
@@ -29,22 +36,6 @@ private let deviceButtons: [DeviceButton] = [
     DeviceButton(id: "tv", label: "TV", symbol: "tv"),
     DeviceButton(id: "quest", label: "Quest", symbol: "visionpro"),
 ]
-
-// MARK: - Visual Effect Background
-
-/// NSViewRepresentable wrapping NSVisualEffectView with .hudWindow material
-/// for macOS dark vibrancy/translucency.
-struct VisualEffectBackground: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.material = .hudWindow
-        view.blendingMode = .behindWindow
-        view.state = .active
-        return view
-    }
-
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
-}
 
 // MARK: - Main View
 
@@ -66,7 +57,8 @@ struct ContentView: View {
             }
         }
         .frame(width: 640, height: 360)
-        .background(VisualEffectBackground())
+        .background(paperColor)
+        .preferredColorScheme(.light)
         .onAppear {
             manager.refreshState()
             syncSliders()
@@ -137,7 +129,7 @@ struct ContentView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(manager.deviceName)
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(activeColor)
+                    .foregroundColor(inkColor)
 
                 HStack(spacing: 6) {
                     Image(systemName: batteryIcon)
@@ -149,7 +141,7 @@ struct ContentView: View {
                     if manager.batteryCharging {
                         Image(systemName: "bolt.fill")
                             .font(.system(size: 10))
-                            .foregroundColor(.orange)
+                            .foregroundColor(boseAccent)
                     }
                 }
             }
@@ -191,7 +183,7 @@ struct ContentView: View {
                             if !editing { manager.setNoiseLevel(Int(noiseSlider)) }
                         }
                     )
-                    .tint(activeColor)
+                    .tint(boseAccent)
                     .disabled(!manager.noiseAdjustable)
                     Text(manager.noiseAdjustable ? "\(Int(noiseSlider))" : "—")
                         .font(.system(size: 10, design: .monospaced))
@@ -227,7 +219,7 @@ struct ContentView: View {
                         }
                     }
                 )
-                .tint(activeColor)
+                .tint(boseAccent)
             }
 
             // Multipoint
@@ -241,7 +233,7 @@ struct ContentView: View {
                     .tracking(1)
             }
             .toggleStyle(.switch)
-            .tint(activeColor)
+            .tint(boseAccent)
 
             // Wear detection
             VStack(alignment: .leading, spacing: 4) {
@@ -251,11 +243,11 @@ struct ContentView: View {
                     .tracking(1)
                 HStack(spacing: 4) {
                     Circle()
-                        .fill(manager.onHead ? Color.green : Color.orange)
+                        .fill(manager.onHead ? boseAccent : offlineColor)
                         .frame(width: 6, height: 6)
                     Text(manager.onHead ? "On head" : "Off head")
                         .font(.system(size: 12))
-                        .foregroundColor(activeColor)
+                        .foregroundColor(inkColor)
                 }
             }
 
@@ -301,9 +293,9 @@ struct ContentView: View {
         let isActive = state == "active"
         let isConnected = state == "connected"
 
-        let textColor: Color = isActive ? activeColor : (isConnected ? secondaryColor : offlineColor)
-        let bg: Color = isActive ? Color.white.opacity(0.14) : cardColor
-        let borderColor: Color = isActive ? activeColor.opacity(0.7) : Color.white.opacity(0.04)
+        let textColor: Color = isActive ? boseAccent : (isConnected ? connectedColor : offlineColor)
+        let bg: Color = isActive ? activeBg : cardColor
+        let borderColor: Color = isActive ? boseAccent.opacity(0.7) : hairColor
 
         return Button(action: { manager.connectDevice(button.id) }) {
             VStack(spacing: 3) {
@@ -355,10 +347,14 @@ struct ContentView: View {
                 }) {
                     Text(preset.name)
                         .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(selected ? .black : secondaryColor)
+                        .foregroundColor(selected ? .white : secondaryColor)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 5)
-                        .background(selected ? activeColor : cardColor)
+                        .background(selected ? boseAccent : cardColor)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(selected ? boseAccent : hairColor, lineWidth: 1)
+                        )
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                 }
                 .buttonStyle(.plain)
@@ -394,7 +390,7 @@ struct ContentView: View {
                     if !editing { onCommit() }
                 }
             )
-            .tint(activeColor)
+            .tint(boseAccent)
             Text("\(Int(value.wrappedValue))")
                 .font(.system(size: 10, design: .monospaced))
                 .foregroundColor(secondaryColor)
@@ -409,11 +405,15 @@ struct ContentView: View {
                 .font(.system(size: 10, weight: .semibold))
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
-                .foregroundColor(isActive ? .black : secondaryColor)
+                .foregroundColor(isActive ? .white : secondaryColor)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 5)
                 .padding(.horizontal, 2)
-                .background(isActive ? activeColor : cardColor)
+                .background(isActive ? boseAccent : cardColor)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(isActive ? boseAccent : hairColor, lineWidth: 1)
+                )
                 .clipShape(RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
@@ -438,10 +438,10 @@ struct ContentView: View {
             }) {
                 Text("Connect")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.black)
+                    .foregroundColor(.white)
                     .padding(.horizontal, 24)
                     .padding(.vertical, 8)
-                    .background(activeColor)
+                    .background(boseAccent)
                     .cornerRadius(8)
             }
             .buttonStyle(.plain)
@@ -465,9 +465,7 @@ struct ContentView: View {
     }
 
     private var batteryColor: Color {
-        if manager.batteryCharging { return .green }
-        if manager.batteryLevel < 15 { return .red }
-        if manager.batteryLevel < 30 { return .orange }
-        return activeColor
+        if manager.batteryLevel < 15 { return warnColor }
+        return boseAccent
     }
 }


### PR DESCRIPTION
Light, refined retheme of both control apps, drawn from the Midterm `paper-hc` terminal palette (warm paper + burnt-orange, no green). Mockup-approved before build.

## Palette
- Background warm paper `#F4EEDE` · cards `#FCFAF4` · hairline `#E6DCC6`
- Text `#21201C` / secondary `#6E6A5E` / tertiary `#A8A18E`
- **Accent burnt-orange `#AF3A03`** (was neon `#00FF88`) · connected-device **blue `#1B4A82`** (was orange) · warm red `#A82E2E`

## Android (`MainActivity.kt`)
`darkColorScheme`→`lightColorScheme`; palette retokenised + renamed for clarity (`BoseGreen`→`BoseAccent`, `BoseOrange`→`BoseConnected`, added `BoseAccentSoft/Faint/Hair`); ANC mode + EQ preset buttons get hairline borders and white-on-accent selected text; switch, sliders, snackbar, device tiles recoloured.

## macOS (`ContentView.swift`, `AppDelegate.swift`)
Solid warm-paper background (drops the dark `NSVisualEffectView` vibrancy); split the overloaded `activeColor` into `inkColor` (text) + `boseAccent` (highlights); window appearance `.darkAqua`→`.aqua`; `.preferredColorScheme(.light)`.

## Verification
- Android: compiles; 22 unit tests pass; **live on the S21** (mode buttons, active-device ring, noise slider enable/disable all correct).
- macOS: builds + Developer-ID signs; **rendered + verified** (warm paper, Aware filled orange, Level slider greyed on a fixed mode).
- Both deployed (APK → S21, app → /Applications).

Pure styling — no behaviour/protocol changes. Home-screen widget keeps its own colours (separate surface; left for a follow-up).