### PR TITLE
refactor: remove call-app launch → ANC aware watcher

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-match Bose app by bundleID so Opt+B hides it
-match Bose app by bundleID so Opt+B hides it
+Remove Teams/Zoom/Meet launch → ANC aware watcher from bose.lua
+Remove Teams/Zoom/Meet launch → ANC aware watcher from bose.lua
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - fix-optb-bundleid
+# Agent Progress - rm-call-aware-watcher
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-09T22:01:34Z
+# Created: 2026-06-11T20:58:15Z
 
-feature=fix-optb-bundleid
-name=match Bose app by bundleID so Opt+B hides it
+feature=rm-call-aware-watcher
+name=Remove Teams/Zoom/Meet launch → ANC aware watcher from bose.lua
 status=pending
 step=0
 step_name=Not started
-created=2026-06-09T22:01:34Z
+created=2026-06-11T20:58:15Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ explicit user action.
 - `raycast/bose-status.sh` / `bose-full-status.sh` -- `bose-ctl status` / `bose-ctl info`
 - `raycast/bose-anc-level.sh` / `bose-profile.sh` -- `bose-ctl anc-level [0-10]` (active mode's noise level, custom modes only) / `bose-ctl profile [name]` (text arg)
 - `profiles.json` (repo root) -- settings presets ({ANC mode, noise level, EQ, multipoint, volume}) applied by `bose-ctl profile`; versioned + hand-editable, ships flight/office/music. A profile's `noiseLevel` is applied via the `anc-level` (1F,06) RMW and ONLY takes effect on the adjustable custom modes (4/5, `cncMutable`) — named modes set the mode only (a level over quiet/aware/spatial is a no-op; the old 1F,0A depth write disabled ANC, #83). flight = {quiet, multipoint off}. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
-- `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B shows/hides the Bose Control app** (the windowed control surface — press once to open/focus, again to hide; switch devices/ANC/EQ from its tiles), **Opt+⇧B toggles Mac ↔ phone** (the former Opt+B; + one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→immersion), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it), and a call-app **launch** watcher (Teams/Zoom/Meet → ANC aware). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
+- `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B shows/hides the Bose Control app** (the windowed control surface — press once to open/focus, again to hide; switch devices/ANC/EQ from its tiles), **Opt+⇧B toggles Mac ↔ phone** (the former Opt+B; + one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→immersion), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it). Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
 - The Swift core that does the actual RFCOMM work lives in `cli/` (see below). The macOS app target (`macos/BoseControl/`) is pure SwiftUI/Foundation and does NO RFCOMM — it shells `bose-ctl`, so the two never drift and the app can't reintroduce a transport/poll bug.
 
 ### Android (`android/`) — regenerated protocol on the kept architecture
@@ -295,7 +295,7 @@ surface. Keep this in sync when adding a verb or control.
 
 | Capability | Block,Func | `bose-ctl` | Raycast | Hammerspoon | Android |
 |------------|-----------|-----------|---------|-------------|---------|
-| ANC mode | 1F,03 | ✅ `anc` | 👁 (in status) | ✅ Opt+N cycle + call-app hook | ✅ mode selector |
+| ANC mode | 1F,03 | ✅ `anc` | 👁 (in status) | ✅ Opt+N cycle | ✅ mode selector |
 | Noise level (CNC) | **1F,06** | ✅ `anc-level` (custom modes) | ✅ `bose-anc-level` | — | ✅ slider (1F,06 RMW, custom modes only) |
 | Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
 | EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
@@ -326,7 +326,7 @@ applies {ANC mode, noise level, EQ, multipoint, volume} in one session (CLI +
 `bose-profile.sh` Raycast; drivable from macOS Focus via a Shortcut, see README).
 
 **Notable gaps (intentional):** Hammerspoon now does Opt+B (open app), Opt+⇧B (toggle),
-Opt+N (ANC cycle), Opt+J (connect → Mac), and a call-app launch hook — still all event-driven, no timers. Raycast
+Opt+N (ANC cycle), Opt+J (connect → Mac) — still all event-driven, no timers. Raycast
 covers the common dropdowns plus full-status / anc-level / profile; deeper config
 (EQ/name/multipoint) is CLI- or Android-only by design. The macOS surface has
 **no resident process** — every reading is on-demand, never polled.

--- a/hammerspoon/bose.lua
+++ b/hammerspoon/bose.lua
@@ -14,8 +14,6 @@
 --   • Opt+J  — unconditionally bring the headphones to THIS Mac (connect + route
 --              audio here). Unlike Opt+⇧B, never guesses direction from the current
 --              output device — it always connects the Mac.
---   • App hook — when a call app LAUNCHES (Teams/Zoom/Meet), switch ANC to aware so
---                you can hear yourself. Fires once on launch, not on every focus.
 --
 -- Wiring (init.lua dofiles this from the repo path; reload Hammerspoon to apply edits):
 --     BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua")
@@ -58,15 +56,6 @@ local CONNECT_TARGET = "mac"
 
 -- Low-battery warning threshold (%), checked on each toggle (no separate poll).
 local LOW_BATTERY  = 20
-
--- Apps whose LAUNCH should switch ANC to aware (so you hear your own voice on calls).
--- Keys are hs.application names; adjust to taste.
-local AWARE_ON_LAUNCH = {
-  ["Microsoft Teams"]      = true,
-  ["Microsoft Teams (work or school)"] = true,
-  ["zoom.us"]              = true,
-  ["Google Meet"]          = true,
-}
 -------------------------------------------------------------------------------
 
 local function boseIsMacOutput()
@@ -162,22 +151,11 @@ local function cycleAnc()
   end)
 end
 
--- App-launch watcher: switch ANC to aware when a call app starts.
-local function onAppEvent(name, event)
-  if event == hs.application.watcher.launched and name and AWARE_ON_LAUNCH[name] then
-    ctl({ "anc", "aware" }, function(ok)
-      if ok then hs.alert.show("🎧  " .. name .. " → ANC aware") end
-    end)
-  end
-end
-
 function M.start()
   M.openHotkey = hs.hotkey.bind(OPEN_MODS, OPEN_KEY, toggleApp)
   M.hotkey = hs.hotkey.bind(HOTKEY_MODS, HOTKEY_KEY, toggle)
   M.ancHotkey = hs.hotkey.bind(ANC_MODS, ANC_KEY, cycleAnc)
   M.connectHotkey = hs.hotkey.bind(CONNECT_MODS, CONNECT_KEY, connectHere)
-  M.appWatcher = hs.application.watcher.new(onAppEvent)
-  M.appWatcher:start()
   return M
 end
 
@@ -186,7 +164,6 @@ function M.stop()
   if M.hotkey then M.hotkey:delete(); M.hotkey = nil end
   if M.ancHotkey then M.ancHotkey:delete(); M.ancHotkey = nil end
   if M.connectHotkey then M.connectHotkey:delete(); M.connectHotkey = nil end
-  if M.appWatcher then M.appWatcher:stop(); M.appWatcher = nil end
 end
 
 return M


### PR DESCRIPTION
Removes the Teams/Zoom/Meet launch watcher from `hammerspoon/bose.lua` that auto-switched ANC to aware. Opt+B only ever showed/hid the app; this watcher was the sole automatic aware switch. ANC aware is now reachable only via the explicit Opt+N cycle. CLAUDE.md synced.