### PR TITLE
feat: name custom modes + show names on C1/C2 buttons

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Bigger resizable default Bose app window
-Bigger resizable default Bose app window
+Name custom modes and show stored names on C1 C2 buttons
+Name custom modes and show stored names on C1 C2 buttons
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - bigger-window
+# Agent Progress - custom-mode-names
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-20T04:22:06Z
+# Created: 2026-06-20T05:23:08Z
 
-feature=bigger-window
-name=Bigger resizable default Bose app window
+feature=custom-mode-names
+name=Name custom modes and show stored names on C1 C2 buttons
 status=pending
 step=0
 step_name=Not started
-created=2026-06-20T04:22:06Z
+created=2026-06-20T05:23:08Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ explicit user action.
   theme (burnt-orange `#AF3A03` accent on warm paper, from the Midterm `paper-hc` palette)
   is shared with the Android app; macOS colours live in `ContentView.swift`, Android in
   `MainActivity.kt` (`BoseAccent`/`BoseConnected`/…). Six ANC
-  mode buttons (Quiet/Aware/Immersion/Cinema/C1/C2 = slots 0-5) + a **noise-level
+  mode buttons (Quiet/Aware/Immersion/Cinema/C1/C2 = slots 0-5; the C1/C2 buttons show
+  the custom slots' stored on-device names when set, e.g. "Spatial", via `mode-name`) + a **noise-level
   slider** driven by `anc-level` (1F,06) — NOT a raw depth (1F,0A disables ANC, #83).
   The slider is enabled only on the adjustable custom slots (4/5, firmware `cncMutable`)
   and greys out with a "level is fixed" hint on Quiet/Aware/Immersion/Cinema.
@@ -71,7 +72,7 @@ explicit user action.
 - Companion device registered for background FGS privileges
 
 ### CLI (`cli/`) — regenerated on the shared layer
-- `cli/main.swift` -- `bose` command surface (status/battery/anc/anc-level/spatial/devices/connect/disconnect/swap/volume/multipoint/auto-pause/auto-answer/favorites/play-pause-next-prev/eq/raw). **No inline byte parsing** — every command routes through the generated `BMAP.*` builders. `connect`/`swap` poll-confirm via `getConnectedDevices` (ACK is never success); volume uses the generated SET_GET builder.
+- `cli/main.swift` -- `bose` command surface (status/battery/anc/anc-level/spatial/mode-name/devices/connect/disconnect/swap/volume/multipoint/auto-pause/auto-answer/favorites/play-pause-next-prev/eq/raw). `mode-name [name]` renames the ACTIVE mode via the 1F,06 RMW (name field, SET payload [3..34]) — custom slots only (`userConfigurable`; presets are locked, firmware ignores the write). The name persists on-device and shows in the Bose app too. `info --json` emits `custom1Name`/`custom2Name` (slot 4/5 stored names, read in one warm session via `readModeInfo`); the Mac app labels the C1/C2 buttons with them (falling back to "C1"/"C2" when unset = "None"). **No inline byte parsing** — every command routes through the generated `BMAP.*` builders. `connect`/`swap` poll-confirm via `getConnectedDevices` (ACK is never success); volume uses the generated SET_GET builder.
 - `cli/Transport.swift` -- IOBluetooth RFCOMM transport (per-command open/drain-300ms/close, cold-start warm-up, serial queue).
 - `cli/Composites.swift` -- live-channel composites (cncLevel RMW, connectedDevices list, getAllState single-session).
 - `cli/Parsers.swift` -- pure, hardware-free response parsers; `cli/Tests/main.swift` + `cli/run-tests.sh` are the standalone unit tests (same captured-byte corpus as Android `Parsers.kt`).

--- a/cli/Composites.swift
+++ b/cli/Composites.swift
@@ -148,6 +148,49 @@ extension Transport {
             return rmwActiveModeSpatial(spatial) { t.send(ch, $0, timeout: 2.0) }
         } ?? .unreachable
     }
+
+    enum NameResult { case ok(name: String), notCustom, unreachable }
+
+    /// Rename the ACTIVE mode via the 1F,06 RMW (writes the 32-byte name field, preserving
+    /// level/spatial). Only the user-configurable custom slots can be renamed — the named
+    /// presets (Quiet/Aware/Immersion/Cinema) have `userConfigurable == false` and the
+    /// firmware ignores a name write, so refuse there. Returns the device's post-write name.
+    func setActiveModeName(_ name: String) -> NameResult {
+        session { ch, t -> NameResult in
+            _ = t.send(ch, [0x02, 0x02, 0x01, 0x00], timeout: 2.0)  // prime warm
+            func send(_ f: [UInt8]) -> [UInt8]? { t.send(ch, f, timeout: 2.0) }
+            guard let cur = send([0x1F, 0x03, 0x01, 0x00]), cur.count >= 5,
+                  let r1 = send([0x1F, 0x06, 0x01, 0x01, cur[4]]),
+                  let cfg = parseModeConfig(r1) else { return .unreachable }
+            guard cfg.userConfigurable else { return .notCustom }
+            _ = send(buildModeConfigSet(cfg, newLevel: nil, newName: name))
+            let after = send([0x1F, 0x06, 0x01, 0x01, cur[4]]).flatMap(parseModeConfig)
+            return .ok(name: after?.displayName ?? name)
+        } ?? .unreachable
+    }
+
+    /// One warm session: the active mode's full config PLUS the display names of the two
+    /// custom slots (4, 5), so the app can label the C1/C2 buttons with their stored names.
+    /// Folding it into one session (vs a separate read per slot) keeps the app's on-open
+    /// read to a single extra RFCOMM open and avoids the cold-start flakiness of stacked
+    /// sessions. nil → unreachable.
+    func readModeInfo() -> (active: ModeConfig?, customNames: [Int: String])? {
+        session { ch, t -> (ModeConfig?, [Int: String]) in
+            _ = t.send(ch, [0x02, 0x02, 0x01, 0x00], timeout: 2.0)  // prime warm
+            var active: ModeConfig? = nil
+            if let cur = t.send(ch, [0x1F, 0x03, 0x01, 0x00], timeout: 2.0), cur.count >= 5 {
+                active = t.send(ch, [0x1F, 0x06, 0x01, 0x01, cur[4]], timeout: 2.0).flatMap(parseModeConfig)
+            }
+            var names: [Int: String] = [:]
+            for idx in [4, 5] {
+                if let r = t.send(ch, [0x1F, 0x06, 0x01, 0x01, UInt8(idx)], timeout: 2.0),
+                   let cfg = parseModeConfig(r) {
+                    names[idx] = cfg.displayName
+                }
+            }
+            return (active, names)
+        }
+    }
 }
 
 /// Uppercase-hex MAC key for set membership (keeps this file independent of

--- a/cli/Parsers.swift
+++ b/cli/Parsers.swift
@@ -127,12 +127,13 @@ func parseModeConfig(_ resp: [UInt8]) -> ModeConfig? {
 /// a level change can't disable ANC). The SET payload layout (from the decompiled app,
 /// distinct from the response): [0]=index, [1..2]=prompt, [3..34]=32-byte name,
 /// [35]=cncLevel, [36]=autoCNC, [37]=spatial, [38]=windBlock, [39]=ancToggle. Pass
-/// `newLevel`/`newSpatial = nil` to leave that field unchanged (a no-op round-trip when
-/// both are nil). `newSpatial`: 0 = off, 1 = Still, 2 = Motion.
-func buildModeConfigSet(_ cfg: ModeConfig, newLevel: Int?, newSpatial: Int? = nil) -> [UInt8] {
+/// `newLevel`/`newSpatial`/`newName = nil` to leave that field unchanged (a no-op
+/// round-trip when all are nil). `newSpatial`: 0 = off, 1 = Still, 2 = Motion. `newName`
+/// is UTF-8, truncated to 32 bytes and null-padded — used to rename a custom mode slot.
+func buildModeConfigSet(_ cfg: ModeConfig, newLevel: Int?, newSpatial: Int? = nil, newName: String? = nil) -> [UInt8] {
     let level = newLevel.map { UInt8(max(0, min(10, $0))) } ?? cfg.cncLevel
     let spatial = newSpatial.map { UInt8(max(0, min(2, $0))) } ?? cfg.spatial
-    var name = Array(cfg.name.prefix(32))
+    var name = newName.map { Array($0.utf8.prefix(32)) } ?? Array(cfg.name.prefix(32))
     while name.count < 32 { name.append(0) }
     var payload: [UInt8] = [cfg.index, cfg.promptB1, cfg.promptB2]
     payload += name

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -107,6 +107,20 @@ check(buildModeConfigSet(parseModeConfig(mcSpatial(2))!, newLevel: nil)[4 + 37] 
 check(buildModeConfigSet(motionMode, newLevel: nil, newSpatial: 9)[4 + 37] == 2, "modeConfigSet: clamps spatial to 2")
 check(buildModeConfigSet(motionMode, newLevel: 4, newSpatial: 1)[4 + 35] == 4, "modeConfigSet: level + spatial together (level @35)")
 
+// ── Custom mode rename (1F,06 name field, SET payload [3..34]) ────────────────────
+// newName writes 32-byte UTF-8 at [3..34], null-padded; nil keeps the existing name.
+let named = buildModeConfigSet(custom, newLevel: nil, newName: "Spatial")
+let np = Array(named[4...])
+check(Array(np[3..<10]) == Array("Spatial".utf8), "modeConfigSet: newName written @3")
+check(np[3 + 7] == 0 && np[3 + 31] == 0, "modeConfigSet: name null-padded to 32")
+let keptName = Array(buildModeConfigSet(custom, newLevel: nil)[4...])  // re-base slice to 0
+check(Array(keptName[3..<7]) == Array("None".utf8), "modeConfigSet: nil newName keeps existing name")
+// Over-long name truncates to 32 bytes (name field stays 32, level still lands at [35]).
+let longName = String(repeating: "x", count: 50)
+let longF = buildModeConfigSet(custom, newLevel: 5, newName: longName)
+check(longF.count == 4 + 40, "modeConfigSet: over-long name truncated (payload stays 40)")
+check(Array(longF[4...])[35] == 5, "modeConfigSet: level still @35 after long name")
+
 // ── Favorites (1F,08) ───────────────────────────────────────────────────────────
 // Live capture on verBosita (fw 8.2.20): GET 1F 08 01 00 -> STATUS 1f 08 03 03 0b 00 07.
 // count 0x0b (11 slots) + reversed-order bitmask 00 07 = modes 0,1,2 favourited.

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -154,7 +154,8 @@ func cmdInfoJSON() {
     // session (event-driven read, not polled). `noiseAdjustable` (cncMutable) gates the
     // slider so a level write can never disable ANC (#83). nil → slider hidden/disabled.
     var mode: [String: Any] = ["noiseAdjustable": false, "spatialAdjustable": false]
-    if let cfg = transport.readActiveModeConfig() {
+    let modeInfo = transport.readModeInfo()
+    if let cfg = modeInfo?.active {
         mode = [
             "modeName": cfg.displayName,
             "modeIndex": Int(cfg.index),
@@ -163,6 +164,12 @@ func cmdInfoJSON() {
             "spatial": spatialName(Int(cfg.spatial)),
             "spatialAdjustable": cfg.spatialMutable,
         ]
+    }
+    // Stored names of the two custom slots → the app labels the C1/C2 buttons with them
+    // (falling back to "C1"/"C2" when unset, i.e. "None"). Empty string = use the fallback.
+    func customName(_ idx: Int) -> String {
+        let n = modeInfo?.customNames[idx] ?? ""
+        return n == "None" ? "" : n
     }
 
     var out: [String: Any] = [
@@ -180,6 +187,8 @@ func cmdInfoJSON() {
         "autoAnswer": s.autoAnswer,
         "favorites": s.favorites,
         "devices": deviceStates,
+        "custom1Name": customName(4),
+        "custom2Name": customName(5),
     ]
     out.merge(mode) { _, new in new }
     emit(out)
@@ -280,6 +289,22 @@ func cmdSpatial(_ arg: String?) {
     }
     guard let cfg = transport.readActiveModeConfig() else { fail("headphones not reachable") }
     print("\(cfg.displayName): Immersive Audio \(spatialName(Int(cfg.spatial)))\(cfg.spatialMutable ? "" : " (fixed)")")
+}
+
+/// mode-name <name> — rename the ACTIVE mode (1F,06 RMW on the 32-byte name field). Only
+/// the custom slots (4/5, userConfigurable) can be renamed; the named presets are locked.
+/// The name persists on-device and shows on the C1/C2 buttons + in the Bose app.
+func cmdModeName(_ name: String?) {
+    guard let name = name, !name.isEmpty else {
+        guard let cfg = transport.readActiveModeConfig() else { fail("headphones not reachable") }
+        print("\(cfg.displayName)\(cfg.userConfigurable ? "" : " (preset — name locked)")")
+        return
+    }
+    switch transport.setActiveModeName(name) {
+    case .ok(let n):       print("mode renamed: \(n)")
+    case .notCustom:       fail("only the custom modes (C1/C2) can be renamed — switch to one first")
+    case .unreachable:     fail("headphones not reachable")
+    }
 }
 
 /// name [new name] — get/set the headphone name. SET is `01,02,06,{len},00,{utf8}`
@@ -663,6 +688,7 @@ func usage() {
       bose anc [mode]           Get/set ANC (quiet/aware/immersion/cinema/custom1/custom2, or slot 0-5)
       bose anc-level [0-10]     Get/set active mode's noise level (0=max cancel … 10=transparent; custom modes only)
       bose spatial [off|still|motion]  Get/set Immersive Audio on the active mode (custom modes only)
+      bose mode-name [name]     Get/rename the active mode (custom modes only; persists on-device)
       bose name [new name]      Get/set headphone name (max 30 UTF-8 bytes)
       bose volume [0-31]        Get/set volume
       bose multipoint [on|off]  Get/set multipoint
@@ -693,6 +719,7 @@ case "battery", "b":           cmdBattery()
 case "anc":                    cmdAnc(args.count >= 3 ? args[2] : nil)
 case "anc-level":              cmdAncLevel(args.count >= 3 ? args[2] : nil)
 case "spatial", "immersive":   cmdSpatial(args.count >= 3 ? args[2] : nil)
+case "mode-name":              cmdModeName(args.count >= 3 ? args[2...].joined(separator: " ") : nil)
 case "name":                   cmdName(args.count >= 3 ? args[2...].joined(separator: " ") : nil)
 case "devices":                cmdDevices()
 case "connect", "c":           cmdConnect(requireArg("device"))

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -46,6 +46,11 @@ final class BoseManager: ObservableObject {
     @Published var spatial: String = "off"
     @Published var spatialAdjustable: Bool = false
 
+    // Stored names of the two custom slots (1F,06 name field). Empty when unset ("None") —
+    // ContentView falls back to "C1"/"C2". Set via the CLI `mode-name`; persists on-device.
+    @Published var custom1Name: String = ""
+    @Published var custom2Name: String = ""
+
     // Device routing states: "active" / "connected" / "offline"
     @Published var deviceStates: [String: String] = [
         "mac": "offline", "phone": "offline", "ipad": "offline",
@@ -195,6 +200,8 @@ final class BoseManager: ObservableObject {
         modeName = (s["modeName"] as? String) ?? modeName
         spatial = (s["spatial"] as? String) ?? spatial
         spatialAdjustable = (s["spatialAdjustable"] as? Bool) ?? false
+        custom1Name = (s["custom1Name"] as? String) ?? ""
+        custom2Name = (s["custom2Name"] as? String) ?? ""
     }
 
     // MARK: - Write (each: run verb, optimistic local update, then re-read)

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -168,8 +168,10 @@ struct ContentView: View {
                     }
                     HStack(spacing: 4) {
                         ancButton("Cinema", 3)
-                        ancButton("C1", 4)
-                        ancButton("C2", 5)
+                        // Custom slots show their stored on-device name (set via `mode-name`),
+                        // falling back to C1/C2 when unnamed.
+                        ancButton(manager.custom1Name.isEmpty ? "C1" : manager.custom1Name, 4)
+                        ancButton(manager.custom2Name.isEmpty ? "C2" : manager.custom2Name, 5)
                     }
                 }
                 // Noise level (1F,06): 0 = max cancellation … 10 = transparency.


### PR DESCRIPTION
Adds `bose mode-name <name>` (1F,06 RMW on the name field, custom slots only — presets refuse). info --json now emits custom1Name/custom2Name (read in one warm session via readModeInfo); the Mac app labels the C1/C2 buttons with the stored names, falling back to C1/C2 when unset. Live-verified: C1 renamed 'Spatial', persists, button shows it; preset rename refused. 4 new parser tests pass.