### PR TITLE
feat: Immersive Audio (Off/Still/Motion) control

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Surface auto-pause/auto-answer/favorites in Raycast + Mac app (favorites display-only)
-Surface auto-pause/auto-answer/favorites in Raycast + Mac app (favorites display-only)
+verBosita surface Immersive Audio Sidetone Voice prompts Button remap
+verBosita surface Immersive Audio Sidetone Voice prompts Button remap
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - surface-autopause-answer-favs
+# Agent Progress - bose-extra-controls
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-20T02:05:30Z
+# Created: 2026-06-20T02:52:42Z
 
-feature=surface-autopause-answer-favs
-name=Surface auto-pause/auto-answer/favorites in Raycast + Mac app (favorites display-only)
+feature=bose-extra-controls
+name=verBosita surface Immersive Audio Sidetone Voice prompts Button remap
 status=pending
 step=0
 step_name=Not started
-created=2026-06-20T02:05:30Z
+created=2026-06-20T02:52:42Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ is three thin front-ends that shell out to the `cli/` binary (`~/bin/bose`), so
 nothing runs in the background and the Mac only touches the headphones on an
 explicit user action.
 - `macos/BoseControl/` -- **Bose.app**: a windowed SwiftUI app (warm-paper light
-  two-panel: battery/ANC mode/volume/multipoint + auto-pause/auto-answer toggles
+  two-panel: battery/ANC mode/Immersive Audio (spatial Off/Still/Motion)/volume/multipoint + auto-pause/auto-answer toggles
   (01,18 / 01,1B) + a favourites display (1F,08, read-only) + device grid + EQ). The light
   theme (burnt-orange `#AF3A03` accent on warm paper, from the Midterm `paper-hc` palette)
   is shared with the Android app; macOS colours live in `ContentView.swift`, Android in
@@ -70,7 +70,7 @@ explicit user action.
 - Companion device registered for background FGS privileges
 
 ### CLI (`cli/`) — regenerated on the shared layer
-- `cli/main.swift` -- `bose` command surface (status/battery/anc/devices/connect/disconnect/swap/volume/multipoint/auto-pause/auto-answer/favorites/play-pause-next-prev/eq/raw). **No inline byte parsing** — every command routes through the generated `BMAP.*` builders. `connect`/`swap` poll-confirm via `getConnectedDevices` (ACK is never success); volume uses the generated SET_GET builder.
+- `cli/main.swift` -- `bose` command surface (status/battery/anc/anc-level/spatial/devices/connect/disconnect/swap/volume/multipoint/auto-pause/auto-answer/favorites/play-pause-next-prev/eq/raw). **No inline byte parsing** — every command routes through the generated `BMAP.*` builders. `connect`/`swap` poll-confirm via `getConnectedDevices` (ACK is never success); volume uses the generated SET_GET builder.
 - `cli/Transport.swift` -- IOBluetooth RFCOMM transport (per-command open/drain-300ms/close, cold-start warm-up, serial queue).
 - `cli/Composites.swift` -- live-channel composites (cncLevel RMW, connectedDevices list, getAllState single-session).
 - `cli/Parsers.swift` -- pure, hardware-free response parsers; `cli/Tests/main.swift` + `cli/run-tests.sh` are the standalone unit tests (same captured-byte corpus as Android `Parsers.kt`).
@@ -277,10 +277,16 @@ BMAP operator (SET/0x06 instead of SET_GET/0x02).
 | Media control | 05,03 | START | `05,03,05,01,{action}` | 01=play 02=pause 03=next 04=prev |
 | **EQ band** | 01,07 | **SET_GET** | `01,07,02,02,{value},{band}` | band: 0=bass 1=mid 2=treble, value: signed -10 to +10 |
 | **Noise level** | **1F,06** | **SET_GET** | per-mode read-modify-write (see below) | 0 = max cancel … 10 = transparency. The CORRECT level command (`bose anc-level`). Reads a mode's config, changes only the level, forces `ancToggle=1`, writes back — ANC stays anchored to the mode. Only on `cncMutable` modes (custom slots); Quiet/Aware/spatial modes are fixed. |
+| **Immersive Audio (spatial)** | **1F,06** | **SET_GET** | per-mode RMW, spatial byte (resp [44] / SET [37]) | 0 = off, 1 = Still (fixed-to-room), 2 = Motion (head-tracking). The CORRECT spatial command (`bose spatial off\|still\|motion`). Same 1F,06 RMW as noise level — changes only the spatial byte. Settable ONLY on `spatialMutable` modes (custom slots 4/5, payload[41] bit2); named modes carry it fixed (Immersion = Motion, Cinema = Still). The global 05,0F path is FuncNotSupp. |
 | ~~ANC depth~~ | ~~1F,0A~~ | — | — | **DO NOT USE.** `1F,0A` (AudioModesSettingsConfig) is GLOBAL live-tuning; writing it over an active mode DETACHES the mode → 1F,03 reads 255 = ANC OFF (#83, confirmed audibly). The old `anc-depth` command + Raycast used this — removed. Use `anc-level` (1F,06) instead. |
 
-**Not supported on QC Ultra 2:** StandbyTimer SET (01,04), MotionAutoOff (01,14), OnHeadDetection SET (01,10).
-Auto-off timer (01,0B) is read-only over RFCOMM — distinct from StandbyTimer (01,04).
+**Not supported / write-locked on QC Ultra 2 (all re-verified live 2026-06-20, fw 8.2.20 — don't re-investigate):**
+- **StandbyTimer SET (01,04)**, **MotionAutoOff (01,14)**, **OnHeadDetection SET (01,10)**, **CncPresets (01,0F)**: reply **FuncNotSupp** (error op 0x04, code 4) to a GET. Dead.
+- **Global Immersive/Spatial Audio (05,0F SpatialAudioMode, 05,10 SpatialAudioStatus)**: FuncNotSupp. The dedicated AudioManagement spatial functions don't exist here — spatial is per-mode only (see AudioModes 1F,06 below).
+- **VoicePrompts (01,03)**: GET works (`01 03 03 07 41 00 00 81 02 00 00` → enabled=0, lang=UsEnglish), but `isTogglable` (config bit7) = 0 and the enable SET_GET is **silently ignored** (response byte unchanged, cold + warm). Read-only on this firmware.
+- **Buttons / action-button mode (01,09)**: GET works (`01 09 03 07 80 09 13 …` → button id 0x80, eventType 0x09, **already SpatialAudioMode (0x13)**; only Vpa/Disabled/SpotifyGoMode/SpatialAudioMode assignable), but the SET_GET (op 0x02) **and** plain SET (op 0x06) both return **No response** and leave state unchanged, cold + warm. Write-locked — Bose's app likely uses a privileged channel we don't replicate.
+- **Sidetone**: no settable opcode (the 01,0B the generic BMAP enum labels "Sidetone" is the read-only **auto-off timer** here — returns `01 0b 03 03 01 02 0f`).
+- Auto-off timer (01,0B) is read-only over RFCOMM — distinct from StandbyTimer (01,04).
 
 ### AudioModes (block 0x1F) — ANC is MODE-based (reverse-engineered from the Bose app, confirmed live fw 8.2.20)
 
@@ -299,6 +305,7 @@ ancToggle. **Level semantics: 0 = max cancellation (Quiet end), 10 = full transp
 - **1F,06 GET** request `1F 06 01 01 {index}`. RESPONSE `1F 06 03 30 {48-byte payload}`; offsets (payload = frame[4:]): `[0]`index, `[1..2]`prompt, `[3]`userConfigurable, `[6..37]`32-byte name, `[41]`mutability bitfield (**bit0 = cncMutable** = level editable; bit4 = ancToggleMutable), `[42]`cncLevel, `[43]`autoCNC, `[44]`spatial, `[46]`windBlock, `[47]`ancToggle.
 - **1F,06 SET_GET** (DIFFERENT layout) `1F 06 02 28 {payload}`: `[0]`index, `[1..2]`prompt, `[3..34]`32-byte name, `[35]`cncLevel, `[36]`autoCNC, `[37]`spatial, `[38]`windBlock, `[39]`ancToggle.
 - `bose anc-level [0-10]` does the GET→change-level→SET_GET RMW on the **active** mode, forcing `ancToggle=1`, and refuses if the mode's `cncMutable` is false (so it can never disable ANC). Pure parse/build = `parseModeConfig`/`buildModeConfigSet` (Parsers); session RMW = `setActiveModeLevel` (Composites).
+- `bose spatial [off|still|motion]` does the same 1F,06 RMW on the **active** mode's spatial byte (Immersive Audio), refusing if the mode's `spatialMutable` (payload[41] bit2) is false. Verified live 2026-06-20: custom slots 4/5 have spatialMutable=1; Immersion carries spatial=2 (Motion), Cinema spatial=1 (Still). Build = `buildModeConfigSet(_, newSpatial:)`; session RMW = `setActiveModeSpatial` (Composites). `ModeConfig.spatialMutable` is the bit2 read. Surfaced in the macOS app as the IMMERSIVE AUDIO segmented control (greys out on fixed modes, like the Level slider).
 - Implementation derived from decompiling `com.bose.bosemusic` (`AudioModesModeConfigResponse`, `FBlockAudioModesKt`); see `docs/plans/2026-06-08-cnc-mode-config-proper.md`.
 
 ### BMAP Function IDs (Block 0x05 — Audio)
@@ -325,6 +332,7 @@ surface. Keep this in sync when adding a verb or control.
 |------------|-----------|-----------|---------|-------------|---------|
 | ANC mode | 1F,03 | ✅ `anc` | 👁 (in status) | ✅ Opt+N cycle | ✅ mode selector |
 | Noise level (CNC) | **1F,06** | ✅ `anc-level` (custom modes) | ✅ `bose-anc-level` | — | ✅ slider (1F,06 RMW, custom modes only) |
+| Immersive Audio (spatial) | **1F,06** | ✅ `spatial` (custom modes) | — | — | — (macOS app only) |
 | Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
 | EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
 | Multipoint | 01,0A | ✅ `multipoint` | — | — | ✅ toggle |

--- a/cli/Composites.swift
+++ b/cli/Composites.swift
@@ -119,6 +119,35 @@ extension Transport {
             return rmwActiveModeLevel(level) { t.send(ch, $0, timeout: 2.0) }
         } ?? .unreachable
     }
+
+    enum SpatialResult { case ok(name: String, spatial: Int), fixed(name: String), unreachable }
+
+    /// In-session RMW of the active mode's Immersive Audio (spatial) mode via the same
+    /// 1F,06 path as the noise level (0 = off, 1 = Still, 2 = Motion). The spatial byte is
+    /// per-mode and only editable where the firmware sets `spatialMutable` (payload[41]
+    /// bit2) — the two custom slots on verBosita; the named modes (Quiet/Aware/Immersion/
+    /// Cinema) carry it fixed (Immersion = Motion, Cinema = Still). Refuses on a fixed mode
+    /// so the call is a clean no-op rather than a silently-ignored write. The global
+    /// AudioManagement function (05,0F) is FuncNotSupp on this firmware — this per-mode RMW
+    /// is the only working path.
+    private func rmwActiveModeSpatial(_ spatial: Int, send: (_ frame: [UInt8]) -> [UInt8]?) -> SpatialResult {
+        guard let cur = send([0x1F, 0x03, 0x01, 0x00]), cur.count >= 5,
+              let r1 = send([0x1F, 0x06, 0x01, 0x01, cur[4]]),
+              let cfg = parseModeConfig(r1) else { return .unreachable }
+        guard cfg.spatialMutable else { return .fixed(name: cfg.displayName) }
+        _ = send(buildModeConfigSet(cfg, newLevel: nil, newSpatial: spatial))
+        let after = send([0x1F, 0x06, 0x01, 0x01, cur[4]]).flatMap(parseModeConfig)
+        return .ok(name: cfg.displayName, spatial: Int(after?.spatial ?? cfg.spatial))
+    }
+
+    /// Set the ACTIVE mode's Immersive Audio mode (0 = off, 1 = Still, 2 = Motion) via the
+    /// 1F,06 RMW. Refuses on a mode whose spatial is fixed. Returns the post-write value.
+    func setActiveModeSpatial(_ spatial: Int) -> SpatialResult {
+        session { ch, t in
+            _ = t.send(ch, [0x02, 0x02, 0x01, 0x00], timeout: 2.0)  // prime warm
+            return rmwActiveModeSpatial(spatial) { t.send(ch, $0, timeout: 2.0) }
+        } ?? .unreachable
+    }
 }
 
 /// Uppercase-hex MAC key for set membership (keeps this file independent of

--- a/cli/Parsers.swift
+++ b/cli/Parsers.swift
@@ -90,9 +90,10 @@ struct ModeConfig: Equatable {
     var userConfigurable: Bool  // payload[3] — a user mode slot
     var name: [UInt8]      // 32 bytes, null-padded UTF-8
     var cncMutable: Bool   // payload[41] bit 0 — is the CNC level editable for this mode?
+    var spatialMutable: Bool  // payload[41] bit 2 — is the spatial (Immersive Audio) mode editable?
     var cncLevel: UInt8
     var autoCNC: UInt8
-    var spatial: UInt8
+    var spatial: UInt8     // 0 = off, 1 = Still (fixed-to-room), 2 = Motion (head-tracking)
     var windBlock: UInt8
     var ancToggle: UInt8
 
@@ -116,22 +117,26 @@ func parseModeConfig(_ resp: [UInt8]) -> ModeConfig? {
         userConfigurable: p[3] == 1,
         name: Array(p[6...37]),
         cncMutable: (p[41] & 0x01) == 1,
+        spatialMutable: (p[41] & 0x04) != 0,
         cncLevel: p[42], autoCNC: p[43], spatial: p[44],
         windBlock: p[46], ancToggle: p[47])
 }
 
-/// Build a 1F,06 AudioModesModeConfig SET_GET frame from a parsed mode, changing ONLY
-/// `cncLevel` and forcing `ancToggle = 1` (so a level change can't disable ANC). The
-/// SET payload layout (from the decompiled app, distinct from the response): [0]=index,
-/// [1..2]=prompt, [3..34]=32-byte name, [35]=cncLevel, [36]=autoCNC, [37]=spatial,
-/// [38]=windBlock, [39]=ancToggle. Pass `newLevel = nil` for an unchanged round-trip.
-func buildModeConfigSet(_ cfg: ModeConfig, newLevel: Int?) -> [UInt8] {
+/// Build a 1F,06 AudioModesModeConfig SET_GET frame from a parsed mode, changing only
+/// `cncLevel` and/or the spatial (Immersive Audio) mode, and forcing `ancToggle = 1` (so
+/// a level change can't disable ANC). The SET payload layout (from the decompiled app,
+/// distinct from the response): [0]=index, [1..2]=prompt, [3..34]=32-byte name,
+/// [35]=cncLevel, [36]=autoCNC, [37]=spatial, [38]=windBlock, [39]=ancToggle. Pass
+/// `newLevel`/`newSpatial = nil` to leave that field unchanged (a no-op round-trip when
+/// both are nil). `newSpatial`: 0 = off, 1 = Still, 2 = Motion.
+func buildModeConfigSet(_ cfg: ModeConfig, newLevel: Int?, newSpatial: Int? = nil) -> [UInt8] {
     let level = newLevel.map { UInt8(max(0, min(10, $0))) } ?? cfg.cncLevel
+    let spatial = newSpatial.map { UInt8(max(0, min(2, $0))) } ?? cfg.spatial
     var name = Array(cfg.name.prefix(32))
     while name.count < 32 { name.append(0) }
     var payload: [UInt8] = [cfg.index, cfg.promptB1, cfg.promptB2]
     payload += name
-    payload += [level, cfg.autoCNC, cfg.spatial, cfg.windBlock, 0x01]  // ancToggle forced on
+    payload += [level, cfg.autoCNC, spatial, cfg.windBlock, 0x01]  // ancToggle forced on
     return [0x1F, 0x06, 0x02, UInt8(payload.count)] + payload
 }
 

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -92,6 +92,21 @@ check(sp[39] == 1, "modeConfigSet: ancToggle forced ON @39 (level change can't d
 check(buildModeConfigSet(custom, newLevel: nil)[4 + 35] == 7, "modeConfigSet: nil keeps current level")
 check(buildModeConfigSet(custom, newLevel: 99)[4 + 35] == 10, "modeConfigSet: clamps to 10")
 
+// ── Immersive Audio / spatial (1F,06 payload[41] bit2 + payload[44]) ─────────────
+// Live verBosita (fw 8.2.20): custom modes p[41]=0x1d -> spatialMutable; Immersion
+// p[44]=2 (Motion), Cinema p[44]=1 (Still). spatial byte: 0 off, 1 Still, 2 Motion.
+check(custom.spatialMutable, "modeConfig: 0x1D mutability bit2 -> spatialMutable")
+check(!fixed.spatialMutable, "modeConfig: 0x00 mutability -> spatial fixed")
+func mcSpatial(_ value: UInt8) -> [UInt8] { var f = mc(index: 5, name: "None", mutability: 0x1D, level: 7, anc: 1); f[4 + 44] = value; return f }
+check(parseModeConfig(mcSpatial(2))!.spatial == 2, "modeConfig: spatial byte @44 = Motion")
+check(parseModeConfig(mcSpatial(1))!.spatial == 1, "modeConfig: spatial byte @44 = Still")
+// SET layout: spatial @37. newSpatial writes it; nil keeps current; clamps to 0...2.
+let motionMode = parseModeConfig(mcSpatial(0))!
+check(buildModeConfigSet(motionMode, newLevel: nil, newSpatial: 2)[4 + 37] == 2, "modeConfigSet: new spatial @37 = Motion")
+check(buildModeConfigSet(parseModeConfig(mcSpatial(2))!, newLevel: nil)[4 + 37] == 2, "modeConfigSet: nil keeps current spatial")
+check(buildModeConfigSet(motionMode, newLevel: nil, newSpatial: 9)[4 + 37] == 2, "modeConfigSet: clamps spatial to 2")
+check(buildModeConfigSet(motionMode, newLevel: 4, newSpatial: 1)[4 + 35] == 4, "modeConfigSet: level + spatial together (level @35)")
+
 // ── Favorites (1F,08) ───────────────────────────────────────────────────────────
 // Live capture on verBosita (fw 8.2.20): GET 1F 08 01 00 -> STATUS 1f 08 03 03 0b 00 07.
 // count 0x0b (11 slots) + reversed-order bitmask 00 07 = modes 0,1,2 favourited.

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -153,13 +153,15 @@ func cmdInfoJSON() {
     // Active mode's noise config (1F,06) — drives the app's noise slider. Its own warm
     // session (event-driven read, not polled). `noiseAdjustable` (cncMutable) gates the
     // slider so a level write can never disable ANC (#83). nil → slider hidden/disabled.
-    var mode: [String: Any] = ["noiseAdjustable": false]
+    var mode: [String: Any] = ["noiseAdjustable": false, "spatialAdjustable": false]
     if let cfg = transport.readActiveModeConfig() {
         mode = [
             "modeName": cfg.displayName,
             "modeIndex": Int(cfg.index),
             "noiseLevel": Int(cfg.cncLevel),
             "noiseAdjustable": cfg.cncMutable,
+            "spatial": spatialName(Int(cfg.spatial)),
+            "spatialAdjustable": cfg.spatialMutable,
         ]
     }
 
@@ -252,6 +254,32 @@ func cmdAncLevel(_ arg: String?) {
     }
     guard let cfg = transport.readActiveModeConfig() else { fail("headphones not reachable") }
     print("\(cfg.displayName): noise level \(cfg.cncLevel)/10\(cfg.cncMutable ? "" : " (fixed)")")
+}
+
+/// Immersive Audio (spatial) mode names ↔ byte: 0 off, 1 Still, 2 Motion.
+let spatialNames = ["off", "still", "motion"]
+func spatialName(_ v: Int) -> String { (0..<spatialNames.count).contains(v) ? spatialNames[v] : "off" }
+
+/// spatial [off|still|motion] — Immersive Audio on the ACTIVE mode (1F,06 RMW). Bare =
+/// read. Settable only on the custom (spatialMutable) modes; named modes are fixed
+/// (Immersion = Motion, Cinema = Still). The global 05,0F function is FuncNotSupp here.
+func cmdSpatial(_ arg: String?) {
+    if let arg = arg {
+        guard let value = spatialNames.firstIndex(of: arg.lowercased()) else {
+            fail("spatial must be off | still | motion")
+        }
+        switch transport.setActiveModeSpatial(value) {
+        case .ok(let name, let spatial):
+            print("\(name): Immersive Audio \(spatialName(spatial))")
+        case .fixed(let name):
+            fail("\(name)'s Immersive Audio is fixed — switch to a custom mode to set it (Immersion = Motion, Cinema = Still)")
+        case .unreachable:
+            fail("headphones not reachable")
+        }
+        return
+    }
+    guard let cfg = transport.readActiveModeConfig() else { fail("headphones not reachable") }
+    print("\(cfg.displayName): Immersive Audio \(spatialName(Int(cfg.spatial)))\(cfg.spatialMutable ? "" : " (fixed)")")
 }
 
 /// name [new name] — get/set the headphone name. SET is `01,02,06,{len},00,{utf8}`
@@ -634,6 +662,7 @@ func usage() {
       bose swap <device>        Route audio to device (multipoint; keeps others)
       bose anc [mode]           Get/set ANC (quiet/aware/immersion/cinema/custom1/custom2, or slot 0-5)
       bose anc-level [0-10]     Get/set active mode's noise level (0=max cancel … 10=transparent; custom modes only)
+      bose spatial [off|still|motion]  Get/set Immersive Audio on the active mode (custom modes only)
       bose name [new name]      Get/set headphone name (max 30 UTF-8 bytes)
       bose volume [0-31]        Get/set volume
       bose multipoint [on|off]  Get/set multipoint
@@ -663,6 +692,7 @@ case "info":                   args.contains("--json") ? cmdInfoJSON() : cmdInfo
 case "battery", "b":           cmdBattery()
 case "anc":                    cmdAnc(args.count >= 3 ? args[2] : nil)
 case "anc-level":              cmdAncLevel(args.count >= 3 ? args[2] : nil)
+case "spatial", "immersive":   cmdSpatial(args.count >= 3 ? args[2] : nil)
 case "name":                   cmdName(args.count >= 3 ? args[2...].joined(separator: " ") : nil)
 case "devices":                cmdDevices()
 case "connect", "c":           cmdConnect(requireArg("device"))

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -38,6 +38,14 @@ final class BoseManager: ObservableObject {
     @Published var noiseAdjustable: Bool = false
     @Published var modeName: String = ""
 
+    // Active mode's Immersive Audio (spatial) mode: "off" / "still" / "motion" (1F,06
+    // payload[44]). `spatialAdjustable` (the firmware spatialMutable bit, payload[41]
+    // bit2) gates the control — only the custom modes are settable; named modes carry it
+    // fixed (Immersion = Motion, Cinema = Still). Writing is via the CLI `spatial`, which
+    // refuses on fixed modes. The global 05,0F function is FuncNotSupp on this firmware.
+    @Published var spatial: String = "off"
+    @Published var spatialAdjustable: Bool = false
+
     // Device routing states: "active" / "connected" / "offline"
     @Published var deviceStates: [String: String] = [
         "mac": "offline", "phone": "offline", "ipad": "offline",
@@ -185,6 +193,8 @@ final class BoseManager: ObservableObject {
         noiseLevel = (s["noiseLevel"] as? Int) ?? noiseLevel
         noiseAdjustable = (s["noiseAdjustable"] as? Bool) ?? false
         modeName = (s["modeName"] as? String) ?? modeName
+        spatial = (s["spatial"] as? String) ?? spatial
+        spatialAdjustable = (s["spatialAdjustable"] as? Bool) ?? false
     }
 
     // MARK: - Write (each: run verb, optimistic local update, then re-read)
@@ -242,6 +252,15 @@ final class BoseManager: ObservableObject {
         let clamped = max(0, min(10, level))
         noiseLevel = clamped
         write(["anc-level", String(clamped)])
+    }
+
+    /// Set the active mode's Immersive Audio mode ("off"/"still"/"motion") via the CLI
+    /// `spatial` (the 1F,06 RMW). No-op unless the active mode is adjustable — the CLI
+    /// refuses on fixed modes anyway. Only the custom modes are settable.
+    func setSpatial(_ value: String) {
+        guard spatialAdjustable, ["off", "still", "motion"].contains(value) else { return }
+        spatial = value
+        write(["spatial", value])
     }
 
     /// Tell the headphones to make `name` the active sink. The tile shows a spinner

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -199,6 +199,28 @@ struct ContentView: View {
                 }
             }
 
+            // Immersive Audio (1F,06 spatial byte): Off / Still / Motion. Settable only on
+            // the custom modes (firmware spatialMutable bit) — the named modes carry it
+            // fixed (Immersion = Motion, Cinema = Still), so this greys out on them just
+            // like the Level slider. The global 05,0F function is FuncNotSupp on this fw.
+            VStack(alignment: .leading, spacing: 6) {
+                Text("IMMERSIVE AUDIO")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(secondaryColor)
+                    .tracking(1)
+                HStack(spacing: 4) {
+                    spatialButton("Off", "off")
+                    spatialButton("Still", "still")
+                    spatialButton("Motion", "motion")
+                }
+                .opacity(manager.spatialAdjustable ? 1.0 : 0.5)
+                if !manager.spatialAdjustable {
+                    Text("\(manager.modeName.isEmpty ? "This mode" : manager.modeName)'s spatial mode is fixed — pick a custom mode")
+                        .font(.system(size: 9))
+                        .foregroundColor(offlineColor)
+                }
+            }
+
             // Volume
             VStack(alignment: .leading, spacing: 6) {
                 HStack {
@@ -482,6 +504,31 @@ struct ContentView: View {
             .contentShape(RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
+    }
+
+    /// One Immersive Audio segment (Off/Still/Motion). Highlights the active spatial mode;
+    /// disabled when the active mode's spatial is fixed (only custom modes are settable).
+    private func spatialButton(_ label: String, _ value: String) -> some View {
+        let isActive = manager.spatial == value
+        return Button(action: { manager.setSpatial(value) }) {
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .foregroundColor(isActive ? .white : secondaryColor)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 5)
+                .padding(.horizontal, 2)
+                .background(isActive ? boseAccent : cardColor)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(isActive ? boseAccent : hairColor, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(!manager.spatialAdjustable)
     }
 
     // MARK: - Disconnected View


### PR DESCRIPTION
Surface Bose Immersive Audio spatial mode (Off/Still/Motion) on custom modes via the 1F,06 RMW. Adds `bose spatial` verb, app segmented control, parser spatialMutable bit + tests. Live-verified on verBosita. Documents re-verified dead-ends (voice prompts, button remap, auto-off — FuncNotSupp/write-locked).