### PR TITLE
feat: deterministic multipoint priority eviction (CLI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,17 @@ own MAC. Use `getConnectedDevices` (05,01) for audio-active devices and
 
 A device's optional `label` (devices.toml) is the friendly display name shared by the Mac app + S21 in-app tile; absent → fall back to the key.
 
+**Connection priority** (`priority` in devices.toml; 1 = highest):
+`1 mac → 2 phone → 3 appletv → 4 ipad → 5 quest → 6 tv → 7 iphone`.
+The headset holds 2 devices (multipoint) and the firmware only evicts by its own LRU
+(`ConnectionPriority 0x10` is FuncNotSupp — see `docs/reverse-engineering.md`). So the
+CLI's `connect`/`swap` enforce the hierarchy in software: when both slots are full and
+the target isn't already connected, it **disconnects the lowest-priority of the two held
+devices first**, then pages the target — and **restores the evicted device if the target
+fails to connect** (`evictLowestPriorityIfFull` / `restoreEvicted` in `cli/main.swift`).
+Mac app / Raycast / Hammerspoon inherit this (they shell `bose`). **Android does NOT yet
+replicate it** (TODO — parity).
+
 **Cycle order** (bose): `mac → quest → ipad → iphone → tv → appletv → phone`
 
 ## BMAP Function IDs (Block 0x04 — DeviceManagement)

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -337,9 +337,42 @@ func cmdDevices() {
     }
 }
 
+/// Deterministic multipoint eviction. The headset holds at most 2 devices and the
+/// firmware only evicts by its own LRU. When both slots are full and `target` isn't
+/// already one of them, drop the LOWEST-priority (highest `priority` number) of the
+/// two held devices first, so the caller's connect lands the new device against the
+/// hierarchy in devices.toml instead of whatever the firmware would have dropped.
+/// Returns the device it evicted (so the caller can restore it if the connect that
+/// follows fails to land — never leave a multipoint slot empty for nothing).
+@discardableResult
+func evictLowestPriorityIfFull(target: [UInt8]) -> BoseDevice? {
+    guard let st = transport.getDeviceStates(query: BoseDeviceMap.knownDevices.map { $0.mac })
+    else { return nil }
+    let targetKey = macString(target)
+    var heldKeys = Set<String>()
+    for m in st.active + st.connected { heldKeys.insert(macString(m)) }
+    if heldKeys.contains(targetKey) { return nil }   // already connected — nothing to evict
+    if heldKeys.count < 2 { return nil }             // a slot is free — no eviction needed
+    let held = BoseDeviceMap.knownDevices.filter { heldKeys.contains(macString($0.mac)) }
+    guard let victim = held.max(by: { $0.priority < $1.priority }) else { return nil }
+    _ = transport.oneShot(BMAP.disconnectDevice(mac: victim.mac))
+    if isMacDevice(victim.mac) { runBlueutil(["--disconnect", Headphone.mac]) }
+    print("Evicted \(victim.name) (priority \(victim.priority)) to free a multipoint slot")
+    Thread.sleep(forTimeInterval: 0.8)           // let the slot clear before paging the target
+    return victim
+}
+
+/// Re-page a device we evicted, after the target connect failed — restores the prior pair.
+func restoreEvicted(_ victim: BoseDevice, failedTarget: String) {
+    _ = transport.oneShot(BMAP.connectDevice(mac: victim.mac))
+    if isMacDevice(victim.mac) { runBlueutil(["--connect", Headphone.mac]) }
+    print("Restored \(victim.name) (target \(failedTarget) was unreachable)")
+}
+
 /// connect / c <device> — poll-confirm via getConnectedDevices (ACK is NOT success).
 func cmdConnect(_ deviceName: String) {
     let mac = macForName(deviceName)
+    let evicted = evictLowestPriorityIfFull(target: mac)
 
     // For the Mac itself, ensure A2DP first (macOS link), like v1/the app.
     if isMacDevice(mac) {
@@ -352,7 +385,9 @@ func cmdConnect(_ deviceName: String) {
     switch confirmConnect(mac) {
     case .active: print("Connected \(deviceName)")
     case .idle:   print("Connected \(deviceName) (idle — audio stayed on the active device; multipoint)")
-    case .none:   fail("connect \(deviceName) not confirmed within timeout")
+    case .none:
+        if let evicted = evicted { restoreEvicted(evicted, failedTarget: deviceName) }
+        fail("connect \(deviceName) not confirmed within timeout")
     }
 }
 
@@ -361,6 +396,7 @@ func cmdConnect(_ deviceName: String) {
 /// "Disconnect others" — it never disconnected anything; corrected here + in usage.)
 func cmdSwap(_ targetName: String) {
     let mac = macForName(targetName)
+    let evicted = evictLowestPriorityIfFull(target: mac)
 
     if isMacDevice(mac) {
         runBlueutil(["--connect", Headphone.mac])
@@ -372,7 +408,9 @@ func cmdSwap(_ targetName: String) {
     switch confirmConnect(mac) {
     case .active: print("Swapped to \(targetName)")
     case .idle:   print("Connected \(targetName) (idle — audio stayed on the active device; multipoint)")
-    case .none:   fail("swap to \(targetName) not confirmed within timeout")
+    case .none:
+        if let evicted = evicted { restoreEvicted(evicted, failedTarget: targetName) }
+        fail("swap to \(targetName) not confirmed within timeout")
     }
 }
 

--- a/protocol/codegen/emit_devices.py
+++ b/protocol/codegen/emit_devices.py
@@ -65,6 +65,7 @@ def emit_devices_swift(spec: dict) -> str:
     lines.append("    let mac: [UInt8]")
     lines.append("    let widget: Bool")
     lines.append("    let label: String?  // friendly display name; nil -> fall back to name")
+    lines.append("    let priority: Int   // 1 = highest; lowest-priority held device is evicted on a full-multipoint connect")
     lines.append("    var id: String { name }")
     lines.append("    var macString: String {")
     lines.append('        mac.map { String(format: "%02X", $0) }.joined(separator: ":")')
@@ -79,9 +80,10 @@ def emit_devices_swift(spec: dict) -> str:
         widget = "true" if d.get("widget", False) else "false"
         label = d.get("label")
         label_lit = f'"{label}"' if label else "nil"
+        prio = d.get("priority", 999)
         lines.append(
             f'        BoseDevice(name: "{name}", mac: [{_mac_bytes_literal(d["mac"])}], '
-            f"widget: {widget}, label: {label_lit}),"
+            f"widget: {widget}, label: {label_lit}, priority: {prio}),"
         )
     lines.append("    ]")
     lines.append("")
@@ -123,6 +125,7 @@ def emit_devices_kotlin(spec: dict) -> str:
     lines.append("    val mac: ByteArray,")
     lines.append("    val widget: Boolean,")
     lines.append("    val label: String? = null,  // friendly display name; null -> fall back to name")
+    lines.append("    val priority: Int = 999,  // 1 = highest; lowest-priority held device is evicted on a full-multipoint connect")
     lines.append(") {")
     lines.append('    val macString: String get() = mac.joinToString(":") { "%02X".format(it) }')
     lines.append("")
@@ -131,12 +134,12 @@ def emit_devices_kotlin(spec: dict) -> str:
     lines.append("        if (this === other) return true")
     lines.append("        if (other !is BoseDevice) return false")
     lines.append("        return name == other.name && mac.contentEquals(other.mac) &&")
-    lines.append("            widget == other.widget && label == other.label")
+    lines.append("            widget == other.widget && label == other.label && priority == other.priority")
     lines.append("    }")
     lines.append("")
     lines.append("    override fun hashCode(): Int =")
-    lines.append("        ((name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()) * 31 +")
-    lines.append("            (label?.hashCode() ?: 0)")
+    lines.append("        (((name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()) * 31 +")
+    lines.append("            (label?.hashCode() ?: 0)) * 31 + priority")
     lines.append("}")
     lines.append("")
     lines.append("/** Single source of truth for the paired device map (from devices.toml). */")
@@ -148,9 +151,10 @@ def emit_devices_kotlin(spec: dict) -> str:
         widget = "true" if d.get("widget", False) else "false"
         label = d.get("label")
         label_lit = f'"{label}"' if label else "null"
+        prio = d.get("priority", 999)
         lines.append(
             f'        BoseDevice("{name}", byteArrayOf({_kt_mac_bytes_literal(d["mac"])}), '
-            f"widget = {widget}, label = {label_lit}),"
+            f"widget = {widget}, label = {label_lit}, priority = {prio}),"
         )
     lines.append("    )")
     lines.append("")

--- a/protocol/generated/Devices.generated.kt
+++ b/protocol/generated/Devices.generated.kt
@@ -16,6 +16,7 @@ data class BoseDevice(
     val mac: ByteArray,
     val widget: Boolean,
     val label: String? = null,  // friendly display name; null -> fall back to name
+    val priority: Int = 999,  // 1 = highest; lowest-priority held device is evicted on a full-multipoint connect
 ) {
     val macString: String get() = mac.joinToString(":") { "%02X".format(it) }
 
@@ -24,25 +25,25 @@ data class BoseDevice(
         if (this === other) return true
         if (other !is BoseDevice) return false
         return name == other.name && mac.contentEquals(other.mac) &&
-            widget == other.widget && label == other.label
+            widget == other.widget && label == other.label && priority == other.priority
     }
 
     override fun hashCode(): Int =
-        ((name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()) * 31 +
-            (label?.hashCode() ?: 0)
+        (((name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()) * 31 +
+            (label?.hashCode() ?: 0)) * 31 + priority
 }
 
 /** Single source of truth for the paired device map (from devices.toml). */
 object BoseDeviceMap {
     /** All known devices, in cycle order. */
     val knownDevices: List<BoseDevice> = listOf(
-        BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true, label = null),
-        BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null),
-        BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true, label = null),
-        BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true, label = null),
-        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null),
-        BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV"),
-        BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null),
+        BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true, label = null, priority = 1),
+        BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null, priority = 5),
+        BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true, label = null, priority = 4),
+        BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true, label = null, priority = 7),
+        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null, priority = 6),
+        BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV", priority = 3),
+        BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null, priority = 2),
     )
 
     /** name -> device, insertion-ordered to match cycle order. */

--- a/protocol/generated/Devices.generated.swift
+++ b/protocol/generated/Devices.generated.swift
@@ -17,6 +17,7 @@ struct BoseDevice: Identifiable {
     let mac: [UInt8]
     let widget: Bool
     let label: String?  // friendly display name; nil -> fall back to name
+    let priority: Int   // 1 = highest; lowest-priority held device is evicted on a full-multipoint connect
     var id: String { name }
     var macString: String {
         mac.map { String(format: "%02X", $0) }.joined(separator: ":")
@@ -25,13 +26,13 @@ struct BoseDevice: Identifiable {
 
 enum BoseDeviceMap {
     static let knownDevices: [BoseDevice] = [
-        BoseDevice(name: "mac", mac: [0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x27], widget: true, label: nil),
-        BoseDevice(name: "quest", mac: [0x78, 0xC4, 0xFA, 0xC8, 0x5C, 0x3D], widget: true, label: nil),
-        BoseDevice(name: "ipad", mac: [0xF4, 0x81, 0xC4, 0xB5, 0xFA, 0xAB], widget: true, label: nil),
-        BoseDevice(name: "iphone", mac: [0xF8, 0x4D, 0x89, 0xC4, 0xB6, 0xED], widget: true, label: nil),
-        BoseDevice(name: "tv", mac: [0x14, 0xC1, 0x4E, 0xB7, 0xCB, 0x68], widget: false, label: nil),
-        BoseDevice(name: "appletv", mac: [0x48, 0xE1, 0x5C, 0x5D, 0x33, 0xB6], widget: false, label: "Katrina's Apple TV"),
-        BoseDevice(name: "phone", mac: [0xA8, 0x76, 0x50, 0xD3, 0xB1, 0x1B], widget: true, label: nil),
+        BoseDevice(name: "mac", mac: [0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x27], widget: true, label: nil, priority: 1),
+        BoseDevice(name: "quest", mac: [0x78, 0xC4, 0xFA, 0xC8, 0x5C, 0x3D], widget: true, label: nil, priority: 5),
+        BoseDevice(name: "ipad", mac: [0xF4, 0x81, 0xC4, 0xB5, 0xFA, 0xAB], widget: true, label: nil, priority: 4),
+        BoseDevice(name: "iphone", mac: [0xF8, 0x4D, 0x89, 0xC4, 0xB6, 0xED], widget: true, label: nil, priority: 7),
+        BoseDevice(name: "tv", mac: [0x14, 0xC1, 0x4E, 0xB7, 0xCB, 0x68], widget: false, label: nil, priority: 6),
+        BoseDevice(name: "appletv", mac: [0x48, 0xE1, 0x5C, 0x5D, 0x33, 0xB6], widget: false, label: "Katrina's Apple TV", priority: 3),
+        BoseDevice(name: "phone", mac: [0xA8, 0x76, 0x50, 0xD3, 0xB1, 0x1B], widget: true, label: nil, priority: 2),
     ]
 
     static let cycleOrder = ["mac", "quest", "ipad", "iphone", "tv", "appletv", "phone"]

--- a/protocol/spec/devices.toml
+++ b/protocol/spec/devices.toml
@@ -11,36 +11,43 @@ cycle_order = ["mac", "quest", "ipad", "iphone", "tv", "appletv", "phone"]
 
 [devices.phone]
 mac = "A8:76:50:D3:B1:1B"
+priority = 2
 widget = true
 notes = "Samsung S21 (local device)"
 
 [devices.mac]
 mac = "BC:D0:74:11:DB:27"
+priority = 1
 widget = true
 notes = "MacBook"
 
 [devices.ipad]
 mac = "F4:81:C4:B5:FA:AB"
+priority = 4
 widget = true
 notes = ""
 
 [devices.iphone]
 mac = "F8:4D:89:C4:B6:ED"
+priority = 7
 widget = true
 notes = ""
 
 [devices.tv]
 mac = "14:C1:4E:B7:CB:68"
+priority = 6
 widget = false          # CLAUDE.md: "macOS only" — no Android widget button
 notes = "Chromecast (macOS only)"
 
 [devices.quest]
 mac = "78:C4:FA:C8:5C:3D"
+priority = 5
 widget = true
 notes = "Meta Quest 3"
 
 [devices.appletv]
 mac = "48:E1:5C:5D:33:B6"          # captured live from connected_devices (05,01); 48:E1:5C = Apple OUI
+priority = 3
 label = "Katrina's Apple TV"
 widget = false          # macOS app + S21 in-app tile only — no Android home-screen widget
 notes = "Lounge Room Apple TV 4K (gen 3)"

--- a/protocol/tests/test_emit_devices.py
+++ b/protocol/tests/test_emit_devices.py
@@ -42,3 +42,10 @@ def test_emits_optional_label_field():
     # appletv has a friendly label; devices without one emit nil.
     assert 'label: "Katrina\'s Apple TV"' in src
     assert "label: nil" in src
+
+
+def test_emits_priority_field():
+    src = emit_devices_swift(SPEC)
+    assert "let priority: Int" in src
+    assert "priority: 1)" in src  # mac — highest priority
+    assert "priority: 2)" in src  # phone


### PR DESCRIPTION
Enforce a software device-priority hierarchy on connect (the firmware's ConnectionPriority 0x10 is FuncNotSupp — see docs/reverse-engineering.md). priority field in devices.toml → codegen; connect/swap evict the lowest-priority of two held devices when full, then page the target, restoring the evicted one on failure. Verified live: evicted phone (prio 2) not mac (prio 1). 32 tests pass. Android parity TODO.