### PR TITLE
feat: Katrina's Apple TV device button (Mac + S21 + CLI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,9 +197,12 @@ own MAC. Use `getConnectedDevices` (05,01) for audio-active devices and
 | ipad | F4:81:C4:B5:FA:AB | yes | |
 | iphone | F8:4D:89:C4:B6:ED | yes | |
 | tv | 14:C1:4E:B7:CB:68 | macOS only | Chromecast |
+| appletv | 48:E1:5C:5D:33:B6 | macOS + S21 in-app | Katrina's Apple TV 4K (label "Katrina's Apple TV"; `widget=false` → no home-screen widget) |
 | quest | 78:C4:FA:C8:5C:3D | yes | Meta Quest 3 |
 
-**Cycle order** (bose): `mac → quest → ipad → iphone → tv → phone`
+A device's optional `label` (devices.toml) is the friendly display name shared by the Mac app + S21 in-app tile; absent → fall back to the key.
+
+**Cycle order** (bose): `mac → quest → ipad → iphone → tv → appletv → phone`
 
 ## BMAP Function IDs (Block 0x04 — DeviceManagement)
 

--- a/android/app/src/generated/java/au/com/jd/bose/BMAP.generated.kt
+++ b/android/app/src/generated/java/au/com/jd/bose/BMAP.generated.kt
@@ -6,7 +6,7 @@ package au.com.jd.bose
 
 enum class BMAPOperator(val v: Int) { GET(0x01), SET_GET(0x02), RESP(0x03), ERROR(0x04), START(0x05), SET(0x06), ACK(0x07) }
 
-enum class AncMode(val v: Int) { QUIET(0), AWARE(1), CUSTOM1(2), CUSTOM2(3) }
+enum class AncMode(val v: Int) { QUIET(0), AWARE(1), IMMERSION(2), CINEMA(3), CUSTOM1(4), CUSTOM2(5), OFF(255) }
 enum class EqBand(val v: Int) { BASS(0), MID(1), TREBLE(2) }
 enum class MediaAction(val v: Int) { PLAY(1), PAUSE(2), NEXT(3), PREV(4) }
 

--- a/android/app/src/generated/java/au/com/jd/bose/Devices.generated.kt
+++ b/android/app/src/generated/java/au/com/jd/bose/Devices.generated.kt
@@ -15,6 +15,7 @@ data class BoseDevice(
     val name: String,
     val mac: ByteArray,
     val widget: Boolean,
+    val label: String? = null,  // friendly display name; null -> fall back to name
 ) {
     val macString: String get() = mac.joinToString(":") { "%02X".format(it) }
 
@@ -22,30 +23,33 @@ data class BoseDevice(
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is BoseDevice) return false
-        return name == other.name && mac.contentEquals(other.mac) && widget == other.widget
+        return name == other.name && mac.contentEquals(other.mac) &&
+            widget == other.widget && label == other.label
     }
 
     override fun hashCode(): Int =
-        (name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()
+        ((name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()) * 31 +
+            (label?.hashCode() ?: 0)
 }
 
 /** Single source of truth for the paired device map (from devices.toml). */
 object BoseDeviceMap {
     /** All known devices, in cycle order. */
     val knownDevices: List<BoseDevice> = listOf(
-        BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true),
-        BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true),
-        BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true),
-        BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true),
-        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false),
-        BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true),
+        BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true, label = null),
+        BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null),
+        BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true, label = null),
+        BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true, label = null),
+        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null),
+        BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV"),
+        BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null),
     )
 
     /** name -> device, insertion-ordered to match cycle order. */
     val byName: Map<String, BoseDevice> =
         knownDevices.associateByTo(LinkedHashMap()) { it.name }
 
-    val CYCLE_ORDER = listOf("mac", "quest", "ipad", "iphone", "tv", "phone")
+    val CYCLE_ORDER = listOf("mac", "quest", "ipad", "iphone", "tv", "appletv", "phone")
 
     /** Devices that get a home-screen widget button (excludes macOS-only ones). */
     val widgetDevices: List<BoseDevice> = knownDevices.filter { it.widget }

--- a/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
+++ b/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
@@ -525,49 +525,61 @@ fun DevicesSection(
     state: BoseViewModel.UiState,
     onSwitch: (String) -> Unit,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        for ((name, deviceState) in state.deviceStates) {
-            val (bgColor, textColor, borderColor) = when (deviceState) {
-                BoseViewModel.DeviceState.ACTIVE ->
-                    Triple(BoseActiveBg, BoseAccent, BoseAccent)
-                BoseViewModel.DeviceState.CONNECTED ->
-                    Triple(Color(0xFFE9EFF6), BoseConnected, BoseConnected)
-                BoseViewModel.DeviceState.OFFLINE ->
-                    Triple(BoseCardBg, BoseDim, BoseHair)
-            }
-
-            Surface(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(56.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .border(1.dp, borderColor, RoundedCornerShape(12.dp))
-                    .clickable { onSwitch(name) },
-                color = bgColor,
-                shape = RoundedCornerShape(12.dp),
+    // Wrap into rows of 4 so 7 devices don't get cramped on the S21. The last
+    // row is padded with invisible weight spacers to keep tile widths uniform.
+    val perRow = 4
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        for (rowItems in state.deviceStates.toList().chunked(perRow)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            text = name,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.Bold,
-                            color = textColor,
-                            textAlign = TextAlign.Center,
-                        )
-                        // State dot
-                        Box(
-                            modifier = Modifier
-                                .padding(top = 4.dp)
-                                .size(6.dp)
-                                .clip(CircleShape)
-                                .background(borderColor),
-                        )
+                for ((name, deviceState) in rowItems) {
+                    val (bgColor, textColor, borderColor) = when (deviceState) {
+                        BoseViewModel.DeviceState.ACTIVE ->
+                            Triple(BoseActiveBg, BoseAccent, BoseAccent)
+                        BoseViewModel.DeviceState.CONNECTED ->
+                            Triple(Color(0xFFE9EFF6), BoseConnected, BoseConnected)
+                        BoseViewModel.DeviceState.OFFLINE ->
+                            Triple(BoseCardBg, BoseDim, BoseHair)
+                    }
+
+                    Surface(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(56.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .border(1.dp, borderColor, RoundedCornerShape(12.dp))
+                            .clickable { onSwitch(name) },
+                        color = bgColor,
+                        shape = RoundedCornerShape(12.dp),
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    // friendly label from the device map; fall back to the key
+                                    text = BoseDeviceMap.byName[name]?.label ?: name,
+                                    fontSize = 11.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = textColor,
+                                    textAlign = TextAlign.Center,
+                                    maxLines = 2,
+                                    lineHeight = 13.sp,
+                                )
+                                // State dot
+                                Box(
+                                    modifier = Modifier
+                                        .padding(top = 4.dp)
+                                        .size(6.dp)
+                                        .clip(CircleShape)
+                                        .background(borderColor),
+                                )
+                            }
+                        }
                     }
                 }
+                // Pad the short final row so tiles keep a consistent width.
+                repeat(perRow - rowItems.size) { Spacer(modifier = Modifier.weight(1f)) }
             }
         }
     }

--- a/macos/BoseControl/BoseApp.swift
+++ b/macos/BoseControl/BoseApp.swift
@@ -18,7 +18,7 @@ struct BoseControlApp: App {
                     manager.refreshState()
                 }
         }
-        .defaultSize(width: 640, height: 360)
+        .defaultSize(width: 640, height: 420)
         .windowResizability(.contentSize)
         .windowStyle(.hiddenTitleBar)  // no title bar chrome — paper runs edge-to-edge
     }

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -38,7 +38,7 @@ final class BoseManager: ObservableObject {
     // Device routing states: "active" / "connected" / "offline"
     @Published var deviceStates: [String: String] = [
         "mac": "offline", "phone": "offline", "ipad": "offline",
-        "iphone": "offline", "tv": "offline", "quest": "offline",
+        "iphone": "offline", "tv": "offline", "appletv": "offline", "quest": "offline",
     ]
 
     // MARK: - Pending-write state (drives the "applying / connecting" UI)

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -34,6 +34,7 @@ private let deviceButtons: [DeviceButton] = [
     DeviceButton(id: "ipad", label: "iPad", symbol: "ipad"),
     DeviceButton(id: "iphone", label: "iPhone", symbol: "iphone"),
     DeviceButton(id: "tv", label: "TV", symbol: "tv"),
+    DeviceButton(id: "appletv", label: "Katrina's Apple TV", symbol: "appletv"),
     DeviceButton(id: "quest", label: "Quest", symbol: "visionpro"),
 ]
 
@@ -56,7 +57,7 @@ struct ContentView: View {
                 disconnectedView
             }
         }
-        .frame(width: 640, height: 360)
+        .frame(width: 640, height: 420)  // 420 fits a 3rd device-grid row (7 devices)
         .background(paperColor)
         .preferredColorScheme(.light)
         .onAppear {
@@ -300,8 +301,9 @@ struct ContentView: View {
                 Text(isConnecting ? "Connecting…" : button.label)
                     .font(.system(size: 10, weight: .medium))
                     .foregroundColor(textColor)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.7)
             }
             .frame(maxWidth: .infinity)
             .frame(height: 52)

--- a/protocol/codegen/emit_devices.py
+++ b/protocol/codegen/emit_devices.py
@@ -64,6 +64,7 @@ def emit_devices_swift(spec: dict) -> str:
     lines.append("    let name: String")
     lines.append("    let mac: [UInt8]")
     lines.append("    let widget: Bool")
+    lines.append("    let label: String?  // friendly display name; nil -> fall back to name")
     lines.append("    var id: String { name }")
     lines.append("    var macString: String {")
     lines.append('        mac.map { String(format: "%02X", $0) }.joined(separator: ":")')
@@ -76,8 +77,11 @@ def emit_devices_swift(spec: dict) -> str:
     for name in cycle:
         d = devices[name]
         widget = "true" if d.get("widget", False) else "false"
+        label = d.get("label")
+        label_lit = f'"{label}"' if label else "nil"
         lines.append(
-            f'        BoseDevice(name: "{name}", mac: [{_mac_bytes_literal(d["mac"])}], widget: {widget}),'
+            f'        BoseDevice(name: "{name}", mac: [{_mac_bytes_literal(d["mac"])}], '
+            f"widget: {widget}, label: {label_lit}),"
         )
     lines.append("    ]")
     lines.append("")
@@ -118,6 +122,7 @@ def emit_devices_kotlin(spec: dict) -> str:
     lines.append("    val name: String,")
     lines.append("    val mac: ByteArray,")
     lines.append("    val widget: Boolean,")
+    lines.append("    val label: String? = null,  // friendly display name; null -> fall back to name")
     lines.append(") {")
     lines.append('    val macString: String get() = mac.joinToString(":") { "%02X".format(it) }')
     lines.append("")
@@ -125,11 +130,13 @@ def emit_devices_kotlin(spec: dict) -> str:
     lines.append("    override fun equals(other: Any?): Boolean {")
     lines.append("        if (this === other) return true")
     lines.append("        if (other !is BoseDevice) return false")
-    lines.append("        return name == other.name && mac.contentEquals(other.mac) && widget == other.widget")
+    lines.append("        return name == other.name && mac.contentEquals(other.mac) &&")
+    lines.append("            widget == other.widget && label == other.label")
     lines.append("    }")
     lines.append("")
     lines.append("    override fun hashCode(): Int =")
-    lines.append("        (name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()")
+    lines.append("        ((name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()) * 31 +")
+    lines.append("            (label?.hashCode() ?: 0)")
     lines.append("}")
     lines.append("")
     lines.append("/** Single source of truth for the paired device map (from devices.toml). */")
@@ -139,8 +146,11 @@ def emit_devices_kotlin(spec: dict) -> str:
     for name in cycle:
         d = devices[name]
         widget = "true" if d.get("widget", False) else "false"
+        label = d.get("label")
+        label_lit = f'"{label}"' if label else "null"
         lines.append(
-            f'        BoseDevice("{name}", byteArrayOf({_kt_mac_bytes_literal(d["mac"])}), widget = {widget}),'
+            f'        BoseDevice("{name}", byteArrayOf({_kt_mac_bytes_literal(d["mac"])}), '
+            f"widget = {widget}, label = {label_lit}),"
         )
     lines.append("    )")
     lines.append("")

--- a/protocol/generated/Devices.generated.kt
+++ b/protocol/generated/Devices.generated.kt
@@ -15,6 +15,7 @@ data class BoseDevice(
     val name: String,
     val mac: ByteArray,
     val widget: Boolean,
+    val label: String? = null,  // friendly display name; null -> fall back to name
 ) {
     val macString: String get() = mac.joinToString(":") { "%02X".format(it) }
 
@@ -22,30 +23,33 @@ data class BoseDevice(
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is BoseDevice) return false
-        return name == other.name && mac.contentEquals(other.mac) && widget == other.widget
+        return name == other.name && mac.contentEquals(other.mac) &&
+            widget == other.widget && label == other.label
     }
 
     override fun hashCode(): Int =
-        (name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()
+        ((name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()) * 31 +
+            (label?.hashCode() ?: 0)
 }
 
 /** Single source of truth for the paired device map (from devices.toml). */
 object BoseDeviceMap {
     /** All known devices, in cycle order. */
     val knownDevices: List<BoseDevice> = listOf(
-        BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true),
-        BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true),
-        BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true),
-        BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true),
-        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false),
-        BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true),
+        BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true, label = null),
+        BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null),
+        BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true, label = null),
+        BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true, label = null),
+        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null),
+        BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV"),
+        BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null),
     )
 
     /** name -> device, insertion-ordered to match cycle order. */
     val byName: Map<String, BoseDevice> =
         knownDevices.associateByTo(LinkedHashMap()) { it.name }
 
-    val CYCLE_ORDER = listOf("mac", "quest", "ipad", "iphone", "tv", "phone")
+    val CYCLE_ORDER = listOf("mac", "quest", "ipad", "iphone", "tv", "appletv", "phone")
 
     /** Devices that get a home-screen widget button (excludes macOS-only ones). */
     val widgetDevices: List<BoseDevice> = knownDevices.filter { it.widget }

--- a/protocol/generated/Devices.generated.swift
+++ b/protocol/generated/Devices.generated.swift
@@ -16,6 +16,7 @@ struct BoseDevice: Identifiable {
     let name: String
     let mac: [UInt8]
     let widget: Bool
+    let label: String?  // friendly display name; nil -> fall back to name
     var id: String { name }
     var macString: String {
         mac.map { String(format: "%02X", $0) }.joined(separator: ":")
@@ -24,15 +25,16 @@ struct BoseDevice: Identifiable {
 
 enum BoseDeviceMap {
     static let knownDevices: [BoseDevice] = [
-        BoseDevice(name: "mac", mac: [0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x27], widget: true),
-        BoseDevice(name: "quest", mac: [0x78, 0xC4, 0xFA, 0xC8, 0x5C, 0x3D], widget: true),
-        BoseDevice(name: "ipad", mac: [0xF4, 0x81, 0xC4, 0xB5, 0xFA, 0xAB], widget: true),
-        BoseDevice(name: "iphone", mac: [0xF8, 0x4D, 0x89, 0xC4, 0xB6, 0xED], widget: true),
-        BoseDevice(name: "tv", mac: [0x14, 0xC1, 0x4E, 0xB7, 0xCB, 0x68], widget: false),
-        BoseDevice(name: "phone", mac: [0xA8, 0x76, 0x50, 0xD3, 0xB1, 0x1B], widget: true),
+        BoseDevice(name: "mac", mac: [0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x27], widget: true, label: nil),
+        BoseDevice(name: "quest", mac: [0x78, 0xC4, 0xFA, 0xC8, 0x5C, 0x3D], widget: true, label: nil),
+        BoseDevice(name: "ipad", mac: [0xF4, 0x81, 0xC4, 0xB5, 0xFA, 0xAB], widget: true, label: nil),
+        BoseDevice(name: "iphone", mac: [0xF8, 0x4D, 0x89, 0xC4, 0xB6, 0xED], widget: true, label: nil),
+        BoseDevice(name: "tv", mac: [0x14, 0xC1, 0x4E, 0xB7, 0xCB, 0x68], widget: false, label: nil),
+        BoseDevice(name: "appletv", mac: [0x48, 0xE1, 0x5C, 0x5D, 0x33, 0xB6], widget: false, label: "Katrina's Apple TV"),
+        BoseDevice(name: "phone", mac: [0xA8, 0x76, 0x50, 0xD3, 0xB1, 0x1B], widget: true, label: nil),
     ]
 
-    static let cycleOrder = ["mac", "quest", "ipad", "iphone", "tv", "phone"]
+    static let cycleOrder = ["mac", "quest", "ipad", "iphone", "tv", "appletv", "phone"]
 
     static func device(_ name: String) -> BoseDevice? {
         knownDevices.first { $0.name == name.lowercased() }

--- a/protocol/spec/bmap.toml
+++ b/protocol/spec/bmap.toml
@@ -186,9 +186,12 @@ payload = ["00", "mac:mac"]
 [commands.connect_device.verified_bytes]
 # `04,01,05,07,00,{MAC}` — mac device from device map (BC:D0:74:11:DB:27)
 connect_mac = "04 01 05 07 00 BC D0 74 11 DB 27"
+# appletv (Katrina's Apple TV) — 48:E1:5C:5D:33:B6
+connect_appletv = "04 01 05 07 00 48 E1 5C 5D 33 B6"
 
 [commands.connect_device.test_args]
 connect_mac = { mac = "BC:D0:74:11:DB:27" }
+connect_appletv = { mac = "48:E1:5C:5D:33:B6" }
 
 [commands.disconnect_device]
 block = 0x04

--- a/protocol/spec/devices.toml
+++ b/protocol/spec/devices.toml
@@ -5,9 +5,9 @@
 headphone_mac = "E4:58:BC:C0:2F:72"
 headphone_name = "verBosita"
 
-# Cycle order for the bose-ctl / hotkey device switch (CLAUDE.md):
-# mac -> quest -> ipad -> iphone -> tv -> phone
-cycle_order = ["mac", "quest", "ipad", "iphone", "tv", "phone"]
+# Cycle order for the bose / hotkey device switch (CLAUDE.md):
+# mac -> quest -> ipad -> iphone -> tv -> appletv -> phone
+cycle_order = ["mac", "quest", "ipad", "iphone", "tv", "appletv", "phone"]
 
 [devices.phone]
 mac = "A8:76:50:D3:B1:1B"
@@ -38,3 +38,9 @@ notes = "Chromecast (macOS only)"
 mac = "78:C4:FA:C8:5C:3D"
 widget = true
 notes = "Meta Quest 3"
+
+[devices.appletv]
+mac = "48:E1:5C:5D:33:B6"          # captured live from connected_devices (05,01); 48:E1:5C = Apple OUI
+label = "Katrina's Apple TV"
+widget = false          # macOS app + S21 in-app tile only — no Android home-screen widget
+notes = "Lounge Room Apple TV 4K (gen 3)"

--- a/protocol/tests/test_emit_devices.py
+++ b/protocol/tests/test_emit_devices.py
@@ -28,5 +28,17 @@ def test_emits_device_list_with_mac_bytes():
 
 def test_emits_cycle_order():
     src = emit_devices_swift(SPEC)
-    # mac -> quest -> ipad -> iphone -> tv -> phone
-    assert 'static let cycleOrder = ["mac", "quest", "ipad", "iphone", "tv", "phone"]' in src
+    # mac -> quest -> ipad -> iphone -> tv -> appletv -> phone
+    assert (
+        'static let cycleOrder = ["mac", "quest", "ipad", "iphone", "tv", "appletv", "phone"]'
+        in src
+    )
+
+
+def test_emits_optional_label_field():
+    src = emit_devices_swift(SPEC)
+    # BoseDevice carries an optional friendly label.
+    assert "let label: String?" in src
+    # appletv has a friendly label; devices without one emit nil.
+    assert 'label: "Katrina\'s Apple TV"' in src
+    assert "label: nil" in src

--- a/protocol/tests/test_emit_devices_kotlin.py
+++ b/protocol/tests/test_emit_devices_kotlin.py
@@ -29,7 +29,18 @@ def test_emits_device_map_with_mac_bytes():
 
 def test_emits_cycle_order():
     src = emit_devices_kotlin(SPEC)
-    assert 'val CYCLE_ORDER = listOf("mac", "quest", "ipad", "iphone", "tv", "phone")' in src
+    assert (
+        'val CYCLE_ORDER = listOf("mac", "quest", "ipad", "iphone", "tv", "appletv", "phone")'
+        in src
+    )
+
+
+def test_emits_optional_label_field():
+    src = emit_devices_kotlin(SPEC)
+    # BoseDevice carries an optional friendly label (null -> fall back to name).
+    assert "val label: String? = null" in src
+    assert 'label = "Katrina\'s Apple TV"' in src
+    assert "label = null" in src
 
 
 def test_emits_widget_set_excludes_tv():

--- a/raycast/bose-connect.sh
+++ b/raycast/bose-connect.sh
@@ -7,6 +7,6 @@
 # @raycast.mode compact
 # @raycast.icon 🎧
 # @raycast.packageName Bose
-# @raycast.argument1 { "type": "dropdown", "placeholder": "Device", "data": [{"title":"Mac","value":"mac"},{"title":"Phone","value":"phone"},{"title":"iPad","value":"ipad"},{"title":"iPhone","value":"iphone"},{"title":"Quest","value":"quest"},{"title":"TV","value":"tv"}] }
+# @raycast.argument1 { "type": "dropdown", "placeholder": "Device", "data": [{"title":"Mac","value":"mac"},{"title":"Phone","value":"phone"},{"title":"iPad","value":"ipad"},{"title":"iPhone","value":"iphone"},{"title":"Quest","value":"quest"},{"title":"TV","value":"tv"},{"title":"Apple TV","value":"appletv"}] }
 
 "$HOME/bin/bose" connect "$1"


### PR DESCRIPTION
Add a **Katrina's Apple TV** device so the headphones can be routed to the Apple TV from the Mac app, the S21, and the CLI — headphone-side, no tvOS Settings.

**MAC** `48:E1:5C:5D:33:B6` (Apple OUI) — captured live from `connected_devices` (05,01) while the headphones were on the Apple TV.

- **Protocol (single source):** optional `label` field threaded through the Swift + Kotlin emitters (+ tests); `[devices.appletv]` with `label="Katrina's Apple TV"`, `widget=false`; `connect_appletv` golden (`04 01 05 07 00 48 E1 5C 5D 33 B6`); added to `cycle_order`. `make check` clean, 31 tests pass.
- **CLI:** `bose connect appletv` verified live (`● appletv`).
- **Mac app:** new tile (appletv SF Symbol); 2-line labels; window 360→420 so the 3rd grid row + EQ aren't clipped.
- **S21 in-app:** friendly label via `BoseDeviceMap.byName[name]?.label`; tiles wrap into rows of 4 so 7 fit. APK built + installed.
- **Raycast:** Apple TV added to the connect dropdown.

No Android home-screen widget (matches the Chromecast `tv` treatment).