### PR TITLE
fix: auto-route restore race on call-app quit

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-auto-route Mac mic off the Bose during calls (Hammerspoon)
-auto-route Mac mic off the Bose during calls (Hammerspoon)
+auto-route: defer terminated re-scan so restore isn't raced by the dying app
+auto-route: defer terminated re-scan so restore isn't raced by the dying app
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - auto-route-on-call
+# Agent Progress - fix-autoroute-restore
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-19T20:44:14Z
+# Created: 2026-06-19T20:51:06Z
 
-feature=auto-route-on-call
-name=auto-route Mac mic off the Bose during calls (Hammerspoon)
+feature=fix-autoroute-restore
+name=auto-route: defer terminated re-scan so restore isn't raced by the dying app
 status=pending
 step=0
 step_name=Not started
-created=2026-06-19T20:44:14Z
+created=2026-06-19T20:51:06Z

--- a/hammerspoon/bose.lua
+++ b/hammerspoon/bose.lua
@@ -198,9 +198,16 @@ local function onAppEvent(_, eventType, app)
       setMacInput(MAC_MIC)
     end
   elseif eventType == hs.application.watcher.terminated then
-    if savedInputName ~= nil and not anyCallAppRunning() then
-      setMacInput(savedInputName)
-      savedInputName = nil
+    -- Defer the re-scan: at `terminated` time the quitting app can still appear in
+    -- hs.application.get, racing anyCallAppRunning() → the restore is skipped and never
+    -- retried (verified 2026-06-20). 0.5s later the process is gone, so the scan is true.
+    if savedInputName ~= nil then
+      hs.timer.doAfter(0.5, function()
+        if savedInputName ~= nil and not anyCallAppRunning() then
+          setMacInput(savedInputName)
+          savedInputName = nil
+        end
+      end)
     end
   end
 end


### PR DESCRIPTION
The terminated handler re-scanned running call apps synchronously, racing the dying app (it still appears in hs.application.get briefly) → restore skipped, never retried. Deferred the re-scan 0.5s. Found by the verification gate live-test (FaceTime launch flipped input ✓ but quit didn't restore).