### PR TITLE
Remove on-head indicator — QC Ultra 2 doesn't expose live wear state

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Remove Teams/Zoom/Meet launch → ANC aware watcher from bose.lua
-Remove Teams/Zoom/Meet launch → ANC aware watcher from bose.lua
+fix-wear-detection-decode — 08,07 on-head byte mislabels worn as off-head
+fix-wear-detection-decode — 08,07 on-head byte mislabels worn as off-head
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - rm-call-aware-watcher
+# Agent Progress - fix-wear-detection-decode
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-11T20:58:15Z
+# Created: 2026-06-11T20:17:34Z
 
-feature=rm-call-aware-watcher
-name=Remove Teams/Zoom/Meet launch → ANC aware watcher from bose.lua
+feature=fix-wear-detection-decode
+name=fix-wear-detection-decode — 08,07 on-head byte mislabels worn as off-head
 status=pending
 step=0
 step_name=Not started
-created=2026-06-11T20:58:15Z
+created=2026-06-11T20:17:34Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ is three thin front-ends that shell out to the `cli/` binary (`~/bin/bose-ctl`),
 nothing runs in the background and the Mac only touches the headphones on an
 explicit user action.
 - `macos/BoseControl/` -- **Bose Control.app**: a windowed SwiftUI app (warm-paper light
-  two-panel: battery/ANC mode/volume/multipoint/on-head + device grid + EQ). The light
+  two-panel: battery/ANC mode/volume/multipoint + device grid + EQ). The light
   theme (burnt-orange `#AF3A03` accent on warm paper, from the Midterm `paper-hc` palette)
   is shared with the Android app; macOS colours live in `ContentView.swift`, Android in
   `MainActivity.kt` (`BoseAccent`/`BoseConnected`/…). Six ANC
@@ -319,7 +319,16 @@ surface. Keep this in sync when adding a verb or control.
 | Platform | 12,0D | 👁 `info` | 👁 (full status) | 👁 state |
 | Codename | 12,0C | 👁 `info` | 👁 (full status) | 👁 state |
 | Auto-off timer | 01,0B | 👁 `info` (read-only) | 👁 (full status) | 👁 state |
-| On-head / wear | 08,07 | 👁 `info` (yes/no; `unknown` if no RESP) | 👁 (full status) | 👁 state |
+
+> **No on-head / live wear state — not exposed on the QC Ultra 2 (verified, do not re-add).**
+> The real wear function is **`StatusInEar` = block `0x02` / func `0x09`** (a plain GET;
+> response decodes `payload[0]` bit0 = left bud, bit1 = right bud). It's an **earbuds**
+> feature — the over-ear headphones answer **`FuncNotSupp`** (error op `0x04`, code `4`)
+> to `02,09`. Auto-pause is handled on-device (sensor → AVRCP pause to the active sink),
+> never published over BMAP. The old `08,07 == 0x04` "on-head" read was a synthetic-fixture
+> guess — `08,07` isn't the wear function and its byte is noise (flips 0x03/0x04 off-head).
+> Confirmed by decompiling the Bose Music app (v13.0.7, `com.bose.bmap.messages…StatusInEar`)
+> + the device's own `FuncNotSupp` reply. Removed from app/CLI/Android (#104-era cleanup).
 
 **Profiles** compose several of these capabilities at once — a `bose-ctl profile`
 applies {ANC mode, noise level, EQ, multipoint, volume} in one session (CLI +

--- a/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
@@ -210,7 +210,7 @@ object BoseProtocol {
     fun getPlatform() = getStringField(intArrayOf(0x12, 0x0D, 0x01, 0x00))
     fun getCodename() = getStringField(intArrayOf(0x12, 0x0C, 0x01, 0x00))
 
-    // ── Auto-off timer / wear / immersion (read-only diagnostics) ─────────────────
+    // ── Auto-off timer / immersion (read-only diagnostics) ───────────────────────
 
     fun getAutoOffTimer(): IntArray? {
         val resp = Transport.send(intArrayOf(0x01, 0x0B, 0x01, 0x00)) ?: return null
@@ -235,12 +235,6 @@ object BoseProtocol {
         if (resp.size < 5 || resp[2] != OP_RESP) return null
         val end = (4 + resp[3]).coerceAtMost(resp.size)
         return resp.copyOfRange(4, end)
-    }
-
-    fun getWearState(): Boolean? {
-        val resp = Transport.send(intArrayOf(0x08, 0x07, 0x01, 0x00)) ?: return null
-        if (resp.size < 5 || resp[2] != OP_RESP) return null
-        return resp[4] == 0x04
     }
 
     // ── Device info (per-device ACL state) ───────────────────────────────────────

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -42,7 +42,6 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
         val modeName: String = "",
         val autoOffTimer: String = "",
         val immersionLevel: IntArray? = null,
-        val wearDetected: Boolean = false,
 
         // Info
         val serialNumber: String = "",
@@ -103,7 +102,6 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                         s = s.copy(noiseLevel = it.cncLevel, noiseAdjustable = it.cncMutable, modeName = it.displayName)
                     }
                     BoseProtocol.getAutoOffTimer()?.let { s = s.copy(autoOffTimer = BoseProtocol.autoOffTimerDescription(it)) }
-                    BoseProtocol.getWearState()?.let { s = s.copy(wearDetected = it) }
                     BoseProtocol.getSerialNumber()?.let { s = s.copy(serialNumber = it) }
                     BoseProtocol.getPlatform()?.let { s = s.copy(platform = it) }
                     BoseProtocol.getCodename()?.let { s = s.copy(codename = it) }

--- a/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
+++ b/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
@@ -953,17 +953,6 @@ fun SettingsSection(
             color = BoseText,
         )
     }
-
-    Spacer(modifier = Modifier.height(12.dp))
-
-    // Wear detection
-    SettingRow("Wear Detection") {
-        Text(
-            text = if (state.wearDetected) "On Head" else "Off Head",
-            fontSize = 14.sp,
-            color = if (state.wearDetected) BoseAccent else BoseDim,
-        )
-    }
 }
 
 @Composable

--- a/android/app/src/main/java/au/com/jd/bose/Parsers.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Parsers.kt
@@ -32,7 +32,6 @@ object Parsers {
         var deviceName: String = "",
         var multipointEnabled: Boolean = false,
         var autoOffTimer: IntArray = IntArray(0),
-        var onHead: Boolean = false,
         var eqBass: Int = 0,
         var eqMid: Int = 0,
         var eqTreble: Int = 0,
@@ -171,7 +170,8 @@ object Parsers {
 
         resp(0x01, 0x0A)?.let { s.multipointEnabled = it[4] != 0 }
         resp(0x01, 0x0B)?.let { s.autoOffTimer = it.copyOfRange(4, it.size) }
-        resp(0x08, 0x07)?.let { s.onHead = it[4] == 0x04 }
+        // No on-head/wear: StatusInEar (02,09) is an EARBUDS function; the QC Ultra 2
+        // headphones answer FuncNotSupp. Live worn state isn't exposed over BMAP.
 
         provide.response(0x01, 0x07)?.let { r ->
             if (r.size >= 16 && r[2] == OP_RESP) {

--- a/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
+++ b/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
@@ -112,7 +112,6 @@ class ParsersTest {
             (0x05 to 0x05) to intArrayOf(0x05, 0x05, 0x03, 0x02, 0x1F, 0x14),             // volMax 31, vol 20
             (0x05 to 0x01) to twoDevices,
             (0x01 to 0x0A) to intArrayOf(0x01, 0x0A, 0x03, 0x01, 0x07),                   // multipoint on
-            (0x08 to 0x07) to intArrayOf(0x08, 0x07, 0x03, 0x01, 0x04),                   // on head
             (0x00 to 0x05) to (intArrayOf(0x00, 0x05, 0x03, 0x05) + "1.2.3".map { it.code }.toIntArray()),
             // EQ RESP: value bytes at absolute indices 6, 10, 14 (signed).
             (0x01 to 0x07) to intArrayOf(
@@ -130,7 +129,6 @@ class ParsersTest {
         assertEquals(31, s.volumeMax)
         assertEquals(2, s.connectedDevices.size)
         assertTrue(s.multipointEnabled)
-        assertTrue(s.onHead)
         assertEquals("1.2.3", s.firmware)
         assertEquals(3, s.eqBass)
         assertEquals(0, s.eqMid)

--- a/cli/Parsers.swift
+++ b/cli/Parsers.swift
@@ -31,8 +31,6 @@ struct HeadphoneState {
     var multipointEnabled: Bool = false
     var autoOffTimer: [UInt8] = []
     var cncLevel: Int = 0
-    var onHead: Bool? = nil         // Optional: nil renders "unknown" when 08,07 yields no
-                                    // matching response; set true/false when it does.
     var eq: (bass: Int, mid: Int, treble: Int) = (0, 0, 0)
 }
 
@@ -174,8 +172,7 @@ func parseAllState(_ provide: ResponseProvider) -> HeadphoneState {
     func resp(_ b: UInt8, _ f: UInt8) -> [UInt8]? {
         // Require the frame to be the RESPONSE to THIS command: BMAP echoes the
         // queried block/func at r[0],r[1]. Without this, a leftover/late frame from a
-        // prior command in the bulk session gets misread as the current field — that
-        // misalignment was making on-head (08,07) report a bogus value on-device.
+        // prior command in the bulk session gets misread as the current field.
         // Matching block/func keeps every field bound to its own response.
         guard let r = provide(b, f), r.count >= 5, r[0] == b, r[1] == f, r[2] == OP_RESP_BYTE else { return nil }
         return r
@@ -207,10 +204,11 @@ func parseAllState(_ provide: ResponseProvider) -> HeadphoneState {
 
     if let r = resp(0x01, 0x0A) { s.multipointEnabled = parseMultipointEnabled(r[4]) }
     if let r = resp(0x01, 0x0B) { s.autoOffTimer = Array(r[4...]) }
-    // 08,07 answers within the warm bulk session (it's silent on a cold standalone
-    // channel, e.g. `raw 08 07`). With resp() now matching block/func, this binds to
-    // the right frame and on-head reads correctly; nil only if no 08,07 RESP arrives.
-    if let r = resp(0x08, 0x07) { s.onHead = r[4] == 0x04 }
+    // No on-head/wear field: the QC Ultra 2 headphones don't expose live worn state.
+    // The real wear function is StatusInEar (02,09) — but it's an EARBUDS feature
+    // (payload bit0/bit1 = left/right bud) and the headphones answer FuncNotSupp
+    // (error 0x04). On-head is handled on-device (sensor → AVRCP pause), never
+    // published over BMAP. (The old 08,07 read was a synthetic guess, not the wear fn.)
 
     if let r = provide(0x01, 0x07), r.count >= 16, r[2] == OP_RESP_BYTE {
         s.eq = (bass: Int(Int8(bitPattern: r[6])),

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -102,7 +102,6 @@ let responses: [[UInt8]: [UInt8]] = [
     [0x05, 0x01]: twoDevices,                                                // 2 active devices
     [0x1F, 0x0A]: cncResp,                                                   // cnc level 7
     [0x01, 0x0A]: [0x01, 0x0A, 0x03, 0x01, 0x07],                            // multipoint on
-    [0x08, 0x07]: [0x08, 0x07, 0x03, 0x01, 0x04],                            // on head
     [0x00, 0x05]: [0x00, 0x05, 0x03, 0x05] + Array("1.2.3".utf8),            // firmware
     // EQ RESP: parser reads value bytes at absolute indices 6, 10, 14 (v1-proven
     // layout: 3x 4-byte groups, value is the 3rd byte of each group).
@@ -118,7 +117,6 @@ check(state.volume == 20 && state.volumeMax == 31, "allState: volume 20/31")
 check(state.connectedDevices.count == 2, "allState: 2 connected devices")
 check(state.cncLevel == 7, "allState: cnc level 7")
 check(state.multipointEnabled, "allState: multipoint on")
-check(state.onHead == true, "allState: on head (parses when 08,07 responds)")
 check(state.firmware == "1.2.3", "allState: firmware 1.2.3")
 check(state.eq.bass == 3 && state.eq.mid == 0 && state.eq.treble == -3, "allState: EQ +3/0/-3 (signed)")
 

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -75,7 +75,7 @@ func cmdStatus() {
 
 /// info — the COMPLETE HeadphoneState from getAllState (one RFCOMM session).
 /// `status` is the quick subset; `info` dumps everything the bulk read returns
-/// (identity, power/wear, full audio config, and the audio-active device list).
+/// (identity, power, full audio config, and the audio-active device list).
 /// No new protocol work — pure formatting over the existing composite.
 func cmdInfo() {
     guard let s = transport.getAllState() else { fail("headphones not reachable") }
@@ -93,9 +93,8 @@ func cmdInfo() {
     if !s.platform.isEmpty     { row("Platform:", s.platform) }
     if !s.codename.isEmpty     { row("Codename:", s.codename) }
 
-    // Power / wear
+    // Power
     row("Battery:", "\(s.batteryLevel)%\(s.batteryCharging ? " ⚡" : "")")
-    row("On head:", s.onHead.map { $0 ? "yes" : "no" } ?? "unknown")
     if !s.autoOffTimer.isEmpty {
         // Encoding unverified over RFCOMM (read-only field) — show raw bytes.
         row("Auto-off:", s.autoOffTimer.map { String(format: "%02X", $0) }.joined(separator: " "))
@@ -175,7 +174,6 @@ func cmdInfoJSON() {
         "volumeMax": s.volumeMax,
         "eq": ["bass": s.eq.bass, "mid": s.eq.mid, "treble": s.eq.treble],
         "multipoint": s.multipointEnabled,
-        "onHead": s.onHead.map { $0 as Any } ?? NSNull(),
         "devices": deviceStates,
     ]
     out.merge(mode) { _, new in new }

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -24,7 +24,6 @@ final class BoseManager: ObservableObject {
     @Published var deviceName: String = "verBosita"
     @Published var firmware: String = ""
     @Published var multipointEnabled: Bool = false
-    @Published var onHead: Bool = false
     @Published var eq: (bass: Int, mid: Int, treble: Int) = (0, 0, 0)
     @Published var isRefreshing: Bool = false
 
@@ -156,7 +155,6 @@ final class BoseManager: ObservableObject {
         volume = (s["volume"] as? Int) ?? volume
         volumeMax = (s["volumeMax"] as? Int) ?? volumeMax
         multipointEnabled = (s["multipoint"] as? Bool) ?? false
-        onHead = (s["onHead"] as? Bool) ?? false
         if let name = s["deviceName"] as? String, !name.isEmpty { deviceName = name }
         if let fw = s["firmware"] as? String { firmware = fw }
         if let e = s["eq"] as? [String: Any] {

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -235,22 +235,6 @@ struct ContentView: View {
             .toggleStyle(.switch)
             .tint(boseAccent)
 
-            // Wear detection
-            VStack(alignment: .leading, spacing: 4) {
-                Text("STATUS")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(secondaryColor)
-                    .tracking(1)
-                HStack(spacing: 4) {
-                    Circle()
-                        .fill(manager.onHead ? boseAccent : offlineColor)
-                        .frame(width: 6, height: 6)
-                    Text(manager.onHead ? "On head" : "Off head")
-                        .font(.system(size: 12))
-                        .foregroundColor(inkColor)
-                }
-            }
-
             Spacer()
         }
         .padding(16)


### PR DESCRIPTION
## What
Removes the broken `On head / Off head` readout from the macOS app, CLI `info`, and Android.

## Why
The indicator was built on a synthetic test fixture (`08,07 == 0x04`) that never matched hardware. Investigation — decompiling Bose Music v13.0.7 + live probes on the QC Ultra 2 — proved:
- The real wear function is **`StatusInEar`** (block `0x02` / func `0x09`, a GET; decode `payload[0]` bit0=left, bit1=right bud).
- It's an **earbuds** feature. The over-ear headphones answer **`FuncNotSupp`** (error `0x04`) to `02,09`.
- On-head is handled **on-device** (sensor → AVRCP pause), never published over BMAP.
- `08,07` isn't the wear function at all — its byte is noise (flips 0x03/0x04 off-head).

## Changes
- Strip the indicator + `08,07` read from CLI (`Parsers/main/Tests`), macOS (`BoseManager/ContentView`), Android (`Parsers/BoseProtocol/BoseViewModel/MainActivity` + test).
- Document the verified finding in CLAUDE.md so it isn't re-added.

## Verified
CLI builds + unit tests pass + live `info` no longer shows the row; macOS app builds + signs; Android compiles + JVM unit tests pass.