### PR TITLE
feat: re-theme Android widget to warm-paper palette

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Light theme redesign Android and macOS
-Light theme redesign Android and macOS
+Re-theme Android widget to warm-paper palette
+Re-theme Android widget to warm-paper palette
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - bose-light-theme
+# Agent Progress - widget-paper-theme
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-09T06:26:47Z
+# Created: 2026-06-09T07:14:40Z
 
-feature=bose-light-theme
-name=Light theme redesign Android and macOS
+feature=widget-paper-theme
+name=Re-theme Android widget to warm-paper palette
 status=pending
 step=0
 step_name=Not started
-created=2026-06-09T06:26:47Z
+created=2026-06-09T07:14:40Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,12 +135,18 @@ access verBosita?" prompt. Association persists across app reinstalls.
 Buttons use `PendingIntent.getForegroundService()` to send `ACTION_CONNECT_DEVICE`
 directly to `BoseService`. No broadcast receiver in the click path.
 
-**State colors:**
-- Green (#00FF88) = active (audio routed here)
-- Orange (#FF9500) = connected but not active
-- Grey (#666666) = offline/not connected
+**State colors** (warm-paper card, shared with the #98 app retheme):
+- Burnt-orange chip (#AF3A03) = active (audio routed here)
+- Blue chip (#1B4A82) = connected but not active
+- Muted paper chip (#E6DCC6 fill / #6E6A5E text) = offline/not connected
 
-Battery percentage shown as overlay text.
+The widget is a paper **card** (`@drawable/widget_card_bg`: #FCFAF4 fill, #E6DCC6
+hairline border, rounded) sitting on the home-screen wallpaper. Active/connected
+are solid filled chips so they read on any wallpaper. Constants live in
+`BoseWidgetProvider.kt` (independent of the app's Compose palette in `MainActivity.kt`).
+
+Battery percentage shown as overlay text — own on-paper thresholds: warm-red
+(#A82E2E) ≤15, burnt-orange (#AF3A03) ≤30, secondary grey (#6E6A5E) otherwise.
 
 ### BoseService (Foreground Service)
 

--- a/android/app/src/main/java/au/com/jd/bose/BoseWidgetProvider.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseWidgetProvider.kt
@@ -6,19 +6,22 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.graphics.Color
 import android.util.Log
 import android.widget.RemoteViews
 
 /**
  * Home screen widget showing device buttons with connection state.
  *
- * States:
- * - Green (#00FF88) = active (audio routed here)
- * - Orange (#FF9500) = connected but not active
- * - Grey (#666666) = offline/not connected
+ * Paper-card surface — matches the #98 app retheme (warm paper + burnt-orange).
+ * The card sits on the user's home-screen wallpaper, so active/connected are
+ * solid filled chips (read on any wallpaper); offline is a recessed paper chip.
  *
- * Shows battery percentage overlay.
+ * States (chip fill / text):
+ * - Burnt-orange fill (#AF3A03), paper text = active (audio routed here)
+ * - Blue fill (#1B4A82), paper text = connected but not active
+ * - Muted paper fill (#E6DCC6), secondary text (#6E6A5E) = offline/not connected
+ *
+ * Shows battery percentage overlay (own on-paper thresholds, see below).
  * Tapping a device sends CONNECT command directly to BoseService
  * via PendingIntent.getForegroundService (companion device grants
  * background FGS start privileges).
@@ -27,12 +30,19 @@ class BoseWidgetProvider : AppWidgetProvider() {
 
     companion object {
         private const val TAG = "BoseWidget"
-        private const val COLOR_ACTIVE = 0xFF00FF88.toInt()
-        private const val COLOR_CONNECTED = 0xFFFF9500.toInt()
-        private const val COLOR_OFFLINE = 0xFF666666.toInt()
-        private const val COLOR_ACTIVE_BG = 0xFF002211.toInt()
-        private const val COLOR_CONNECTED_BG = 0xFF1A1500.toInt()
-        private const val COLOR_OFFLINE_BG = 0xFF222222.toInt()
+        // Paper-card palette — shared with the #98 app retheme. Active/connected are
+        // filled chips (strong fill + paper text); offline is a recessed paper chip.
+        private const val COLOR_PAPER = 0xFFFCFAF4.toInt()        // chip text on filled states
+        private const val COLOR_ACTIVE = COLOR_PAPER              // text on the burnt-orange chip
+        private const val COLOR_CONNECTED = COLOR_PAPER           // text on the blue chip
+        private const val COLOR_OFFLINE = 0xFF6E6A5E.toInt()      // secondary text on the paper chip
+        private const val COLOR_ACTIVE_BG = 0xFFAF3A03.toInt()    // burnt-orange
+        private const val COLOR_CONNECTED_BG = 0xFF1B4A82.toInt() // blue
+        private const val COLOR_OFFLINE_BG = 0xFFE6DCC6.toInt()   // hairline / muted paper
+        // Battery overlay sits on the paper card — needs on-paper-readable colours.
+        private const val COLOR_BATTERY_LOW = 0xFFA82E2E.toInt()  // warm red,     <= 15
+        private const val COLOR_BATTERY_MID = 0xFFAF3A03.toInt()  // burnt-orange, <= 30
+        private const val COLOR_BATTERY_OK = 0xFF6E6A5E.toInt()   // secondary grey, healthy
         private const val PREFS_NAME = "bose_ctl"
 
         fun updateAll(context: Context, activeDevice: String?, connectedDevices: Set<String> = emptySet()) {
@@ -109,9 +119,9 @@ class BoseWidgetProvider : AppWidgetProvider() {
             if (batteryLevel >= 0) {
                 views.setTextViewText(R.id.txt_battery, "${batteryLevel}%")
                 views.setTextColor(R.id.txt_battery, when {
-                    batteryLevel <= 15 -> Color.RED
-                    batteryLevel <= 30 -> COLOR_CONNECTED
-                    else -> COLOR_ACTIVE
+                    batteryLevel <= 15 -> COLOR_BATTERY_LOW
+                    batteryLevel <= 30 -> COLOR_BATTERY_MID
+                    else -> COLOR_BATTERY_OK
                 })
             }
 

--- a/android/app/src/main/res/drawable/widget_card_bg.xml
+++ b/android/app/src/main/res/drawable/widget_card_bg.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Warm-paper widget card (matches the #98 app retheme). Rounded paper fill
+     with a hairline border so it reads as a card on the home-screen wallpaper. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FCFAF4" />
+    <corners android:radius="16dp" />
+    <stroke
+        android:width="1dp"
+        android:color="#E6DCC6" />
+</shape>

--- a/android/app/src/main/res/layout/widget_layout.xml
+++ b/android/app/src/main/res/layout/widget_layout.xml
@@ -3,9 +3,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:background="#0D0D0D"
+    android:background="@drawable/widget_card_bg"
     android:gravity="center"
-    android:padding="4dp">
+    android:padding="6dp">
 
     <!-- Battery percentage overlay -->
     <TextView
@@ -14,7 +14,7 @@
         android:layout_height="wrap_content"
         android:text=""
         android:textSize="10sp"
-        android:textColor="#00FF88"
+        android:textColor="#6E6A5E"
         android:textStyle="bold"
         android:gravity="end"
         android:paddingEnd="6dp"
@@ -36,10 +36,10 @@
             android:layout_weight="1"
             android:text="phone"
             android:textSize="11sp"
-            android:textColor="#666666"
+            android:textColor="#6E6A5E"
             android:textStyle="bold"
             android:gravity="center"
-            android:background="#222222"
+            android:background="#E6DCC6"
             android:layout_margin="2dp"
             android:clickable="true"
             android:focusable="true" />
@@ -51,10 +51,10 @@
             android:layout_weight="1"
             android:text="mac"
             android:textSize="11sp"
-            android:textColor="#666666"
+            android:textColor="#6E6A5E"
             android:textStyle="bold"
             android:gravity="center"
-            android:background="#222222"
+            android:background="#E6DCC6"
             android:layout_margin="2dp"
             android:clickable="true"
             android:focusable="true" />
@@ -66,10 +66,10 @@
             android:layout_weight="1"
             android:text="ipad"
             android:textSize="11sp"
-            android:textColor="#666666"
+            android:textColor="#6E6A5E"
             android:textStyle="bold"
             android:gravity="center"
-            android:background="#222222"
+            android:background="#E6DCC6"
             android:layout_margin="2dp"
             android:clickable="true"
             android:focusable="true" />
@@ -81,10 +81,10 @@
             android:layout_weight="1"
             android:text="iphone"
             android:textSize="11sp"
-            android:textColor="#666666"
+            android:textColor="#6E6A5E"
             android:textStyle="bold"
             android:gravity="center"
-            android:background="#222222"
+            android:background="#E6DCC6"
             android:layout_margin="2dp"
             android:clickable="true"
             android:focusable="true" />
@@ -96,10 +96,10 @@
             android:layout_weight="1"
             android:text="quest"
             android:textSize="11sp"
-            android:textColor="#666666"
+            android:textColor="#6E6A5E"
             android:textStyle="bold"
             android:gravity="center"
-            android:background="#222222"
+            android:background="#E6DCC6"
             android:layout_margin="2dp"
             android:clickable="true"
             android:focusable="true" />


### PR DESCRIPTION
Re-themes the home-screen widget to the warm-paper / burnt-orange light look from PR #98 (the widget was intentionally left out of #98 as a separate RemoteViews surface).

- **Paper card:** new `@drawable/widget_card_bg` — #FCFAF4 fill, #E6DCC6 hairline border, rounded — sits on the wallpaper.
- **Chips:** active = burnt-orange fill (#AF3A03), connected = blue (#1B4A82), offline = recessed paper chip (#E6DCC6 / #6E6A5E text). Filled active/connected states read on any wallpaper.
- **Battery overlay:** own on-paper thresholds — warm-red ≤15, burnt-orange ≤30, secondary grey otherwise.
- Colours/layout only — click path, button-set logic, and the QS tile untouched.

Verified on the S21 (SM-G991B): card renders, 'mac' shows as the burnt-orange active chip, offline chips legible against the dark wallpaper.

Closes #99