### PR TITLE
feat: Android parity for Immersive Audio (Off/Still/Motion)

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-verBosita surface Immersive Audio Sidetone Voice prompts Button remap
-verBosita surface Immersive Audio Sidetone Voice prompts Button remap
+Android parity for Immersive Audio spatial control
+Android parity for Immersive Audio spatial control
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - bose-extra-controls
+# Agent Progress - android-spatial-parity
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-20T02:52:42Z
+# Created: 2026-06-20T03:44:45Z
 
-feature=bose-extra-controls
-name=verBosita surface Immersive Audio Sidetone Voice prompts Button remap
+feature=android-spatial-parity
+name=Android parity for Immersive Audio spatial control
 status=pending
 step=0
 step_name=Not started
-created=2026-06-20T02:52:42Z
+created=2026-06-20T03:44:45Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,7 @@ ancToggle. **Level semantics: 0 = max cancellation (Quiet end), 10 = full transp
 - **1F,06 GET** request `1F 06 01 01 {index}`. RESPONSE `1F 06 03 30 {48-byte payload}`; offsets (payload = frame[4:]): `[0]`index, `[1..2]`prompt, `[3]`userConfigurable, `[6..37]`32-byte name, `[41]`mutability bitfield (**bit0 = cncMutable** = level editable; bit4 = ancToggleMutable), `[42]`cncLevel, `[43]`autoCNC, `[44]`spatial, `[46]`windBlock, `[47]`ancToggle.
 - **1F,06 SET_GET** (DIFFERENT layout) `1F 06 02 28 {payload}`: `[0]`index, `[1..2]`prompt, `[3..34]`32-byte name, `[35]`cncLevel, `[36]`autoCNC, `[37]`spatial, `[38]`windBlock, `[39]`ancToggle.
 - `bose anc-level [0-10]` does the GET→change-level→SET_GET RMW on the **active** mode, forcing `ancToggle=1`, and refuses if the mode's `cncMutable` is false (so it can never disable ANC). Pure parse/build = `parseModeConfig`/`buildModeConfigSet` (Parsers); session RMW = `setActiveModeLevel` (Composites).
-- `bose spatial [off|still|motion]` does the same 1F,06 RMW on the **active** mode's spatial byte (Immersive Audio), refusing if the mode's `spatialMutable` (payload[41] bit2) is false. Verified live 2026-06-20: custom slots 4/5 have spatialMutable=1; Immersion carries spatial=2 (Motion), Cinema spatial=1 (Still). Build = `buildModeConfigSet(_, newSpatial:)`; session RMW = `setActiveModeSpatial` (Composites). `ModeConfig.spatialMutable` is the bit2 read. Surfaced in the macOS app as the IMMERSIVE AUDIO segmented control (greys out on fixed modes, like the Level slider).
+- `bose spatial [off|still|motion]` does the same 1F,06 RMW on the **active** mode's spatial byte (Immersive Audio), refusing if the mode's `spatialMutable` (payload[41] bit2) is false. Verified live 2026-06-20: custom slots 4/5 have spatialMutable=1; Immersion carries spatial=2 (Motion), Cinema spatial=1 (Still). Build = `buildModeConfigSet(_, newSpatial:)`; session RMW = `setActiveModeSpatial` (Composites). `ModeConfig.spatialMutable` is the bit2 read. Surfaced in the macOS app AND the Android app (`MainActivity.kt` SettingsSection → `BoseViewModel.setSpatial` → `Composites.setActiveModeSpatial`) as an Off/Still/Motion segmented control that greys out on fixed modes, like the Level slider.
 - Implementation derived from decompiling `com.bose.bosemusic` (`AudioModesModeConfigResponse`, `FBlockAudioModesKt`); see `docs/plans/2026-06-08-cnc-mode-config-proper.md`.
 
 ### BMAP Function IDs (Block 0x05 — Audio)
@@ -332,7 +332,7 @@ surface. Keep this in sync when adding a verb or control.
 |------------|-----------|-----------|---------|-------------|---------|
 | ANC mode | 1F,03 | ✅ `anc` | 👁 (in status) | ✅ Opt+N cycle | ✅ mode selector |
 | Noise level (CNC) | **1F,06** | ✅ `anc-level` (custom modes) | ✅ `bose-anc-level` | — | ✅ slider (1F,06 RMW, custom modes only) |
-| Immersive Audio (spatial) | **1F,06** | ✅ `spatial` (custom modes) | — | — | — (macOS app only) |
+| Immersive Audio (spatial) | **1F,06** | ✅ `spatial` (custom modes) | — | — | ✅ Off/Still/Motion selector (custom modes only) |
 | Device name | 01,02 | ✅ `name` | — | — | ✅ rename |
 | EQ band | 01,07 | ✅ `eq` | 👁 (in status) | — | ✅ 3-band |
 | Multipoint | 01,0A | ✅ `multipoint` | — | — | ✅ toggle |

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -40,6 +40,11 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
         val noiseLevel: Int = 0,
         val noiseAdjustable: Boolean = false,
         val modeName: String = "",
+        // Immersive Audio (1F,06 spatial byte): 0 = off, 1 = Still, 2 = Motion. Adjustable
+        // only where the firmware spatialMutable bit is set (the custom slots 4/5); named
+        // modes carry it fixed (Immersion = Motion, Cinema = Still).
+        val spatial: Int = 0,
+        val spatialAdjustable: Boolean = false,
         val autoOffTimer: String = "",
         val immersionLevel: IntArray? = null,
 
@@ -99,7 +104,8 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                     BoseProtocol.getDeviceName()?.let { s = s.copy(deviceName = it) }
                     BoseProtocol.getMultipoint()?.let { s = s.copy(multipointEnabled = it) }
                     Composites.readActiveModeConfig()?.let {
-                        s = s.copy(noiseLevel = it.cncLevel, noiseAdjustable = it.cncMutable, modeName = it.displayName)
+                        s = s.copy(noiseLevel = it.cncLevel, noiseAdjustable = it.cncMutable, modeName = it.displayName,
+                            spatial = it.spatial, spatialAdjustable = it.spatialMutable)
                     }
                     BoseProtocol.getAutoOffTimer()?.let { s = s.copy(autoOffTimer = BoseProtocol.autoOffTimerDescription(it)) }
                     BoseProtocol.getSerialNumber()?.let { s = s.copy(serialNumber = it) }
@@ -186,6 +192,8 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                         noiseLevel = cfg.cncLevel,
                         noiseAdjustable = cfg.cncMutable,
                         modeName = cfg.displayName,
+                        spatial = cfg.spatial,
+                        spatialAdjustable = cfg.spatialMutable,
                     )
                 } else {
                     _state.value.copy(ancMode = mode)
@@ -226,6 +234,19 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
         command("Failed to set noise level",
             action = { Composites.setActiveModeLevel(level) },
             onSuccess = { _state.value = _state.value.copy(noiseLevel = level) },
+        )
+    }
+
+    /**
+     * Set the active mode's Immersive Audio (spatial) mode via the 1F,06 RMW. No-op on a
+     * fixed mode (the control is disabled there anyway, and `setActiveModeSpatial` refuses).
+     * spatial: 0 = off, 1 = Still, 2 = Motion.
+     */
+    fun setSpatial(spatial: Int) {
+        if (!_state.value.spatialAdjustable) return
+        command("Failed to set Immersive Audio",
+            action = { Composites.setActiveModeSpatial(spatial) },
+            onSuccess = { _state.value = _state.value.copy(spatial = spatial) },
         )
     }
 

--- a/android/app/src/main/java/au/com/jd/bose/Composites.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Composites.kt
@@ -87,6 +87,34 @@ object Composites {
         return AncLevelResult.Ok(cfg.displayName, after?.cncLevel ?: cfg.cncLevel)
     }
 
+    /** Outcome of an Immersive Audio (spatial) write — mirrors macOS `SpatialResult`. */
+    sealed class SpatialResult {
+        data class Ok(val name: String, val spatial: Int) : SpatialResult()
+        data class Fixed(val name: String) : SpatialResult()
+        object Unreachable : SpatialResult()
+    }
+
+    /**
+     * Set the ACTIVE mode's Immersive Audio (spatial) mode (0 = off, 1 = Still, 2 = Motion)
+     * via the same 1F,06 RMW as the noise level. The spatial byte is per-mode and only
+     * editable where the firmware sets `spatialMutable` (response[41] bit2) — the custom
+     * slots; named modes carry it fixed (Immersion = Motion, Cinema = Still). Refuses on a
+     * fixed mode so the call is a clean no-op. The global AudioManagement function (05,0F) is
+     * FuncNotSupp on this firmware — this per-mode RMW is the only working path. Caller must
+     * be inside `Transport.withConnection { }`.
+     */
+    fun setActiveModeSpatial(spatial: Int): SpatialResult {
+        Transport.send(intArrayOf(0x02, 0x02, 0x01, 0x00)) // prime warm session
+        val cur = Transport.send(intArrayOf(0x1F, 0x03, 0x01, 0x00)) ?: return SpatialResult.Unreachable
+        if (cur.size < 5) return SpatialResult.Unreachable
+        val r1 = Transport.send(intArrayOf(0x1F, 0x06, 0x01, 0x01, cur[4])) ?: return SpatialResult.Unreachable
+        val cfg = Parsers.parseModeConfig(r1) ?: return SpatialResult.Unreachable
+        if (!cfg.spatialMutable) return SpatialResult.Fixed(cfg.displayName)
+        Transport.send(Parsers.buildModeConfigSet(cfg, newLevel = null, newSpatial = spatial))
+        val after = Transport.send(intArrayOf(0x1F, 0x06, 0x01, 0x01, cur[4]))?.let { Parsers.parseModeConfig(it) }
+        return SpatialResult.Ok(cfg.displayName, after?.spatial ?: cfg.spatial)
+    }
+
     /**
      * Connect (switch audio to) a device by MAC. Sends connectDevice (04,01) for the
      * ACK, then polls getConnectedDevices on the SAME channel until the target MAC is

--- a/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
+++ b/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
@@ -357,6 +357,7 @@ fun BoseApp(vm: BoseViewModel = viewModel()) {
                         onSetName = { vm.setDeviceName(it) },
                         onSetMultipoint = { vm.setMultipoint(it) },
                         onSetNoiseLevel = { vm.setNoiseLevel(it) },
+                        onSetSpatial = { vm.setSpatial(it) },
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
@@ -841,6 +842,7 @@ fun SettingsSection(
     onSetName: (String) -> Unit,
     onSetMultipoint: (Boolean) -> Unit,
     onSetNoiseLevel: (Int) -> Unit = {},
+    onSetSpatial: (Int) -> Unit = {},
 ) {
     // Device name
     var editingName by remember { mutableStateOf(false) }
@@ -936,6 +938,53 @@ fun SettingsSection(
     if (!state.noiseAdjustable) {
         Text(
             text = "${state.modeName.ifEmpty { "This mode" }}'s level is fixed — pick a custom mode",
+            fontSize = 11.sp,
+            color = BoseDim,
+            modifier = Modifier.padding(top = 2.dp),
+        )
+    }
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    // Immersive Audio (1F,06 spatial byte): Off / Still / Motion. Settable ONLY on the
+    // custom modes (firmware spatialMutable); named modes carry it fixed (Immersion = Motion,
+    // Cinema = Still) so this greys out on them, like the Noise Level slider. The global
+    // 05,0F path is FuncNotSupp — this per-mode RMW is the only working path.
+    Text("Immersive Audio", fontSize = 14.sp, color = BoseText)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        listOf("Off" to 0, "Still" to 1, "Motion" to 2).forEach { (label, value) ->
+            val isActive = state.spatial == value
+            Surface(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(40.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .border(1.dp, if (isActive) BoseAccent else BoseHair, RoundedCornerShape(10.dp))
+                    .then(if (state.spatialAdjustable) Modifier.clickable { onSetSpatial(value) } else Modifier),
+                color = if (isActive) BoseAccent else BoseCardBg,
+                shape = RoundedCornerShape(10.dp),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Text(
+                        text = label,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        color = if (isActive) Color.White else BoseDim,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+    if (!state.spatialAdjustable) {
+        Text(
+            text = "${state.modeName.ifEmpty { "This mode" }}'s spatial mode is fixed — pick a custom mode",
             fontSize = 11.sp,
             color = BoseDim,
             modifier = Modifier.padding(top = 2.dp),

--- a/android/app/src/main/java/au/com/jd/bose/Parsers.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Parsers.kt
@@ -51,9 +51,10 @@ object Parsers {
         val userConfigurable: Boolean,
         val name: IntArray, // 32 bytes, null-padded UTF-8
         val cncMutable: Boolean, // response[41] bit 0 — is the CNC level editable?
+        val spatialMutable: Boolean, // response[41] bit 2 — is the spatial (Immersive Audio) mode editable?
         val cncLevel: Int,
         val autoCNC: Int,
-        val spatial: Int,
+        val spatial: Int, // 0 = off, 1 = Still (fixed-to-room), 2 = Motion (head-tracking)
         val windBlock: Int,
         val ancToggle: Int,
     ) {
@@ -98,23 +99,26 @@ object Parsers {
             userConfigurable = p[3] == 1,
             name = p.copyOfRange(6, 38), // [6..37] inclusive = 32 bytes
             cncMutable = (p[41] and 0x01) == 1,
+            spatialMutable = (p[41] and 0x04) != 0,
             cncLevel = p[42], autoCNC = p[43], spatial = p[44],
             windBlock = p[46], ancToggle = p[47],
         )
     }
 
     /**
-     * Build a 1F,06 AudioModesModeConfig SET_GET frame, changing ONLY `cncLevel` and
-     * forcing `ancToggle = 1` (so a level change can't disable ANC). SET payload layout
-     * (distinct from the response): [0]=index, [1..2]=prompt, [3..34]=32-byte name,
-     * [35]=cncLevel, [36]=autoCNC, [37]=spatial, [38]=windBlock, [39]=ancToggle. Pass
-     * newLevel=null for an unchanged round-trip.
+     * Build a 1F,06 AudioModesModeConfig SET_GET frame, changing only `cncLevel` and/or the
+     * spatial (Immersive Audio) mode, and forcing `ancToggle = 1` (so a level change can't
+     * disable ANC). SET payload layout (distinct from the response): [0]=index, [1..2]=prompt,
+     * [3..34]=32-byte name, [35]=cncLevel, [36]=autoCNC, [37]=spatial, [38]=windBlock,
+     * [39]=ancToggle. Pass newLevel/newSpatial=null to leave that field unchanged.
+     * newSpatial: 0 = off, 1 = Still, 2 = Motion.
      */
-    fun buildModeConfigSet(cfg: ModeConfig, newLevel: Int?): IntArray {
+    fun buildModeConfigSet(cfg: ModeConfig, newLevel: Int?, newSpatial: Int? = null): IntArray {
         val level = (newLevel ?: cfg.cncLevel).coerceIn(0, 10)
+        val spatial = (newSpatial ?: cfg.spatial).coerceIn(0, 2)
         val name = IntArray(32) { if (it < cfg.name.size) cfg.name[it] else 0 }
         val payload = intArrayOf(cfg.index, cfg.promptB1, cfg.promptB2) + name +
-            intArrayOf(level, cfg.autoCNC, cfg.spatial, cfg.windBlock, 0x01) // ancToggle forced on
+            intArrayOf(level, cfg.autoCNC, spatial, cfg.windBlock, 0x01) // ancToggle forced on
         return intArrayOf(0x1F, 0x06, 0x02, payload.size) + payload
     }
 

--- a/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
+++ b/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
@@ -102,6 +102,39 @@ class ParsersTest {
         assertEquals(10, Parsers.buildModeConfigSet(cfg, 99).copyOfRange(4, 4 + 40)[35]) // clamps to 10
     }
 
+    // ── Immersive Audio / spatial (1F,06 response[41] bit2 + response[44]) ──────
+    // Live verBosita (fw 8.2.20): custom modes p[41]=0x1d → spatialMutable; Immersion
+    // p[44]=2 (Motion), Cinema p[44]=1 (Still). spatial byte: 0 off, 1 Still, 2 Motion.
+    // Mirrors macOS `cli/Tests/main.swift`.
+
+    private fun mcSpatial(value: Int): IntArray {
+        val f = mc(5, "None", 0x1D, 7, 1)
+        f[4 + 44] = value
+        return f
+    }
+
+    @Test
+    fun modeConfig_parsesSpatialMutableAndValue() {
+        val custom = Parsers.parseModeConfig(mc(5, "None", 0x1D, 7, 1))!!
+        assertTrue(custom.spatialMutable) // 0x1D bit2 → spatial editable
+        val fixed = Parsers.parseModeConfig(mc(0, "Quiet", 0x00, 0, 1))!!
+        assertFalse(fixed.spatialMutable)
+        assertEquals(2, Parsers.parseModeConfig(mcSpatial(2))!!.spatial) // Motion
+        assertEquals(1, Parsers.parseModeConfig(mcSpatial(1))!!.spatial) // Still
+    }
+
+    @Test
+    fun buildModeConfigSet_changesSpatial() {
+        val motionMode = Parsers.parseModeConfig(mcSpatial(0))!!
+        // SET layout: spatial @37. newSpatial writes it; null keeps current; clamps to 0..2.
+        assertEquals(2, Parsers.buildModeConfigSet(motionMode, null, 2).copyOfRange(4, 4 + 40)[37])
+        assertEquals(2, Parsers.buildModeConfigSet(Parsers.parseModeConfig(mcSpatial(2))!!, null).copyOfRange(4, 4 + 40)[37]) // null keeps
+        assertEquals(2, Parsers.buildModeConfigSet(motionMode, null, 9).copyOfRange(4, 4 + 40)[37]) // clamps to 2
+        // level + spatial together: level @35, spatial @37
+        val both = Parsers.buildModeConfigSet(motionMode, 4, 1).copyOfRange(4, 4 + 40)
+        assertEquals(4, both[35]); assertEquals(1, both[37])
+    }
+
     // ── Favorites (1F,08) ──────────────────────────────────────────────────────
     // Live capture on verBosita (fw 8.2.20): GET 1F 08 01 00 -> STATUS 1f 08 03 03 0b 00 07.
     // count 0x0b (11 slots) + reversed-order bitmask 00 07 = modes 0,1,2 favourited.


### PR DESCRIPTION
Mirror the macOS Immersive Audio spatial control into the Android/Compose app so the clients don't drift. Adds spatialMutable + spatial to Kotlin ModeConfig, buildModeConfigSet newSpatial param, Composites.setActiveModeSpatial, BoseViewModel.setSpatial + state, an Off/Still/Motion segmented control in MainActivity (greys out on fixed modes), and ParsersTest spatial cases against the same captured-byte corpus as macOS. 22 unit tests pass; APK builds + installs on S21.