### PR TITLE
fix: device tiles + ANC pending→confirmed feedback; Opt+B opens app

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Re-theme Android widget to warm-paper palette
-Re-theme Android widget to warm-paper palette
+fix device tiles no click feedback + add connecting state
+fix device tiles no click feedback + add connecting state
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - widget-paper-theme
+# Agent Progress - fix-device-tile-feedback
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-09T07:14:40Z
+# Created: 2026-06-09T20:26:57Z
 
-feature=widget-paper-theme
-name=Re-theme Android widget to warm-paper palette
+feature=fix-device-tile-feedback
+name=fix device tiles no click feedback + add connecting state
 status=pending
 step=0
 step_name=Not started
-created=2026-06-09T07:14:40Z
+created=2026-06-09T20:26:57Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ explicit user action.
 - `raycast/bose-status.sh` / `bose-full-status.sh` -- `bose-ctl status` / `bose-ctl info`
 - `raycast/bose-anc-level.sh` / `bose-profile.sh` -- `bose-ctl anc-level [0-10]` (active mode's noise level, custom modes only) / `bose-ctl profile [name]` (text arg)
 - `profiles.json` (repo root) -- settings presets ({ANC mode, noise level, EQ, multipoint, volume}) applied by `bose-ctl profile`; versioned + hand-editable, ships flight/office/music. A profile's `noiseLevel` is applied via the `anc-level` (1F,06) RMW and ONLY takes effect on the adjustable custom modes (4/5, `cncMutable`) — named modes set the mode only (a level over quiet/aware/spatial is a no-op; the old 1F,0A depth write disabled ANC, #83). flight = {quiet, multipoint off}. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
-- `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B toggles Mac ↔ phone** (+ one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→immersion), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
+- `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B opens the Bose Control app** (the windowed control surface — switch devices/ANC/EQ from its tiles), **Opt+⇧B toggles Mac ↔ phone** (the former Opt+B; + one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→immersion), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
 - The Swift core that does the actual RFCOMM work lives in `cli/` (see below). The macOS app target (`macos/BoseControl/`) is pure SwiftUI/Foundation and does NO RFCOMM — it shells `bose-ctl`, so the two never drift and the app can't reintroduce a transport/poll bug.
 
 ### Android (`android/`) — regenerated protocol on the kept architecture
@@ -300,7 +300,7 @@ surface. Keep this in sync when adding a verb or control.
 | Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
 | EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
 | Multipoint | 01,0A | ✅ `multipoint` | — | — | ✅ toggle |
-| Connect device | 04,01 | ✅ `connect`/`swap` | ✅ `bose-connect` | ✅ Opt+B toggle · Opt+J → Mac | ✅ widget/tile/picker |
+| Connect device | 04,01 | ✅ `connect`/`swap` | ✅ `bose-connect` | ✅ Opt+⇧B toggle · Opt+J → Mac (Opt+B opens app) | ✅ widget/tile/picker |
 | Disconnect device | 04,02 | ✅ `disconnect` | ✅ `bose-disconnect` | 👁 (toggle path) | — |
 | Device info (ACL) | 04,05 | 👁 `devices` (○ state) | — | — | 👁 widget colour |
 | Connected devices | 05,01 | 👁 `devices`/`status`/`info` | 👁 (in status) | 👁 toggle-direction | 👁 widget/tile active |
@@ -325,8 +325,8 @@ surface. Keep this in sync when adding a verb or control.
 applies {ANC mode, noise level, EQ, multipoint, volume} in one session (CLI +
 `bose-profile.sh` Raycast; drivable from macOS Focus via a Shortcut, see README).
 
-**Notable gaps (intentional):** Hammerspoon now does Opt+B (toggle), Opt+N (ANC
-cycle), Opt+J (connect → Mac), and a call-app launch hook — still all event-driven, no timers. Raycast
+**Notable gaps (intentional):** Hammerspoon now does Opt+B (open app), Opt+⇧B (toggle),
+Opt+N (ANC cycle), Opt+J (connect → Mac), and a call-app launch hook — still all event-driven, no timers. Raycast
 covers the common dropdowns plus full-status / anc-level / profile; deeper config
 (EQ/name/multipoint) is CLI- or Android-only by design. The macOS surface has
 **no resident process** — every reading is on-demand, never polled.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See `CLAUDE.md` for the protocol tables, device map, and hard-won lessons.
 | `protocol/` | `bmap.toml` + `devices.toml` spec, Python codegen, golden byte tests. `make gen` regenerates `protocol/generated/{BMAP,Devices}.generated.{swift,kt}`. |
 | `cli/` | `bose-ctl` CLI + the Swift core (`Transport`/`Parsers`/`Composites`) + generated Swift. The on-demand RFCOMM engine the Mac front-ends call. |
 | `raycast/` | Raycast script commands (connect / disconnect / status / full-status / anc-level / profile) → `bose-ctl`. |
-| `hammerspoon/` | `bose.lua` — Opt+B toggles Mac ↔ phone, Opt+N cycles ANC, call-app launch → ANC aware, low-battery warning on toggle. All event-driven. |
+| `hammerspoon/` | `bose.lua` — Opt+B opens the app, Opt+⇧B toggles Mac ↔ phone, Opt+N cycles ANC, call-app launch → ANC aware, low-battery warning on toggle. All event-driven. |
 | `profiles.json` | Settings presets ({ANC mode, noise level, EQ, multipoint, volume}) applied via `bose-ctl profile`. Versioned + editable. |
 | `android/` | Jetpack Compose app + foreground service (package `au.com.jd.bose`). |
 
@@ -79,8 +79,10 @@ The cardinal rule is **no background polling of the headphones**. These hooks fi
 keypress or an OS event, then make one on-demand `bose-ctl` call.
 
 **Hammerspoon** (`hammerspoon/bose.lua`, reload Hammerspoon after editing):
-- `Opt+B` — toggle audio Mac ↔ phone (also warns if battery ≤ 20%, piggybacking the press).
+- `Opt+B` — open (launch/focus) the Bose Control app — switch devices/ANC/EQ from its tiles.
+- `Opt+⇧B` — toggle audio Mac ↔ phone (also warns if battery ≤ 20%, piggybacking the press).
 - `Opt+N` — cycle ANC quiet → aware → immersion.
+- `Opt+J` — bring the headphones to this Mac (always connects the Mac, no direction-guessing).
 - Launching a call app (Teams / Zoom / Meet) switches ANC to aware. Edit `AWARE_ON_LAUNCH`
   / the chords at the top of `bose.lua` to taste.
 

--- a/hammerspoon/bose.lua
+++ b/hammerspoon/bose.lua
@@ -5,12 +5,14 @@
 -- poller was the original audio-dropout cause, so this module must never introduce one.
 --
 -- Features:
---   • Opt+B  — toggle audio between Mac and phone (direction from Mac's output device).
---              On the way, reads battery and warns if low (piggybacks the keypress;
---              no separate poll loop).
+--   • Opt+B  — open (launch/focus) the Bose Control app, the windowed control surface.
+--              Switch devices, ANC and EQ from there (its device tiles do the connect).
+--   • Opt+⇧B — no-look toggle of audio between Mac and phone (direction from Mac's
+--              output device). The former Opt+B; kept as a fallback to the app. On the
+--              way, reads battery and warns if low (piggybacks the keypress; no poll).
 --   • Opt+N  — cycle ANC mode quiet → aware → custom1.
 --   • Opt+J  — unconditionally bring the headphones to THIS Mac (connect + route
---              audio here). Unlike Opt+B, never guesses direction from the current
+--              audio here). Unlike Opt+⇧B, never guesses direction from the current
 --              output device — it always connects the Mac.
 --   • App hook — when a call app LAUNCHES (Teams/Zoom/Meet), switch ANC to aware so
 --                you can hear yourself. Fires once on launch, not on every focus.
@@ -25,7 +27,15 @@ local M = {}
 local CTL          = os.getenv("HOME") .. "/bin/bose-ctl"
 local BOSE_NAME    = "verBosita"             -- macOS output-device name when on the Mac
 local MAC_SPEAKERS = "MacBook Pro Speakers"  -- Mac audio falls back here after "→ phone"
-local HOTKEY_MODS  = { "alt" }
+
+-- Open the windowed app (Opt+B): the primary control surface now that its device
+-- tiles do live connect/switch with a pending → connected state.
+local OPEN_MODS    = { "alt" }
+local OPEN_KEY     = "b"
+local APP_NAME     = "Bose Control"
+
+-- No-look Mac↔phone toggle, moved to Opt+⇧B (was Opt+B). Kept as a fallback to the app.
+local HOTKEY_MODS  = { "alt", "shift" }
 local HOTKEY_KEY   = "b"
 local TO_MAC       = "mac"                    -- the two favourites the toggle flips between
 local TO_PHONE     = "phone"
@@ -85,6 +95,12 @@ local function warnIfLowBattery()
       hs.alert.show("🪫  Bose battery " .. pct .. "%")
     end
   end)
+end
+
+-- Open / focus the windowed control app. launchOrFocus brings it forward if it's
+-- already running, else launches it from /Applications.
+local function openApp()
+  hs.application.launchOrFocus(APP_NAME)
 end
 
 local function toggle()
@@ -147,6 +163,7 @@ local function onAppEvent(name, event)
 end
 
 function M.start()
+  M.openHotkey = hs.hotkey.bind(OPEN_MODS, OPEN_KEY, openApp)
   M.hotkey = hs.hotkey.bind(HOTKEY_MODS, HOTKEY_KEY, toggle)
   M.ancHotkey = hs.hotkey.bind(ANC_MODS, ANC_KEY, cycleAnc)
   M.connectHotkey = hs.hotkey.bind(CONNECT_MODS, CONNECT_KEY, connectHere)
@@ -156,6 +173,7 @@ function M.start()
 end
 
 function M.stop()
+  if M.openHotkey then M.openHotkey:delete(); M.openHotkey = nil end
   if M.hotkey then M.hotkey:delete(); M.hotkey = nil end
   if M.ancHotkey then M.ancHotkey:delete(); M.ancHotkey = nil end
   if M.connectHotkey then M.connectHotkey:delete(); M.connectHotkey = nil end

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -42,6 +42,28 @@ final class BoseManager: ObservableObject {
         "iphone": "offline", "tv": "offline", "quest": "offline",
     ]
 
+    // MARK: - Pending-write state (drives the "applying / connecting" UI)
+    //
+    // Writes are optimistic AND confirmed. The catch: a `bose-ctl info` read fired on
+    // window-open / focus can still be in flight when the user acts, then land a beat
+    // later carrying the PRE-change value and revert the optimistic update — the visible
+    // flicker (tap Quiet → snaps back to Aware → settles on Quiet). These flags both
+    // surface a spinner and let `apply()` reject a stale snapshot until the change lands.
+
+    /// ANC slot awaiting device confirmation (nil when settled). `ancMode` already shows
+    /// the optimistic target; this marks it "applying" and protects it from a stale revert.
+    @Published var pendingAncMode: Int? = nil
+
+    /// Device tile awaiting a `connect` result (nil when settled) — renders its spinner.
+    @Published var connectingDevice: String? = nil
+
+    /// Last device we successfully told the headphones to make the active sink. The
+    /// `info` routing probe reports everything "offline" when off-head/idle (the #81
+    /// quirk), which would dark out a tile we just confirmed connected — so we trust the
+    /// `connect` result over the probe and keep this tile lit until the probe positively
+    /// reports a *different* device as active.
+    private var assertedActiveDevice: String? = nil
+
     // MARK: - Private
 
     /// Serial queue: one `bose-ctl` invocation at a time (RFCOMM is single-session;
@@ -121,7 +143,16 @@ final class BoseManager: ObservableObject {
         }
         batteryLevel = (s["batteryLevel"] as? Int) ?? batteryLevel
         batteryCharging = (s["batteryCharging"] as? Bool) ?? false
-        ancMode = (s["ancMode"] as? Int) ?? ancMode
+        let snapAnc = (s["ancMode"] as? Int) ?? ancMode
+        if let pending = pendingAncMode {
+            // A mode change is in flight: ignore a snapshot still showing the old mode
+            // (an info read that started before the change landed) so it can't revert the
+            // optimistic highlight. Once the snapshot agrees, the change has applied —
+            // accept it and clear the pending flag.
+            if snapAnc == pending { ancMode = pending; pendingAncMode = nil }
+        } else {
+            ancMode = snapAnc
+        }
         volume = (s["volume"] as? Int) ?? volume
         volumeMax = (s["volumeMax"] as? Int) ?? volumeMax
         multipointEnabled = (s["multipoint"] as? Bool) ?? false
@@ -135,6 +166,17 @@ final class BoseManager: ObservableObject {
         }
         if let d = s["devices"] as? [String: String] {
             for (name, state) in d { deviceStates[name] = state }
+            // Off-head/idle, the routing probe reports every device "offline" (#81),
+            // which would wrongly dark out a device we just confirmed connected. Trust
+            // the connect result: keep the asserted tile lit unless the probe positively
+            // reports a *different* device as the active sink (a real, external switch).
+            if let asserted = assertedActiveDevice {
+                if d.contains(where: { $0.key != asserted && $0.value == "active" }) {
+                    assertedActiveDevice = nil
+                } else if (deviceStates[asserted] ?? "offline") == "offline" {
+                    deviceStates[asserted] = "active"
+                }
+            }
         }
         noiseLevel = (s["noiseLevel"] as? Int) ?? noiseLevel
         noiseAdjustable = (s["noiseAdjustable"] as? Bool) ?? false
@@ -149,8 +191,15 @@ final class BoseManager: ObservableObject {
     /// (read back from `info`) is the same slot index, so button highlighting matches.
     func setAncMode(_ mode: Int) {
         guard (0...5).contains(mode) else { return }
-        ancMode = mode
-        write(["anc", String(mode)])
+        ancMode = mode            // optimistic highlight
+        pendingAncMode = mode      // mark "applying" + reject any stale revert in apply()
+        confirmWrite(["anc", String(mode)],
+                     confirm: { ($0["ancMode"] as? Int) == mode },
+                     onTimeout: { [weak self] in
+                         // Write never confirmed (rare — a genuinely failed set). Drop the
+                         // pending guard so the next refresh can show the real mode.
+                         if self?.pendingAncMode == mode { self?.pendingAncMode = nil }
+                     })
     }
 
     func setVolume(_ level: Int) {
@@ -179,8 +228,33 @@ final class BoseManager: ObservableObject {
         write(["anc-level", String(clamped)])
     }
 
+    /// Tell the headphones to make `name` the active sink. The tile shows a spinner
+    /// ("Connecting…") for the duration — `bose-ctl connect` poll-confirms internally
+    /// (ACK is never success) and can take up to ~15 s paging a sleeping device — then
+    /// settles to active/connected from the CLI's result, which we trust over the flaky
+    /// off-head routing probe (see `assertedActiveDevice`).
     func connectDevice(_ name: String) {
-        write(["connect", name])
+        guard connectingDevice == nil else { return }   // ignore taps while one is in flight
+        connectingDevice = name
+        DispatchQueue.main.async { self.isRefreshing = true }
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            let (code, out) = self.run(["connect", name])
+            // The CLI prints "Connected <name>" on success, with "(idle …)" when
+            // multipoint kept audio on the previous device (ACL up, not the active sink).
+            let ok = code == 0 && out.range(of: "connected", options: .caseInsensitive) != nil
+            let idle = out.range(of: "(idle", options: .caseInsensitive) != nil
+            let snapshot = Self.parse(self.run(["info", "--json"]).out)
+            DispatchQueue.main.async {
+                if ok { self.assertedActiveDevice = idle ? nil : name }
+                self.apply(snapshot)   // refresh battery/EQ/etc; honours the assertion above
+                if ok && idle && (self.deviceStates[name] ?? "offline") == "offline" {
+                    self.deviceStates[name] = "connected"
+                }
+                self.connectingDevice = nil
+                self.isRefreshing = false
+            }
+        }
     }
 
     func applyProfile(_ name: String) {
@@ -194,6 +268,36 @@ final class BoseManager: ObservableObject {
             guard let self = self else { return }
             _ = self.run(args)
             self.refreshState()
+        }
+    }
+
+    /// Run a write verb, then read `info` a few times until `confirm` reports the new
+    /// value has landed (applying each snapshot so the rest of the UI stays fresh). This
+    /// is a BOUNDED, self-terminating post-write settle — it returns the instant the
+    /// change confirms (almost always the first read) and nothing reschedules it, so it
+    /// is NOT the resident poll that caused the #69-era dropout. It closes the window in
+    /// which an already-in-flight refresh could leave the optimistic value reverted.
+    /// `onTimeout` runs only if the change never confirms (a failed write) so a pending
+    /// spinner can't stick forever.
+    private func confirmWrite(_ verb: [String],
+                              confirm: @escaping ([String: Any]) -> Bool,
+                              attempts: Int = 5, gap: TimeInterval = 0.3,
+                              onTimeout: @escaping () -> Void) {
+        DispatchQueue.main.async { self.isRefreshing = true }
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            _ = self.run(verb)
+            for i in 0..<attempts {
+                let parsed = Self.parse(self.run(["info", "--json"]).out)
+                let ok = confirm(parsed)
+                DispatchQueue.main.async {
+                    self.apply(parsed)
+                    if ok || i == attempts - 1 { self.isRefreshing = false }
+                }
+                if ok { return }
+                if i < attempts - 1 { Thread.sleep(forTimeInterval: gap) }
+            }
+            DispatchQueue.main.async { onTimeout() }
         }
     }
 

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -290,21 +290,34 @@ struct ContentView: View {
 
     private func deviceButton(_ button: DeviceButton) -> some View {
         let state = manager.deviceStates[button.id] ?? "offline"
+        let isConnecting = manager.connectingDevice == button.id
         let isActive = state == "active"
         let isConnected = state == "connected"
+        // Another tile is mid-connect — dim this one and ignore taps until it settles.
+        let isBlocked = manager.connectingDevice != nil && !isConnecting
 
-        let textColor: Color = isActive ? boseAccent : (isConnected ? connectedColor : offlineColor)
-        let bg: Color = isActive ? activeBg : cardColor
-        let borderColor: Color = isActive ? boseAccent.opacity(0.7) : hairColor
+        let textColor: Color = (isActive || isConnecting) ? boseAccent
+            : (isConnected ? connectedColor : offlineColor)
+        let bg: Color = (isActive || isConnecting) ? activeBg : cardColor
+        let borderColor: Color = (isActive || isConnecting) ? boseAccent.opacity(0.7) : hairColor
 
         return Button(action: { manager.connectDevice(button.id) }) {
             VStack(spacing: 3) {
-                Image(systemName: button.symbol)
-                    .font(.system(size: 18, weight: .regular))
-                    .foregroundColor(textColor)
-                Text(button.label)
+                if isConnecting {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.7)
+                        .frame(height: 18)
+                } else {
+                    Image(systemName: button.symbol)
+                        .font(.system(size: 18, weight: .regular))
+                        .foregroundColor(textColor)
+                }
+                Text(isConnecting ? "Connecting…" : button.label)
                     .font(.system(size: 10, weight: .medium))
                     .foregroundColor(textColor)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
             .frame(maxWidth: .infinity)
             .frame(height: 52)
@@ -314,9 +327,11 @@ struct ContentView: View {
                     .stroke(borderColor, lineWidth: 1)
             )
             .clipShape(RoundedRectangle(cornerRadius: 10))
+            .contentShape(RoundedRectangle(cornerRadius: 10))  // whole tile is the hit area
         }
         .buttonStyle(.plain)
-        .opacity(state == "offline" ? 0.6 : 1.0)
+        .disabled(isBlocked)
+        .opacity(isBlocked ? 0.4 : (state == "offline" && !isConnecting ? 0.6 : 1.0))
     }
 
     private struct EqPreset {
@@ -400,21 +415,33 @@ struct ContentView: View {
 
     private func ancButton(_ label: String, _ mode: Int) -> some View {
         let isActive = manager.ancMode == mode
+        let isPending = manager.pendingAncMode == mode  // optimistic + awaiting confirm
         return Button(action: { manager.setAncMode(mode) }) {
-            Text(label)
-                .font(.system(size: 10, weight: .semibold))
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-                .foregroundColor(isActive ? .white : secondaryColor)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 5)
-                .padding(.horizontal, 2)
-                .background(isActive ? boseAccent : cardColor)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(isActive ? boseAccent : hairColor, lineWidth: 1)
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+            ZStack {
+                Text(label)
+                    .font(.system(size: 10, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .foregroundColor(isActive ? .white : secondaryColor)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 5)
+                    .padding(.horizontal, 2)
+                if isPending {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .scaleEffect(0.55)
+                        .tint(.white)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .padding(.trailing, 3)
+                }
+            }
+            .background(isActive ? boseAccent : cardColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(isActive ? boseAccent : hairColor, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .contentShape(RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
     }


### PR DESCRIPTION
## Problem
Device tiles never lit up when clicked, and ANC modes flickered (Quiet→Aware→Quiet). Both traced to an in-flight `bose-ctl info` refresh (fired on window-open/focus) landing *after* an optimistic write and reverting it — compounded by the off-head routing probe reporting every device `offline` (#81).

## Fix
- **BoseManager**: `pendingAncMode` / `connectingDevice` pending state; `apply()` rejects a contradicting snapshot while a write is in flight; `assertedActiveDevice` trusts the `connect` result over the flaky probe; `connectDevice` interprets the CLI result directly; bounded `confirmWrite` settle (self-terminating, not a resident poll — the #69-era dropout stays dead).
- **ContentView**: 'Connecting…' spinner on tiles, 'applying' spinner on ANC buttons, full-tile `contentShape` hit area, other tiles dim mid-connect.
- **hammerspoon/bose.lua**: Opt+B now opens the Bose Control app; Mac↔phone toggle moves to Opt+⇧B. Docs updated (CLAUDE.md, README.md).

## Verification
- macOS app builds + signs clean; installed to /Applications.
- `bose.lua` passes `luac -p`.
- CLI behaviour confirmed empirically (connect result, ANC read-back).