### PR TITLE
fix: match Bose app by bundle ID so Opt+B can hide it

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Opt+B show/hide toggle for Bose Control app
-Opt+B show/hide toggle for Bose Control app
+match Bose app by bundleID so Opt+B hides it
+match Bose app by bundleID so Opt+B hides it
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - opt-b-toggle-app-window
+# Agent Progress - fix-optb-bundleid
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-09T21:53:42Z
+# Created: 2026-06-09T22:01:34Z
 
-feature=opt-b-toggle-app-window
-name=Opt+B show/hide toggle for Bose Control app
+feature=fix-optb-bundleid
+name=match Bose app by bundleID so Opt+B hides it
 status=pending
 step=0
 step_name=Not started
-created=2026-06-09T21:53:42Z
+created=2026-06-09T22:01:34Z

--- a/hammerspoon/bose.lua
+++ b/hammerspoon/bose.lua
@@ -32,7 +32,10 @@ local MAC_SPEAKERS = "MacBook Pro Speakers"  -- Mac audio falls back here after 
 -- tiles do live connect/switch with a pending → connected state.
 local OPEN_MODS    = { "alt" }
 local OPEN_KEY     = "b"
-local APP_NAME     = "Bose Control"
+-- Match by bundle ID, not display name: the .app's CFBundleName is "Bose" (not
+-- "Bose Control"), so hs.application.get("Bose Control") returns nil and the toggle
+-- could never find the running app to hide it. The bundle ID is unambiguous.
+local APP_BUNDLE_ID = "com.jamesdowzard.bose-control"
 
 -- No-look Mac↔phone toggle, moved to Opt+⇧B (was Opt+B). Kept as a fallback to the app.
 local HOTKEY_MODS  = { "alt", "shift" }
@@ -101,11 +104,11 @@ end
 -- again (while it's frontmost) to hide it. Not running → launch it; running but behind
 -- → bring it forward; running + frontmost → hide. So Opt+B both summons and dismisses.
 local function toggleApp()
-  local app = hs.application.get(APP_NAME)
+  local app = hs.application.get(APP_BUNDLE_ID)
   if app and app:isFrontmost() then
     app:hide()
   else
-    hs.application.launchOrFocus(APP_NAME)
+    hs.application.launchOrFocusByBundleID(APP_BUNDLE_ID)
   end
 end
 


### PR DESCRIPTION
Follow-up to #102. The .app's `CFBundleName` is `Bose` (not `Bose Control`), so `hs.application.get("Bose Control")` returned nil — the toggle never found the running app and always launched/focused, so a second Opt+B couldn't hide it. Match by bundle ID `com.jamesdowzard.bose-control` (`get` + `launchOrFocusByBundleID`). `luac -p` passes.