### PR TITLE
feat: surface auto-pause / auto-answer / favorites in Raycast + Mac app

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Android multipoint-eviction parity — replicate CLI evictLowestPriorityIfFull/restoreEvicted in BoseService connect path
-Android multipoint-eviction parity — replicate CLI evictLowestPriorityIfFull/restoreEvicted in BoseService connect path
+Surface auto-pause/auto-answer/favorites in Raycast + Mac app (favorites display-only)
+Surface auto-pause/auto-answer/favorites in Raycast + Mac app (favorites display-only)
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - android-eviction-parity
+# Agent Progress - surface-autopause-answer-favs
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-20T01:57:34Z
+# Created: 2026-06-20T02:05:30Z
 
-feature=android-eviction-parity
-name=Android multipoint-eviction parity — replicate CLI evictLowestPriorityIfFull/restoreEvicted in BoseService connect path
+feature=surface-autopause-answer-favs
+name=Surface auto-pause/auto-answer/favorites in Raycast + Mac app (favorites display-only)
 status=pending
 step=0
 step_name=Not started
-created=2026-06-20T01:57:34Z
+created=2026-06-20T02:05:30Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ is three thin front-ends that shell out to the `cli/` binary (`~/bin/bose`), so
 nothing runs in the background and the Mac only touches the headphones on an
 explicit user action.
 - `macos/BoseControl/` -- **Bose.app**: a windowed SwiftUI app (warm-paper light
-  two-panel: battery/ANC mode/volume/multipoint + device grid + EQ). The light
+  two-panel: battery/ANC mode/volume/multipoint + auto-pause/auto-answer toggles
+  (01,18 / 01,1B) + a favourites display (1F,08, read-only) + device grid + EQ). The light
   theme (burnt-orange `#AF3A03` accent on warm paper, from the Midterm `paper-hc` palette)
   is shared with the Android app; macOS colours live in `ContentView.swift`, Android in
   `MainActivity.kt` (`BoseAccent`/`BoseConnected`/…). Six ANC
@@ -48,6 +49,7 @@ explicit user action.
 - `raycast/bose-connect.sh` / `bose-disconnect.sh` -- Raycast script commands with a device dropdown → `bose connect|disconnect <device>`
 - `raycast/bose-status.sh` / `bose-full-status.sh` -- `bose status` / `bose info`
 - `raycast/bose-anc-level.sh` / `bose-profile.sh` -- `bose anc-level [0-10]` (active mode's noise level, custom modes only) / `bose profile [name]` (text arg)
+- `raycast/bose-auto-pause.sh` / `bose-auto-answer.sh` -- `bose auto-pause [on|off]` / `bose auto-answer [on|off]` (blank arg = read); `bose-favorites.sh` -- `bose favorites` (display-only)
 - `profiles.json` (repo root) -- settings presets ({ANC mode, noise level, EQ, multipoint, volume}) applied by `bose profile`; versioned + hand-editable, ships flight/office/music. A profile's `noiseLevel` is applied via the `anc-level` (1F,06) RMW and ONLY takes effect on the adjustable custom modes (4/5, `cncMutable`) — named modes set the mode only (a level over quiet/aware/spatial is a no-op; the old 1F,0A depth write disabled ANC, #83). flight = {quiet, multipoint off}. Runtime JSON (not codegen'd TOML) because `profile save` writes it; loader resolves `$BOSE_PROFILES` → repo path → `~/.config/bose/`. Pure logic in `cli/Profiles.swift`, live apply in `cli/Composites.swift` (`applyProfile`).
 - `hammerspoon/bose.lua` -- Hammerspoon module, all **event-driven** (no timers): **Opt+B shows/hides the Bose app** (the windowed control surface — press once to open/focus, again to hide; switch devices/ANC/EQ from its tiles), **Opt+⇧B toggles Mac ↔ phone** (the former Opt+B; + one-shot low-battery warn piggybacked on the press), **Opt+N cycles ANC** (quiet→aware→immersion), **Opt+J connects the headphones to this Mac** (unconditional, no toggle direction-guessing; `CONNECT_TARGET` retargets it). Plus two **OS-event** behaviours (no hotkey, no poll — driven by `hs.audiodevice`/`hs.application` watchers): **battery announce** — `say`s the battery through the headphones when they become the Mac output (a stand-in for the power-on announcement Bose removed in fw 8.2.20; `ANNOUNCE_BATTERY`), and **auto-route on call** — a call app (Teams/Zoom/FaceTime/Slack/Webex) launching routes the Mac's *input* to the MacBook mic, and the audiodevice guard never lets the Bose be the system input (its over-ear mics make callers hear the room); input **stays** on the MacBook mic after calls — no restore, because `hs.application.watcher` doesn't reliably deliver `terminated` (verified 2026-06-20) and the MacBook mic is the right default. `AUTO_ROUTE_ON_CALL` + `CALL_APPS`. NB Teams can override the system input with its own setting — set its in-app mic once. Returns a table with `.start()`/`.stop()`. Wired in `init.lua` via `BoseCtl = dofile(os.getenv("HOME").."/code/personal/bose/hammerspoon/bose.lua"); BoseCtl.start()`. Edits apply on Hammerspoon reload.
 - The Swift core that does the actual RFCOMM work lives in `cli/` (see below). The macOS app target (`macos/BoseControl/`) is pure SwiftUI/Foundation and does NO RFCOMM — it shells `bose`, so the two never drift and the app can't reintroduce a transport/poll bug.
@@ -326,9 +328,9 @@ surface. Keep this in sync when adding a verb or control.
 | Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
 | EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
 | Multipoint | 01,0A | ✅ `multipoint` | — | — | ✅ toggle |
-| Auto-pause | **01,18** | ✅ `auto-pause` | — | — | — (parser only, no UI) |
-| Auto-answer | **01,1B** | ✅ `auto-answer` | — | — | — |
-| Favorites | **1F,08** | ✅ `favorites` | — | — | — (parser only, no UI) |
+| Auto-pause | **01,18** | ✅ `auto-pause` | ✅ `bose-auto-pause` | — | — (parser only, no UI) |
+| Auto-answer | **01,1B** | ✅ `auto-answer` | ✅ `bose-auto-answer` | — | — |
+| Favorites | **1F,08** | ✅ `favorites` | 👁 `bose-favorites` | — | — (parser only, no UI) |
 | Connect device | 04,01 | ✅ `connect`/`swap` | ✅ `bose-connect` | ✅ Opt+⇧B toggle · Opt+J → Mac (Opt+B opens app) | ✅ widget/tile/picker |
 | Disconnect device | 04,02 | ✅ `disconnect` | ✅ `bose-disconnect` | 👁 (toggle path) | — |
 | Device info (ACL) | 04,05 | 👁 `devices` (○ state) | — | — | 👁 widget colour |

--- a/cli/Parsers.swift
+++ b/cli/Parsers.swift
@@ -29,6 +29,9 @@ struct HeadphoneState {
     var audioCodec: String = ""
     var deviceName: String = ""
     var multipointEnabled: Bool = false
+    var autoPlayPause: Bool = false   // 01,18 — pause when removed
+    var autoAnswer: Bool = false      // 01,1B — answer call when donned
+    var favorites: [Int] = []         // 1F,08 — favourited mode slots
     var autoOffTimer: [UInt8] = []
     var cncLevel: Int = 0
     var eq: (bass: Int, mid: Int, treble: Int) = (0, 0, 0)
@@ -242,6 +245,9 @@ func parseAllState(_ provide: ResponseProvider) -> HeadphoneState {
     }
 
     if let r = resp(0x01, 0x0A) { s.multipointEnabled = parseMultipointEnabled(r[4]) }
+    if let r = resp(0x01, 0x18), r.count >= 5 { s.autoPlayPause = (r[4] & 0x01) != 0 }
+    if let r = resp(0x01, 0x1B), r.count >= 5 { s.autoAnswer = (r[4] & 0x01) != 0 }
+    if let r = provide(0x1F, 0x08), let fav = parseFavorites(r) { s.favorites = fav }
     if let r = resp(0x01, 0x0B) { s.autoOffTimer = Array(r[4...]) }
     // No on-head/wear field: the QC Ultra 2 headphones don't expose live worn state.
     // The real wear function is StatusInEar (02,09) — but it's an EARBUDS feature

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -123,6 +123,9 @@ let responses: [[UInt8]: [UInt8]] = [
     [0x05, 0x01]: twoDevices,                                                // 2 active devices
     [0x1F, 0x0A]: cncResp,                                                   // cnc level 7
     [0x01, 0x0A]: [0x01, 0x0A, 0x03, 0x01, 0x07],                            // multipoint on
+    [0x01, 0x18]: [0x01, 0x18, 0x03, 0x01, 0x01],                            // auto-pause on
+    [0x01, 0x1B]: [0x01, 0x1B, 0x03, 0x01, 0x00],                            // auto-answer off
+    [0x1F, 0x08]: [0x1F, 0x08, 0x03, 0x03, 0x0B, 0x00, 0x07],                // favorites 0/1/2
     [0x00, 0x05]: [0x00, 0x05, 0x03, 0x05] + Array("1.2.3".utf8),            // firmware
     // EQ RESP: parser reads value bytes at absolute indices 6, 10, 14 (v1-proven
     // layout: 3x 4-byte groups, value is the 3rd byte of each group).
@@ -138,6 +141,9 @@ check(state.volume == 20 && state.volumeMax == 31, "allState: volume 20/31")
 check(state.connectedDevices.count == 2, "allState: 2 connected devices")
 check(state.cncLevel == 7, "allState: cnc level 7")
 check(state.multipointEnabled, "allState: multipoint on")
+check(state.autoPlayPause, "allState: auto-pause on")
+check(!state.autoAnswer, "allState: auto-answer off")
+check(state.favorites == [0, 1, 2], "allState: favorites 0/1/2")
 check(state.firmware == "1.2.3", "allState: firmware 1.2.3")
 check(state.eq.bass == 3 && state.eq.mid == 0 && state.eq.treble == -3, "allState: EQ +3/0/-3 (signed)")
 

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -174,6 +174,9 @@ func cmdInfoJSON() {
         "volumeMax": s.volumeMax,
         "eq": ["bass": s.eq.bass, "mid": s.eq.mid, "treble": s.eq.treble],
         "multipoint": s.multipointEnabled,
+        "autoPlayPause": s.autoPlayPause,
+        "autoAnswer": s.autoAnswer,
+        "favorites": s.favorites,
         "devices": deviceStates,
     ]
     out.merge(mode) { _, new in new }

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -24,6 +24,9 @@ final class BoseManager: ObservableObject {
     @Published var deviceName: String = "verBosita"
     @Published var firmware: String = ""
     @Published var multipointEnabled: Bool = false
+    @Published var autoPlayPause: Bool = false   // 01,18 — pause when removed
+    @Published var autoAnswer: Bool = false      // 01,1B — answer call when donned
+    @Published var favorites: [Int] = []         // 1F,08 — favourited mode slots (display-only)
     @Published var eq: (bass: Int, mid: Int, treble: Int) = (0, 0, 0)
     @Published var isRefreshing: Bool = false
 
@@ -155,6 +158,9 @@ final class BoseManager: ObservableObject {
         volume = (s["volume"] as? Int) ?? volume
         volumeMax = (s["volumeMax"] as? Int) ?? volumeMax
         multipointEnabled = (s["multipoint"] as? Bool) ?? false
+        autoPlayPause = (s["autoPlayPause"] as? Bool) ?? false
+        autoAnswer = (s["autoAnswer"] as? Bool) ?? false
+        favorites = (s["favorites"] as? [Int]) ?? []
         if let name = s["deviceName"] as? String, !name.isEmpty { deviceName = name }
         if let fw = s["firmware"] as? String { firmware = fw }
         if let e = s["eq"] as? [String: Any] {
@@ -214,6 +220,18 @@ final class BoseManager: ObservableObject {
     func setMultipoint(_ enabled: Bool) {
         multipointEnabled = enabled
         write(["multipoint", enabled ? "on" : "off"])
+    }
+
+    /// Pause playback when the headphones are removed (01,18, SET_GET).
+    func setAutoPlayPause(_ enabled: Bool) {
+        autoPlayPause = enabled
+        write(["auto-pause", enabled ? "on" : "off"])
+    }
+
+    /// Answer an incoming call when the headphones are donned (01,1B, SET_GET).
+    func setAutoAnswer(_ enabled: Bool) {
+        autoAnswer = enabled
+        write(["auto-answer", enabled ? "on" : "off"])
     }
 
     /// Set the active mode's noise level (0 = max cancel … 10 = transparency) via the

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -236,9 +236,61 @@ struct ContentView: View {
             .toggleStyle(.switch)
             .tint(boseAccent)
 
+            // Auto-pause (01,18) — pause when the headphones are removed
+            Toggle(isOn: Binding(
+                get: { manager.autoPlayPause },
+                set: { manager.setAutoPlayPause($0) }
+            )) {
+                Text("AUTO-PAUSE")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(secondaryColor)
+                    .tracking(1)
+            }
+            .toggleStyle(.switch)
+            .tint(boseAccent)
+
+            // Auto-answer (01,1B) — answer a call when the headphones are donned
+            Toggle(isOn: Binding(
+                get: { manager.autoAnswer },
+                set: { manager.setAutoAnswer($0) }
+            )) {
+                Text("AUTO-ANSWER")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(secondaryColor)
+                    .tracking(1)
+            }
+            .toggleStyle(.switch)
+            .tint(boseAccent)
+
+            // Favourites (1F,08) — display-only: which mode slots are marked favourite
+            if !manager.favorites.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("FAVOURITES")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(secondaryColor)
+                        .tracking(1)
+                    Text(manager.favorites.map(favoriteModeName).joined(separator: ", "))
+                        .font(.system(size: 12))
+                        .foregroundColor(inkColor)
+                }
+            }
+
             Spacer()
         }
         .padding(16)
+    }
+
+    /// Friendly name for a favourited AudioModes slot index (display-only).
+    private func favoriteModeName(_ idx: Int) -> String {
+        switch idx {
+        case 0: return "Quiet"
+        case 1: return "Aware"
+        case 2: return "Immersion"
+        case 3: return "Cinema"
+        case 4: return "Custom 1"
+        case 5: return "Custom 2"
+        default: return "Slot \(idx)"
+        }
     }
 
     // MARK: - Right Panel (Device Grid + EQ)

--- a/raycast/bose-auto-answer.sh
+++ b/raycast/bose-auto-answer.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Raycast script command — get/set auto-answer (answer an incoming call when the
+# headphones are donned, BMAP 01,1B). Leave the argument blank to read the state.
+# Requires the Bose to be connected to this Mac (it talks over RFCOMM on demand).
+#
+# @raycast.schemaVersion 1
+# @raycast.title Bose: Auto-Answer
+# @raycast.mode inline
+# @raycast.icon 🎧
+# @raycast.packageName Bose
+# @raycast.argument1 { "type": "text", "placeholder": "on/off (blank=read)", "optional": true }
+
+"$HOME/bin/bose" auto-answer "$1"

--- a/raycast/bose-auto-pause.sh
+++ b/raycast/bose-auto-pause.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Raycast script command — get/set auto-pause (pause when the headphones are
+# removed, BMAP 01,18). Leave the argument blank to read the current state.
+# Requires the Bose to be connected to this Mac (it talks over RFCOMM on demand).
+#
+# @raycast.schemaVersion 1
+# @raycast.title Bose: Auto-Pause
+# @raycast.mode inline
+# @raycast.icon 🎧
+# @raycast.packageName Bose
+# @raycast.argument1 { "type": "text", "placeholder": "on/off (blank=read)", "optional": true }
+
+"$HOME/bin/bose" auto-pause "$1"

--- a/raycast/bose-favorites.sh
+++ b/raycast/bose-favorites.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Raycast script command — show which AudioModes slots are marked favourite
+# (BMAP 1F,08). Display-only. Requires the Bose to be connected to this Mac
+# (it talks over RFCOMM on demand).
+#
+# @raycast.schemaVersion 1
+# @raycast.title Bose: Favourites
+# @raycast.mode inline
+# @raycast.icon 🎧
+# @raycast.packageName Bose
+
+"$HOME/bin/bose" favorites


### PR DESCRIPTION
Surfaces the three commands added in #120 beyond the CLI. Scope (chosen): Raycast + Mac app; Favorites display-only; Android UI out of scope.

- **CLI read-path** — `HeadphoneState` gains `autoPlayPause`/`autoAnswer`/`favorites`; `parseAllState` reads 01,18 / 01,1B / 1F,08 (favorites via the #120 `parseFavorites`); `cmdInfoJSON` emits them. The `info --json` test is extended (auto-pause on / auto-answer off / favorites {0,1,2}).
- **Mac app (Bose.app)** — `BoseManager` parses the new JSON fields and gains `setAutoPlayPause`/`setAutoAnswer` writers; `ContentView` adds two switch toggles + a read-only favourites display (mode-slot names).
- **Raycast** — `bose-auto-pause.sh` / `bose-auto-answer.sh` (on/off, blank = read) + `bose-favorites.sh` (display-only).

Android UI intentionally untouched (out of scope; the Kotlin parser already exists from #120).

**Verification**: Swift parser tests green (incl. the 3 new `info --json` fields), `cli/build.sh` builds, `macos/build.sh` builds + Developer-ID signs the app. The verbs themselves were live-verified in #120; the `info --json` aggregation is additive + unit-tested, but its live read is pending the headphones reconnecting to the Mac (they slept mid-session, so RFCOMM couldn't open for a live check).