### PR TITLE
feat: add verified AutoPlayPause / AutoAnswer / Favorites BMAP commands

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-auto-route: drop unreliable restore (terminated event doesn't fire); keep verified launch-flip + during-call guard
-auto-route: drop unreliable restore (terminated event doesn't fire); keep verified launch-flip + during-call guard
+Add verified 01,18 AutoPlayPause / 01,1B AutoAnswer / 1F,08 Favorites commands to bmap.toml. Closes #119
+Add verified 01,18 AutoPlayPause / 01,1B AutoAnswer / 1F,08 Favorites commands to bmap.toml. Closes #119
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - autoroute-drop-restore
+# Agent Progress - bmap-autopause-answer-favs
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-19T20:55:47Z
+# Created: 2026-06-19T21:18:11Z
 
-feature=autoroute-drop-restore
-name=auto-route: drop unreliable restore (terminated event doesn't fire); keep verified launch-flip + during-call guard
+feature=bmap-autopause-answer-favs
+name=Add verified 01,18 AutoPlayPause / 01,1B AutoAnswer / 1F,08 Favorites commands to bmap.toml. Closes #119
 status=pending
 step=0
 step_name=Not started
-created=2026-06-19T20:55:47Z
+created=2026-06-19T21:18:11Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ explicit user action.
 - Companion device registered for background FGS privileges
 
 ### CLI (`cli/`) — regenerated on the shared layer
-- `cli/main.swift` -- `bose` command surface (status/battery/anc/devices/connect/disconnect/swap/volume/multipoint/play-pause-next-prev/eq/raw). **No inline byte parsing** — every command routes through the generated `BMAP.*` builders. `connect`/`swap` poll-confirm via `getConnectedDevices` (ACK is never success); volume uses the generated SET_GET builder.
+- `cli/main.swift` -- `bose` command surface (status/battery/anc/devices/connect/disconnect/swap/volume/multipoint/auto-pause/auto-answer/favorites/play-pause-next-prev/eq/raw). **No inline byte parsing** — every command routes through the generated `BMAP.*` builders. `connect`/`swap` poll-confirm via `getConnectedDevices` (ACK is never success); volume uses the generated SET_GET builder.
 - `cli/Transport.swift` -- IOBluetooth RFCOMM transport (per-command open/drain-300ms/close, cold-start warm-up, serial queue).
 - `cli/Composites.swift` -- live-channel composites (cncLevel RMW, connectedDevices list, getAllState single-session).
 - `cli/Parsers.swift` -- pure, hardware-free response parsers; `cli/Tests/main.swift` + `cli/run-tests.sh` are the standalone unit tests (same captured-byte corpus as Android `Parsers.kt`).
@@ -264,6 +264,9 @@ BMAP operator (SET/0x06 instead of SET_GET/0x02).
 | Volume | 05,05 | SET_GET | `05,05,02,01,{level}` | 0-31 |
 | Device name | 01,02 | SET | `01,02,06,{len},00,{utf8}` | max 30 UTF-8 bytes |
 | Multipoint | 01,0A | SET_GET | `01,0A,02,01,{07/00}` | SET 07=on/00=off. RESPONSE is a bitfield — bit 0 = enable; fw 8.2.20: on→0x07, off→0x06 (slot bits persist). Parse `& 0x01`, NOT `!= 0` (that misread 0x06 as on, #83). |
+| **Auto-pause** | **01,18** | **SET_GET** | `01,18,02,01,{00/01}` | Pause when headphones are removed. Single bool byte; RESP echoes STATUS (`& 0x01`). Verified live (no-op SET_GET) + app builder. The *setting toggle* — distinct from the live wear STATE (02,09, FuncNotSupp on over-ears). |
+| **Auto-answer** | **01,1B** | **SET_GET** | `01,1B,02,01,{00/01}` | Answer a call when headphones are donned. Single bool byte; RESP echoes STATUS. Verified live + app builder. |
+| **Favorites** | **1F,08** | **SET_GET** | `1F,08,02,{len},{count},{reversed bitmask…}` | Which mode slots are favourited. Payload = count byte + `ceil(count/8)`-byte REVERSED-order bitmask (low modes in the LAST byte). Live: `1F 08 02 03 0b 00 07` = count 11, modes 0/1/2. GET is a generated builder; the SET_GET bitmask + decode are hand-written (`buildFavoritesSetGet`/`parseFavorites`, Swift+Kotlin). |
 | Connect device | 04,01 | START | `04,01,05,07,00,{MAC}` | Also routes audio |
 | Disconnect | 04,02 | START | `04,02,05,06,{MAC}` | |
 | Media control | 05,03 | START | `05,03,05,01,{action}` | 01=play 02=pause 03=next 04=prev |
@@ -320,6 +323,9 @@ surface. Keep this in sync when adding a verb or control.
 | Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
 | EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
 | Multipoint | 01,0A | ✅ `multipoint` | — | — | ✅ toggle |
+| Auto-pause | **01,18** | ✅ `auto-pause` | — | — | — (parser only, no UI) |
+| Auto-answer | **01,1B** | ✅ `auto-answer` | — | — | — |
+| Favorites | **1F,08** | ✅ `favorites` | — | — | — (parser only, no UI) |
 | Connect device | 04,01 | ✅ `connect`/`swap` | ✅ `bose-connect` | ✅ Opt+⇧B toggle · Opt+J → Mac (Opt+B opens app) | ✅ widget/tile/picker |
 | Disconnect device | 04,02 | ✅ `disconnect` | ✅ `bose-disconnect` | 👁 (toggle path) | — |
 | Device info (ACL) | 04,05 | 👁 `devices` (○ state) | — | — | 👁 widget colour |
@@ -344,8 +350,11 @@ surface. Keep this in sync when adding a verb or control.
 > The real wear function is **`StatusInEar` = block `0x02` / func `0x09`** (a plain GET;
 > response decodes `payload[0]` bit0 = left bud, bit1 = right bud). It's an **earbuds**
 > feature — the over-ear headphones answer **`FuncNotSupp`** (error op `0x04`, code `4`)
-> to `02,09`. Auto-pause is handled on-device (sensor → AVRCP pause to the active sink),
-> never published over BMAP. The old `08,07 == 0x04` "on-head" read was a synthetic-fixture
+> to `02,09`. The live wear STATE (which bud is in the ear) is never published over BMAP
+> on the over-ears — auto-pause is handled on-device (sensor → AVRCP pause to the active
+> sink). The on/off *setting* for that feature IS published, though: it's `01,18`
+> AutoPlayPause (mapped above), distinct from the unpublished wear state. The old
+> `08,07 == 0x04` "on-head" read was a synthetic-fixture
 > guess — `08,07` isn't the wear function and its byte is noise (flips 0x03/0x04 off-head).
 > Confirmed by decompiling the Bose Music app (v13.0.7, `com.bose.bmap.messages…StatusInEar`)
 > + the device's own `FuncNotSupp` reply. Removed from app/CLI/Android (#104-era cleanup).

--- a/android/app/src/generated/java/au/com/jd/bose/BMAP.generated.kt
+++ b/android/app/src/generated/java/au/com/jd/bose/BMAP.generated.kt
@@ -19,6 +19,10 @@ object BMAP {
         return intArrayOf(0x1F, 0x03, 0x01, 0x00)
     }
 
+    fun getFavorites(): IntArray {
+        return intArrayOf(0x1F, 0x08, 0x01, 0x00)
+    }
+
     fun setDeviceName(): IntArray {
         return intArrayOf(0x01, 0x02, 0x06, 0x00)
     }
@@ -37,6 +41,22 @@ object BMAP {
 
     fun getMultipoint(): IntArray {
         return intArrayOf(0x01, 0x0A, 0x01, 0x00)
+    }
+
+    fun setAutoPlayPause(enabled: Int): IntArray {
+        return intArrayOf(0x01, 0x18, 0x02, 0x01, (enabled and 0xFF))
+    }
+
+    fun getAutoPlayPause(): IntArray {
+        return intArrayOf(0x01, 0x18, 0x01, 0x00)
+    }
+
+    fun setAutoAnswer(enabled: Int): IntArray {
+        return intArrayOf(0x01, 0x1B, 0x02, 0x01, (enabled and 0xFF))
+    }
+
+    fun getAutoAnswer(): IntArray {
+        return intArrayOf(0x01, 0x1B, 0x01, 0x00)
     }
 
     fun connectDevice(mac: IntArray): IntArray {

--- a/android/app/src/generated/java/au/com/jd/bose/Devices.generated.kt
+++ b/android/app/src/generated/java/au/com/jd/bose/Devices.generated.kt
@@ -16,6 +16,7 @@ data class BoseDevice(
     val mac: ByteArray,
     val widget: Boolean,
     val label: String? = null,  // friendly display name; null -> fall back to name
+    val priority: Int = 999,  // 1 = highest; lowest-priority held device is evicted on a full-multipoint connect
 ) {
     val macString: String get() = mac.joinToString(":") { "%02X".format(it) }
 
@@ -24,25 +25,25 @@ data class BoseDevice(
         if (this === other) return true
         if (other !is BoseDevice) return false
         return name == other.name && mac.contentEquals(other.mac) &&
-            widget == other.widget && label == other.label
+            widget == other.widget && label == other.label && priority == other.priority
     }
 
     override fun hashCode(): Int =
-        ((name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()) * 31 +
-            (label?.hashCode() ?: 0)
+        (((name.hashCode() * 31 + mac.contentHashCode()) * 31 + widget.hashCode()) * 31 +
+            (label?.hashCode() ?: 0)) * 31 + priority
 }
 
 /** Single source of truth for the paired device map (from devices.toml). */
 object BoseDeviceMap {
     /** All known devices, in cycle order. */
     val knownDevices: List<BoseDevice> = listOf(
-        BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true, label = null),
-        BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null),
-        BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true, label = null),
-        BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true, label = null),
-        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null),
-        BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV"),
-        BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null),
+        BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true, label = null, priority = 1),
+        BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null, priority = 5),
+        BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true, label = null, priority = 4),
+        BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true, label = null, priority = 7),
+        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null, priority = 6),
+        BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV", priority = 3),
+        BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null, priority = 2),
     )
 
     /** name -> device, insertion-ordered to match cycle order. */

--- a/android/app/src/main/java/au/com/jd/bose/Parsers.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Parsers.kt
@@ -118,6 +118,50 @@ object Parsers {
         return intArrayOf(0x1F, 0x06, 0x02, payload.size) + payload
     }
 
+    /**
+     * Parse a 1F,08 AudioModes Favorites RESPONSE into the sorted favourited mode slots.
+     * Wire format (verified live on verBosita fw 8.2.20 + the decompiled app's
+     * AudioModesFavorites packets): payload[0] = slot count, then a REVERSED-order bitmask
+     * of ceil(count/8) bytes — the LOW modes live in the LAST byte. For favourite mode d,
+     * bit (d % 8) is set in byte (maskLen - floor(d/8) - 1). Live capture
+     * `1f 08 03 03 0b 00 07` -> count 11, modes {0,1,2} (Quiet/Aware/Immersion).
+     */
+    fun parseFavorites(resp: IntArray): List<Int>? {
+        if (resp.size < 5 || resp[0] != 0x1F || resp[1] != 0x08 || resp[2] != OP_RESP) return null
+        val payload = resp.copyOfRange(4, resp.size)
+        val count = payload[0]
+        val mask = payload.copyOfRange(1, payload.size) // ceil(count/8) bytes, reversed order
+        val modes = mutableListOf<Int>()
+        for (k in mask.indices) {
+            val group = mask.size - 1 - k // last byte = group 0 (modes 0..7)
+            for (bit in 0 until 8) {
+                if ((mask[k] shr bit) and 1 == 1) {
+                    val mode = group * 8 + bit
+                    if (mode < count) modes.add(mode)
+                }
+            }
+        }
+        return modes.sorted()
+    }
+
+    /**
+     * Build a 1F,08 Favorites SET_GET frame from the desired favourite slots + slot count.
+     * Inverse of parseFavorites; mirrors the app's AudioModesFavoritesSetGetPacket:
+     * payload length = ceil(count/8)+1, payload[0] = count, bit (d % 8) of byte
+     * (len - floor(d/8) - 1) set per favourite mode d. modes {0,1,2}, count 11 ->
+     * `1F 08 02 03 0b 00 07` (the live no-op-restore frame).
+     */
+    fun buildFavoritesSetGet(modes: List<Int>, slotCount: Int): IntArray {
+        val maskLen = (slotCount + 7) / 8 // ceil(count/8)
+        val len = maskLen + 1
+        val payload = IntArray(len)
+        payload[0] = slotCount and 0xFF
+        for (d in modes) if (d in 0 until slotCount) {
+            payload[len - (d / 8) - 1] = payload[len - (d / 8) - 1] or (1 shl (d % 8))
+        }
+        return intArrayOf(0x1F, 0x08, 0x02, payload.size) + payload
+    }
+
     /** Decode a UTF-8 string field response from a given payload offset. */
     fun parseString(resp: IntArray, from: Int = 4): String {
         if (resp.size <= from) return ""

--- a/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
+++ b/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
@@ -102,6 +102,49 @@ class ParsersTest {
         assertEquals(10, Parsers.buildModeConfigSet(cfg, 99).copyOfRange(4, 4 + 40)[35]) // clamps to 10
     }
 
+    // ── Favorites (1F,08) ──────────────────────────────────────────────────────
+    // Live capture on verBosita (fw 8.2.20): GET 1F 08 01 00 -> STATUS 1f 08 03 03 0b 00 07.
+    // count 0x0b (11 slots) + reversed-order bitmask 00 07 = modes 0,1,2 favourited.
+    // Mirrors macOS `cli/Tests/main.swift`.
+
+    @Test
+    fun favorites_decodesCapturedBitmask() {
+        val resp = intArrayOf(0x1F, 0x08, 0x03, 0x03, 0x0B, 0x00, 0x07)
+        assertEquals(listOf(0, 1, 2), Parsers.parseFavorites(resp))
+    }
+
+    @Test
+    fun favorites_buildsLiveNoOpSetGet() {
+        assertArrayEquals(
+            intArrayOf(0x1F, 0x08, 0x02, 0x03, 0x0B, 0x00, 0x07),
+            Parsers.buildFavoritesSetGet(listOf(0, 1, 2), 11),
+        )
+    }
+
+    @Test
+    fun favorites_highModeLandsInFirstMaskByte() {
+        // Reversed byte order: mode 8 -> first mask byte, low modes -> last.
+        assertArrayEquals(
+            intArrayOf(0x1F, 0x08, 0x02, 0x03, 0x0B, 0x01, 0x00),
+            Parsers.buildFavoritesSetGet(listOf(8), 11),
+        )
+        assertEquals(listOf(8), Parsers.parseFavorites(intArrayOf(0x1F, 0x08, 0x03, 0x03, 0x0B, 0x01, 0x00)))
+    }
+
+    @Test
+    fun favorites_buildParseRoundTrips() {
+        val mixed = listOf(0, 2, 9)
+        val frame = Parsers.buildFavoritesSetGet(mixed, 11)
+        val asResp = intArrayOf(0x1F, 0x08, 0x03) + frame.copyOfRange(3, frame.size)
+        assertEquals(mixed, Parsers.parseFavorites(asResp))
+    }
+
+    @Test
+    fun favorites_shortOrWrongHeaderIsNull() {
+        assertNull(Parsers.parseFavorites(intArrayOf(0x1F, 0x08, 0x01, 0x00))) // non-RESP (GET echo)
+        assertNull(Parsers.parseFavorites(intArrayOf(0x1F, 0x06, 0x03, 0x03, 0x0B, 0x00, 0x07))) // wrong func
+    }
+
     // ── parseAllState (bulk session) ──────────────────────────────────────────
 
     @Test

--- a/cli/Parsers.swift
+++ b/cli/Parsers.swift
@@ -132,6 +132,45 @@ func buildModeConfigSet(_ cfg: ModeConfig, newLevel: Int?) -> [UInt8] {
     return [0x1F, 0x06, 0x02, UInt8(payload.count)] + payload
 }
 
+/// Parse a 1F,08 AudioModes Favorites RESPONSE into the sorted set of favourited mode
+/// slots. Wire format (verified live on verBosita fw 8.2.20 + the decompiled app's
+/// AudioModesFavorites packets): payload[0] = slot count, followed by a REVERSED-order
+/// bitmask of `ceil(count/8)` bytes — the LOW modes live in the LAST byte. For each
+/// favourite mode `d`, bit `(d % 8)` is set in byte index `(maskLen - floor(d/8) - 1)`.
+/// Live capture `1f 08 03 03 0b 00 07` -> count 11, modes {0,1,2} (Quiet/Aware/Immersion).
+/// Returns nil on a short/non-RESP/wrong-header frame.
+func parseFavorites(_ resp: [UInt8]) -> [Int]? {
+    guard resp.count >= 5, resp[0] == 0x1F, resp[1] == 0x08, resp[2] == OP_RESP_BYTE else { return nil }
+    let payload = Array(resp[4...])
+    let count = Int(payload[0])
+    let mask = Array(payload.dropFirst())          // ceil(count/8) bytes, reversed order
+    var modes: [Int] = []
+    for (k, byte) in mask.enumerated() {
+        let group = mask.count - 1 - k             // last byte = group 0 (modes 0..7)
+        for bit in 0..<8 where (byte >> bit) & 1 == 1 {
+            let mode = group * 8 + bit
+            if mode < count { modes.append(mode) }
+        }
+    }
+    return modes.sorted()
+}
+
+/// Build a 1F,08 Favorites SET_GET frame from the desired favourite mode slots + total
+/// slot count. Inverse of parseFavorites; mirrors the app's AudioModesFavoritesSetGetPacket:
+/// payload length = ceil(count/8)+1, payload[0] = count, bit (d % 8) of byte
+/// (len - floor(d/8) - 1) set per favourite mode d. e.g. modes {0,1,2}, count 11 ->
+/// `1F 08 02 03 0b 00 07` (the live no-op-restore frame).
+func buildFavoritesSetGet(modes: [Int], slotCount: Int) -> [UInt8] {
+    let maskLen = (slotCount + 7) / 8              // ceil(count/8)
+    let len = maskLen + 1
+    var payload = [UInt8](repeating: 0, count: len)
+    payload[0] = UInt8(slotCount & 0xFF)
+    for d in modes where d >= 0 && d < slotCount {
+        payload[len - (d / 8) - 1] |= UInt8(1 << (d % 8))
+    }
+    return [0x1F, 0x08, 0x02, UInt8(payload.count)] + payload
+}
+
 /// Decoded per-device info (04,05 RESP). `connected` is ACL presence (status
 /// bit 0) — reliable for "is this device linked at all", NOT for audio routing
 /// (use parseConnectedDevices / 05,01 for the active sink). Mirrors the Android

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -92,6 +92,27 @@ check(sp[39] == 1, "modeConfigSet: ancToggle forced ON @39 (level change can't d
 check(buildModeConfigSet(custom, newLevel: nil)[4 + 35] == 7, "modeConfigSet: nil keeps current level")
 check(buildModeConfigSet(custom, newLevel: 99)[4 + 35] == 10, "modeConfigSet: clamps to 10")
 
+// ── Favorites (1F,08) ───────────────────────────────────────────────────────────
+// Live capture on verBosita (fw 8.2.20): GET 1F 08 01 00 -> STATUS 1f 08 03 03 0b 00 07.
+// count 0x0b (11 slots) + reversed-order bitmask 00 07 = modes 0,1,2 favourited.
+let favResp: [UInt8] = [0x1F, 0x08, 0x03, 0x03, 0x0B, 0x00, 0x07]
+check(parseFavorites(favResp) ?? [] == [0, 1, 2], "favorites: decodes captured 0b 00 07 -> {0,1,2}")
+// Round-trip: building the SET_GET from {0,1,2}/count 11 reproduces the live no-op frame.
+check(buildFavoritesSetGet(modes: [0, 1, 2], slotCount: 11) == [0x1F, 0x08, 0x02, 0x03, 0x0B, 0x00, 0x07],
+      "favorites: builds the live no-op SET_GET 1F 08 02 03 0b 00 07")
+// A high mode (slot 8) lands in the FIRST mask byte (reversed order), low modes in the last.
+let fav8 = buildFavoritesSetGet(modes: [8], slotCount: 11)
+check(fav8 == [0x1F, 0x08, 0x02, 0x03, 0x0B, 0x01, 0x00], "favorites: mode 8 -> first mask byte (reversed)")
+check(parseFavorites([0x1F, 0x08, 0x03, 0x03, 0x0B, 0x01, 0x00]) ?? [] == [8], "favorites: decodes mode 8 from first byte")
+// Build/parse are inverses across a mixed set.
+let mixed = [0, 2, 9]
+let rt = parseFavorites([0x1F, 0x08, 0x03] + [UInt8(buildFavoritesSetGet(modes: mixed, slotCount: 11).count - 4)]
+                        + Array(buildFavoritesSetGet(modes: mixed, slotCount: 11).dropFirst(4)))
+check(rt ?? [] == mixed, "favorites: build->parse round-trips {0,2,9}")
+// Guards: short / non-RESP / wrong header -> nil.
+check(parseFavorites([0x1F, 0x08, 0x01, 0x00]) == nil, "favorites: non-RESP (GET echo) -> nil")
+check(parseFavorites([0x1F, 0x06, 0x03, 0x03, 0x0B, 0x00, 0x07]) == nil, "favorites: wrong func -> nil")
+
 // ── parseAllState (bulk session) ─────────────────────────────────────────────────
 
 // Stub provider: returns a representative RESP per (block,func) GET.

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -495,6 +495,60 @@ func cmdMultipoint(_ arg: String?) {
     print(parseMultipointEnabled(r[4]) ? "on" : "off")
 }
 
+/// auto-pause [on|off] — pause when headphones are removed (01,18). Generated
+/// setAutoPlayPause uses SET_GET; the set's own RESP carries the new state (no verify-GET).
+func cmdAutoPlayPause(_ arg: String?) {
+    if let toggle = arg {
+        let on = ["on", "true", "1"].contains(toggle.lowercased())
+        guard let r = transport.oneShot(BMAP.setAutoPlayPause(enabled: on ? 1 : 0)),
+              r.count >= 5, r[2] == OP_RESP_BYTE else { fail("auto-pause set failed") }
+        print((r[4] & 0x01) != 0 ? "on" : "off")
+        return
+    }
+    guard let r = transport.oneShot(BMAP.getAutoPlayPause()),
+          r.count >= 5, r[2] == OP_RESP_BYTE else { fail("auto-pause query failed") }
+    print((r[4] & 0x01) != 0 ? "on" : "off")
+}
+
+/// auto-answer [on|off] — answer a call when headphones are donned (01,1B). SET_GET.
+func cmdAutoAnswer(_ arg: String?) {
+    if let toggle = arg {
+        let on = ["on", "true", "1"].contains(toggle.lowercased())
+        guard let r = transport.oneShot(BMAP.setAutoAnswer(enabled: on ? 1 : 0)),
+              r.count >= 5, r[2] == OP_RESP_BYTE else { fail("auto-answer set failed") }
+        print((r[4] & 0x01) != 0 ? "on" : "off")
+        return
+    }
+    guard let r = transport.oneShot(BMAP.getAutoAnswer()),
+          r.count >= 5, r[2] == OP_RESP_BYTE else { fail("auto-answer query failed") }
+    print((r[4] & 0x01) != 0 ? "on" : "off")
+}
+
+/// favorites [m1 m2 …] — which AudioModes slots are favourited (1F,08). Bare = list;
+/// with mode indices = set them. GET first to learn the slot count, then build the
+/// SET_GET (count + reversed bitmask) via the hand-written buildFavoritesSetGet — the
+/// payload isn't expressible in the generated builder DSL (getFavorites() is generated).
+func cmdFavorites(_ favArgs: [String]) {
+    guard let g = transport.oneShot(BMAP.getFavorites()), g.count >= 5,
+          let current = parseFavorites(g) else { fail("favorites query failed") }
+    let slotCount = Int(g[4])  // payload[0] = slot count
+    func fmt(_ modes: [Int]) -> String {
+        modes.map { m in (AncMode(rawValue: UInt8(m)).map { "\(m):\($0)" } ?? "\(m)") }.joined(separator: " ")
+    }
+    if favArgs.isEmpty {
+        print(current.isEmpty ? "(none)" : fmt(current))
+        return
+    }
+    let modes = favArgs.flatMap { $0.split(whereSeparator: { $0 == "," || $0 == " " }) }
+        .compactMap { Int($0) }
+    guard !modes.isEmpty, modes.allSatisfy({ $0 >= 0 && $0 < slotCount }) else {
+        fail("usage: bose favorites <mode indices 0-\(slotCount - 1)>")
+    }
+    guard let r = transport.oneShot(buildFavoritesSetGet(modes: modes, slotCount: slotCount)),
+          let updated = parseFavorites(r) else { fail("favorites set failed") }
+    print(updated.isEmpty ? "(none)" : fmt(updated))
+}
+
 /// play / pause / next / prev — generated mediaControl builder.
 func cmdMedia(_ action: MediaAction) {
     _ = transport.oneShot(BMAP.mediaControl(action: action.rawValue))
@@ -580,6 +634,9 @@ func usage() {
       bose name [new name]      Get/set headphone name (max 30 UTF-8 bytes)
       bose volume [0-31]        Get/set volume
       bose multipoint [on|off]  Get/set multipoint
+      bose auto-pause [on|off]  Get/set auto-pause when headphones are removed (01,18)
+      bose auto-answer [on|off] Get/set auto-answer when headphones are donned (01,1B)
+      bose favorites [m …]      List favourite mode slots; pass indices to set them (1F,08)
       bose play|pause|next|prev Media transport
       bose eq [bass mid treble] Get/set EQ (each -10 to +10)
       bose profile [name]       Apply a preset (bare = list); save <name> / rm <name>
@@ -610,6 +667,9 @@ case "disconnect", "d":        cmdDisconnect(requireArg("device"))
 case "swap":                   cmdSwap(requireArg("device"))
 case "volume", "vol", "v":     cmdVolume(args.count >= 3 ? args[2] : nil)
 case "multipoint", "mp":       cmdMultipoint(args.count >= 3 ? args[2] : nil)
+case "auto-pause", "autopause": cmdAutoPlayPause(args.count >= 3 ? args[2] : nil)
+case "auto-answer", "autoanswer": cmdAutoAnswer(args.count >= 3 ? args[2] : nil)
+case "favorites", "favourites", "fav": cmdFavorites(args.count >= 3 ? Array(args[2...]) : [])
 case "play":                   cmdMedia(.play)
 case "pause":                  cmdMedia(.pause)
 case "next":                   cmdMedia(.next)

--- a/protocol/generated/BMAP.generated.kt
+++ b/protocol/generated/BMAP.generated.kt
@@ -19,6 +19,10 @@ object BMAP {
         return intArrayOf(0x1F, 0x03, 0x01, 0x00)
     }
 
+    fun getFavorites(): IntArray {
+        return intArrayOf(0x1F, 0x08, 0x01, 0x00)
+    }
+
     fun setDeviceName(): IntArray {
         return intArrayOf(0x01, 0x02, 0x06, 0x00)
     }
@@ -37,6 +41,22 @@ object BMAP {
 
     fun getMultipoint(): IntArray {
         return intArrayOf(0x01, 0x0A, 0x01, 0x00)
+    }
+
+    fun setAutoPlayPause(enabled: Int): IntArray {
+        return intArrayOf(0x01, 0x18, 0x02, 0x01, (enabled and 0xFF))
+    }
+
+    fun getAutoPlayPause(): IntArray {
+        return intArrayOf(0x01, 0x18, 0x01, 0x00)
+    }
+
+    fun setAutoAnswer(enabled: Int): IntArray {
+        return intArrayOf(0x01, 0x1B, 0x02, 0x01, (enabled and 0xFF))
+    }
+
+    fun getAutoAnswer(): IntArray {
+        return intArrayOf(0x01, 0x1B, 0x01, 0x00)
     }
 
     fun connectDevice(mac: IntArray): IntArray {

--- a/protocol/generated/BMAP.generated.swift
+++ b/protocol/generated/BMAP.generated.swift
@@ -46,6 +46,10 @@ enum BMAP {
         return [0x1F, 0x03, 0x01, 0x00]
     }
 
+    static func getFavorites() -> [UInt8] {
+        return [0x1F, 0x08, 0x01, 0x00]
+    }
+
     static func setDeviceName() -> [UInt8] {
         return [0x01, 0x02, 0x06, 0x00]
     }
@@ -64,6 +68,22 @@ enum BMAP {
 
     static func getMultipoint() -> [UInt8] {
         return [0x01, 0x0A, 0x01, 0x00]
+    }
+
+    static func setAutoPlayPause(enabled: UInt8) -> [UInt8] {
+        return [0x01, 0x18, 0x02, 0x01, enabled]
+    }
+
+    static func getAutoPlayPause() -> [UInt8] {
+        return [0x01, 0x18, 0x01, 0x00]
+    }
+
+    static func setAutoAnswer(enabled: UInt8) -> [UInt8] {
+        return [0x01, 0x1B, 0x02, 0x01, enabled]
+    }
+
+    static func getAutoAnswer() -> [UInt8] {
+        return [0x01, 0x1B, 0x01, 0x00]
     }
 
     static func connectDevice(mac: [UInt8]) -> [UInt8] {

--- a/protocol/spec/bmap.toml
+++ b/protocol/spec/bmap.toml
@@ -100,6 +100,40 @@ summary = "ANC/CNC depth level 0-10 (read-modify-write, preserve other fields)."
 # CUSTOM mode (custom1/custom2). Never write depth alongside quiet/aware — profiles
 # and the macOS app enforce this (named mode → mode only).
 
+[commands.favorites]
+block = 0x1F
+function = 0x08
+summary = "Which AudioModes slots are marked favourite (count + reversed-order bitmask)."
+# GET-verified live on verBosita (fw 8.2.20): `1F 08 01 00` → STATUS
+# `1f 08 03 03 0b 00 07` = count 0x0b (11 slots) + 2-byte bitmask `00 07`, where the
+# LOW modes land in the LAST byte (reversed byte order): 0x07 = bits 0,1,2 = modes
+# 0/1/2 (Quiet/Aware/Immersion) favourited.
+#
+# Modelled like `device_info` (NOT composite): the GET request is a clean generated
+# builder (`BMAP.favoritesGet()`), and only the SET_GET payload build + the response
+# decode are hand-written per-platform — because the SET_GET payload is COMPUTED
+# (count + reversed bitmask), which the fixed-token encoder DSL can't express. Those
+# live as pure functions in Parsers (`buildFavoritesSetGet` / `parseFavorites`,
+# Swift + Kotlin) tested against the live capture below.
+#
+# SET_GET frame (from the app's `AudioModesFavoritesSetGetPacket(count, modes[])`,
+# jadx): payload[0] = count; payload length = ceil(count/8)+1; for each favourite
+# mode d set bit (d % 8) in byte `(len - floor(d/8) - 1)`. The no-op restore that
+# re-creates the live state is `1F 08 02 03 0b 00 07` (count 11, modes {0,1,2}) —
+# captured live (STATUS echo unchanged).
+
+[commands.favorites.get]
+operator = "GET"
+payload = []
+
+[commands.favorites.verified_bytes]
+# Only the GET request is a generated golden; the SET_GET bitmask is covered by the
+# Parsers byte tests (cli/Tests + Android test corpus), not here.
+get = "1F 08 01 00"
+
+[commands.favorites.test_args]
+get = {}
+
 
 # ── Block 0x01 — Settings / Device ─────────────────────────────────────────────
 
@@ -168,6 +202,66 @@ get = "01 0A 01 00"
 [commands.multipoint.test_args]
 set_on = { state = 7 }
 set_off = { state = 0 }
+get = {}
+
+[commands.auto_play_pause]
+block = 0x01
+function = 0x18
+# Pause playback when the headphones are removed / resume when re-donned. This is the
+# on-device *setting toggle* (01,18) — distinct from the live wear STATE (02,09,
+# StatusInEar) which is FuncNotSupp on the over-ears. GET-verified live on verBosita
+# (fw 8.2.20). SET_GET is a single bool byte, confirmed two ways: the Bose Music app's
+# `SettingsAutoPlayPauseSetGetPacket(bool)` builder (jadx) emits `new byte[]{0|1}`, and
+# a live no-op SET_GET (re-sending the current ON value) echoed STATUS unchanged.
+summary = "Toggle auto-pause when headphones are removed (SET_GET 00=off/01=on)."
+
+[commands.auto_play_pause.set]
+operator = "SET_GET"        # app builder uses SetGet (0x02); plain SET is auth-gated
+payload = ["enabled:u8"]    # 0x00 = off, 0x01 = on
+
+[commands.auto_play_pause.get]
+operator = "GET"
+payload = []
+
+[commands.auto_play_pause.verified_bytes]
+# `01,18,02,01,{00/01}` — set_on captured live (no-op re-send, STATUS echo 01 18 03 01 01);
+# set_off matches the app builder (not toggled on-device to avoid changing state).
+set_on = "01 18 02 01 01"
+set_off = "01 18 02 01 00"
+get = "01 18 01 00"
+
+[commands.auto_play_pause.test_args]
+set_on = { enabled = 1 }
+set_off = { enabled = 0 }
+get = {}
+
+[commands.auto_answer]
+block = 0x01
+function = 0x1B
+# Auto-answer an incoming call when the headphones are donned. GET-verified live on
+# verBosita (fw 8.2.20). SET_GET single bool byte — confirmed via the app's
+# `SettingsAutoAnswerSetGetPacket(bool)` builder (`new byte[]{0|1}`) and a live no-op
+# SET_GET that echoed STATUS unchanged.
+summary = "Toggle auto-answer when headphones are donned (SET_GET 00=off/01=on)."
+
+[commands.auto_answer.set]
+operator = "SET_GET"
+payload = ["enabled:u8"]    # 0x00 = off, 0x01 = on
+
+[commands.auto_answer.get]
+operator = "GET"
+payload = []
+
+[commands.auto_answer.verified_bytes]
+# `01,1B,02,01,{00/01}` — set_on captured live (no-op re-send, STATUS echo 01 1b 03 01 01);
+# set_off matches the app builder.
+set_on = "01 1B 02 01 01"
+set_off = "01 1B 02 01 00"
+get = "01 1B 01 00"
+
+[commands.auto_answer.test_args]
+set_on = { enabled = 1 }
+set_off = { enabled = 0 }
 get = {}
 
 


### PR DESCRIPTION
Adds the three GET-verified BMAP commands to `bmap.toml` with captured SET_GET bytes:

- **01,18 AutoPlayPause** & **01,1B AutoAnswer** — single bool-byte SET_GET; golden frames verified live on verBosita (fw 8.2.20) via no-op re-send AND cross-checked against the decompiled Bose Music app packet builders (`SettingsAutoPlayPauseSetGetPacket`/`SettingsAutoAnswerSetGetPacket`).
- **1F,08 Favorites** — count byte + reversed-order bitmask. GET is a generated builder; the SET_GET payload build + response decode are hand-written (`buildFavoritesSetGet`/`parseFavorites`, Swift + Kotlin) since the bitmask isn't expressible in the encoder DSL. Tested against the live `1f 08 03 03 0b 00 07` capture (modes 0/1/2).

Also adds `bose` CLI verbs (`auto-pause` / `auto-answer` / `favorites`), mirrors the CLAUDE.md command + exposure tables, and syncs the Android `Devices.generated.kt` mirror (pre-existing drift behind `protocol/generated/`).

Verification: `make check` green (32 golden tests, no drift), Swift parser tests pass (7 new favorites cases), Kotlin `ParsersTest` passes, CLI builds and the live verbs return the correct values. Every device probe was a no-op restore — state left unchanged.

Closes #119