### PR TITLE
feat: Android multipoint-eviction parity with the CLI

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Add verified 01,18 AutoPlayPause / 01,1B AutoAnswer / 1F,08 Favorites commands to bmap.toml. Closes #119
-Add verified 01,18 AutoPlayPause / 01,1B AutoAnswer / 1F,08 Favorites commands to bmap.toml. Closes #119
+Android multipoint-eviction parity — replicate CLI evictLowestPriorityIfFull/restoreEvicted in BoseService connect path
+Android multipoint-eviction parity — replicate CLI evictLowestPriorityIfFull/restoreEvicted in BoseService connect path
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - bmap-autopause-answer-favs
+# Agent Progress - android-eviction-parity
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-19T21:18:11Z
+# Created: 2026-06-20T01:57:34Z
 
-feature=bmap-autopause-answer-favs
-name=Add verified 01,18 AutoPlayPause / 01,1B AutoAnswer / 1F,08 Favorites commands to bmap.toml. Closes #119
+feature=android-eviction-parity
+name=Android multipoint-eviction parity — replicate CLI evictLowestPriorityIfFull/restoreEvicted in BoseService connect path
 status=pending
 step=0
 step_name=Not started
-created=2026-06-19T21:18:11Z
+created=2026-06-20T01:57:34Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,8 +210,11 @@ CLI's `connect`/`swap` enforce the hierarchy in software: when both slots are fu
 the target isn't already connected, it **disconnects the lowest-priority of the two held
 devices first**, then pages the target — and **restores the evicted device if the target
 fails to connect** (`evictLowestPriorityIfFull` / `restoreEvicted` in `cli/main.swift`).
-Mac app / Raycast / Hammerspoon inherit this (they shell `bose`). **Android does NOT yet
-replicate it** (TODO — parity).
+Mac app / Raycast / Hammerspoon inherit this (they shell `bose`). **Android now replicates
+it too**: pure victim selection in `android/.../Eviction.kt` (`evictionVictim`, JVM-unit-
+tested), held-state read via `Composites.getDeviceStates`, wired into `BoseService.switchDevice`
+(evict-then-page, restore on failure). Android can't run the Mac's host-side blueutil step, so
+it only sends the BMAP disconnect/connect — correct from the phone's side.
 
 **Cycle order** (bose): `mac → quest → ipad → iphone → tv → appletv → phone`
 

--- a/android/app/src/main/java/au/com/jd/bose/BoseService.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseService.kt
@@ -243,6 +243,22 @@ class BoseService : Service() {
                 return
             }
 
+            // Multipoint eviction (parity with the CLI's evictLowestPriorityIfFull): the
+            // headset holds 2 devices and the firmware only evicts by its own LRU. When both
+            // slots are full and the target isn't already held, drop the LOWEST-priority held
+            // device first so the connect lands the target against our hierarchy, not the
+            // firmware's LRU. Restore the victim if the target then fails to connect — never
+            // leave a slot empty for nothing.
+            val (active, connected) = Composites.getDeviceStates(
+                BoseDeviceMap.knownDevices.map { it.mac.toIntArray() }
+            )
+            val victim = evictionVictim(active + connected, mac)
+            if (victim != null) {
+                Log.i(TAG, "Evicting ${victim.name} (priority ${victim.priority}) to free a multipoint slot")
+                Transport.send(BMAP.disconnectDevice(victim.mac.toIntArray()))
+                Thread.sleep(800) // let the slot clear before paging the target
+            }
+
             Log.i(TAG, "Switching to $deviceName")
             val result = Composites.connectDevice(mac)
 
@@ -269,10 +285,12 @@ class BoseService : Service() {
 
                 Composites.SwitchResult.TARGET_OFFLINE -> {
                     Log.w(TAG, "$deviceName is not connected to Bose — can't switch")
+                    restoreEvicted(victim, deviceName)
                     broadcastError("$deviceName is offline — connect it to Bose first")
                 }
 
                 Composites.SwitchResult.FAILED -> {
+                    restoreEvicted(victim, deviceName)
                     broadcastError("Failed to switch to $deviceName")
                 }
             }
@@ -282,6 +300,18 @@ class BoseService : Service() {
         } finally {
             BoseProtocol.disconnect()
         }
+    }
+
+    /**
+     * Re-page a device we evicted, after the target connect failed — restores the prior
+     * pair so we never leave a multipoint slot empty for nothing. No-op when nothing was
+     * evicted. Mirrors the CLI's `restoreEvicted`. (No host-side BT action: unlike the Mac
+     * — which also runs blueutil for its own link — Android just re-sends the BMAP connect.)
+     */
+    private fun restoreEvicted(victim: BoseDevice?, failedTarget: String) {
+        if (victim == null) return
+        Log.i(TAG, "Restoring ${victim.name} (target $failedTarget was unreachable)")
+        Transport.send(BMAP.connectDevice(victim.mac.toIntArray()))
     }
 
     /** Send a media transport command (play/pause/next/prev) to the headphones. */

--- a/android/app/src/main/java/au/com/jd/bose/Composites.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Composites.kt
@@ -29,6 +29,25 @@ object Composites {
         return Parsers.parseConnectedDevices(resp)
     }
 
+    /**
+     * Which of the queried devices the headset currently HOLDS, split into audio-active
+     * (05,01) and ACL-connected-but-idle (04,05). Mirrors macOS `getDeviceStates`: prime a
+     * warm session (05,01 is silent as the first cold frame, #81), read the active sink, then
+     * probe 04,05 per non-active queried device for ACL presence. Caller must hold an open
+     * connection (inside switchDevice's connect/disconnect bracket). Returns (active, connected).
+     */
+    fun getDeviceStates(query: List<IntArray>): Pair<List<IntArray>, List<IntArray>> {
+        Transport.send(intArrayOf(0x02, 0x02, 0x01, 0x00)) // prime warm session (05,01 silent cold)
+        val active = getConnectedDevices()
+        val activeKeys = active.map { it.toList() }.toSet()
+        val connected = mutableListOf<IntArray>()
+        for (mac in query) {
+            if (mac.toList() in activeKeys) continue
+            if (BoseProtocol.getDeviceInfo(mac)?.connected == true) connected.add(mac)
+        }
+        return active to connected
+    }
+
     /** Outcome of a noise-level write — mirrors macOS `AncLevelResult`. */
     sealed class AncLevelResult {
         data class Ok(val name: String, val level: Int) : AncLevelResult()

--- a/android/app/src/main/java/au/com/jd/bose/Eviction.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Eviction.kt
@@ -1,0 +1,28 @@
+package au.com.jd.bose
+
+/**
+ * Deterministic multipoint-eviction victim selection — the pure, hardware-free core of the
+ * connect-path device hierarchy. Mirrors macOS `evictLowestPriorityIfFull` in cli/main.swift
+ * (the macOS app / Raycast / Hammerspoon inherit it by shelling `bose`; Android needs its own).
+ *
+ * The headset holds at most 2 devices and the firmware only evicts by its own LRU
+ * (ConnectionPriority 0x10 is FuncNotSupp — see docs/reverse-engineering.md). So when both
+ * slots are full and the target isn't already held, we drop the LOWEST-priority held device
+ * (the highest `priority` number in devices.toml) first, so the subsequent connect lands the
+ * target against our hierarchy instead of whatever the firmware's LRU would have dropped.
+ *
+ * Returns the device to evict, or null when no eviction is needed/possible:
+ *  - target already held (it's one of the two)            -> null
+ *  - a slot is free (fewer than 2 devices held)            -> null
+ *  - both full but neither held device is in our map       -> null (let the firmware decide)
+ */
+private fun macKey(mac: IntArray): String = mac.joinToString(":") { "%02X".format(it and 0xFF) }
+
+fun evictionVictim(heldMacs: List<IntArray>, targetMac: IntArray): BoseDevice? {
+    val heldKeys = heldMacs.map { macKey(it) }.toSet()
+    if (macKey(targetMac) in heldKeys) return null // already connected — nothing to evict
+    if (heldKeys.size < 2) return null // a slot is free — no eviction needed
+    return BoseDeviceMap.knownDevices
+        .filter { it.macString in heldKeys }
+        .maxByOrNull { it.priority } // highest priority number = lowest priority = the victim
+}

--- a/android/app/src/test/java/au/com/jd/bose/EvictionTest.kt
+++ b/android/app/src/test/java/au/com/jd/bose/EvictionTest.kt
@@ -1,0 +1,52 @@
+package au.com.jd.bose
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure unit tests for multipoint-eviction victim selection (Eviction.kt) — the Android
+ * parity for the CLI's evictLowestPriorityIfFull. Hardware-free: drives the selection off
+ * the generated BoseDeviceMap priorities (1 mac, 2 phone, 3 appletv, 4 ipad, 5 quest, 6 tv,
+ * 7 iphone). Mirrors the macOS behaviour proven on-device.
+ */
+class EvictionTest {
+    private fun mac(name: String) = BoseDeviceMap.mac(name)!!.toIntArray()
+
+    @Test
+    fun bothSlotsFull_targetNotHeld_evictsLowestPriority() {
+        // mac (prio 1) + phone (prio 2) held; switching to ipad -> evict phone (higher number).
+        assertEquals("phone", evictionVictim(listOf(mac("mac"), mac("phone")), mac("ipad"))?.name)
+        // mac (prio 1) + ipad (prio 4) held; switching to phone -> evict ipad.
+        assertEquals("ipad", evictionVictim(listOf(mac("mac"), mac("ipad")), mac("phone"))?.name)
+        // Order of the held list must not matter — selection is by priority, not position.
+        assertEquals("ipad", evictionVictim(listOf(mac("ipad"), mac("mac")), mac("phone"))?.name)
+    }
+
+    @Test
+    fun targetAlreadyHeld_noEviction() {
+        assertNull(evictionVictim(listOf(mac("mac"), mac("phone")), mac("mac")))
+        assertNull(evictionVictim(listOf(mac("mac"), mac("phone")), mac("phone")))
+    }
+
+    @Test
+    fun freeSlot_noEviction() {
+        assertNull(evictionVictim(listOf(mac("mac")), mac("ipad"))) // 1 held -> a slot is free
+        assertNull(evictionVictim(emptyList(), mac("ipad")))        // 0 held
+    }
+
+    @Test
+    fun unknownHeldDevice_picksAmongKnown() {
+        val unknown = intArrayOf(0x00, 0x11, 0x22, 0x33, 0x44, 0x55)
+        // Two slots full (unknown + mac), target not held -> only known held is mac.
+        assertEquals("mac", evictionVictim(listOf(unknown, mac("mac")), mac("ipad"))?.name)
+    }
+
+    @Test
+    fun bothHeldUnknown_noVictim() {
+        val u1 = intArrayOf(0x00, 0x11, 0x22, 0x33, 0x44, 0x55)
+        val u2 = intArrayOf(0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB)
+        // Both slots full but neither is in our map -> let the firmware's LRU decide.
+        assertNull(evictionVictim(listOf(u1, u2), mac("ipad")))
+    }
+}


### PR DESCRIPTION
Brings the Android client up to parity with the CLI's deterministic multipoint eviction. The headset holds 2 devices and the firmware only evicts by its own LRU (`ConnectionPriority 0x10` is FuncNotSupp), so the CLI enforces the `devices.toml` priority hierarchy in software. Android previously called plain `connect` and let the firmware decide — a documented behavioural inconsistency between the two clients.

- **`Eviction.kt`** — pure `evictionVictim(held, target)`: both slots full + target not held → drop the lowest-priority (highest priority-number) *known* held device; else null. Mirrors the macOS free function. JVM-unit-tested (`EvictionTest`: lowest-priority pick, order-independence, target-held, free-slot, unknown-device handling).
- **`Composites.getDeviceStates`** — held-state read (active 05,01 ∪ ACL 04,05 per device), mirroring the CLI's `getDeviceStates`.
- **`BoseService.switchDevice`** — evict-then-page, and restore the victim if the target then fails to connect. Android can't run the Mac's host-side `blueutil` step, so it only sends the BMAP disconnect/connect — correct from the phone's side.

Also flips the "Android does NOT yet replicate it (TODO — parity)" note in CLAUDE.md.

**Verification**: full Android unit suite + `assembleDebug` green. Pure selection logic is unit-tested and the connect/disconnect frames are the same ones the CLI proves live. Remaining manual check: a live multipoint-eviction run on the S21 (needs two devices held), deliberately not done here to avoid disrupting live audio routing.