### PR TITLE
feat: bigger, drag-resizable Bose app window

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Raycast bose-spatial command and Hammerspoon spatial hotkey
-Raycast bose-spatial command and Hammerspoon spatial hotkey
+Bigger resizable default Bose app window
+Bigger resizable default Bose app window
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - spatial-frontends
+# Agent Progress - bigger-window
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-20T04:08:24Z
+# Created: 2026-06-20T04:22:06Z
 
-feature=spatial-frontends
-name=Raycast bose-spatial command and Hammerspoon spatial hotkey
+feature=bigger-window
+name=Bigger resizable default Bose app window
 status=pending
 step=0
 step_name=Not started
-created=2026-06-20T04:08:24Z
+created=2026-06-20T04:22:06Z

--- a/macos/BoseControl/BoseApp.swift
+++ b/macos/BoseControl/BoseApp.swift
@@ -18,8 +18,8 @@ struct BoseControlApp: App {
                     manager.refreshState()
                 }
         }
-        .defaultSize(width: 640, height: 420)
-        .windowResizability(.contentSize)
+        .defaultSize(width: 760, height: 560)
+        .windowResizability(.contentMinSize)  // user can drag larger; min comes from the frame
         .windowStyle(.hiddenTitleBar)  // no title bar chrome — paper runs edge-to-edge
     }
 }

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -57,7 +57,12 @@ struct ContentView: View {
                 disconnectedView
             }
         }
-        .frame(width: 640, height: 420)  // 420 fits a 3rd device-grid row (7 devices)
+        // Flexible frame (min/ideal/max) so the window is resizable by dragging — a fixed
+        // width/height + .windowResizability(.contentSize) pinned it to one exact size. The
+        // ideal is the bigger default; maxWidth/Height .infinity let the panels fill when
+        // dragged larger; the min keeps the two-column layout + hints from clipping.
+        .frame(minWidth: 700, idealWidth: 760, maxWidth: .infinity,
+               minHeight: 480, idealHeight: 560, maxHeight: .infinity)
         .background(paperColor)
         .preferredColorScheme(.light)
         .onAppear {
@@ -108,7 +113,7 @@ struct ContentView: View {
         HStack(spacing: 0) {
             // Left panel — status sidebar
             leftPanel
-                .frame(width: 220)
+                .frame(width: 260)  // wide enough for the fixed-mode hints to wrap cleanly
 
             // Divider
             Rectangle()


### PR DESCRIPTION
Default window 640x420 → 760x560 and now drag-resizable. Fixed .frame + .windowResizability(.contentSize) pinned it to one size; switched to flexible min/ideal/max frame + .contentMinSize. Left column 220 → 260 so fixed-mode hints stop truncating and the FAVOURITES row fits.