### PR TITLE
refactor: lowercase the app display name to bose

### DIFF
--- a/macos/BoseControl/Info.plist
+++ b/macos/BoseControl/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>Bose</string>
+	<string>bose</string>
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Bose</string>
+	<string>bose</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build "Bose.app" — the windowed macOS controller.
+# Build "bose.app" — the windowed macOS controller.
 #
 # The app is a THIN FRONT-END over `bose`: it shells the CLI for every read
 # (`info --json`) and write (anc/volume/eq/multipoint/anc-depth/connect/profile).
@@ -15,7 +15,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BUILD_DIR="$SCRIPT_DIR/build"
-APP_NAME="Bose"
+APP_NAME="bose"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
 RESOURCES_DIR="$APP_BUNDLE/Contents/Resources"


### PR DESCRIPTION
Lowercase the visible app name to `bose` (matches the CLI). Bundle is now `bose.app` with CFBundleName/CFBundleExecutable = `bose`; bundle ID unchanged so macOS permissions + Hammerspoon (finds the app by bundle ID) keep working. Verified: live app reports LSDisplayName=bose.