### PR TITLE
fix: info --json device grid showing active sink as offline

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Android show custom mode names on C1 C2 buttons
-Android show custom mode names on C1 C2 buttons
+fix-info-json-device-grid-offline
+fix-info-json-device-grid-offline
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - android-mode-names
+# Agent Progress - fix-device-grid-offline
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-20T05:35:14Z
+# Created: 2026-06-22T18:38:40Z
 
-feature=android-mode-names
-name=Android show custom mode names on C1 C2 buttons
+feature=fix-device-grid-offline
+name=fix-info-json-device-grid-offline
 status=pending
 step=0
 step_name=Not started
-created=2026-06-20T05:35:14Z
+created=2026-06-22T18:38:40Z

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -135,11 +135,20 @@ func cmdInfoJSON() {
 
     // Per-device 3-state, resolved by NAME (same logic as cmdDevices, #81). If the
     // dedicated probe is unreachable, fall back to active-only from getAllState.
+    //
+    // `getAllState` reads 05,01 as its 4th in-session read — well-warmed, reliably
+    // returns the active sink (→ activeFromAll). The dedicated `getDeviceStates` opens
+    // a FRESH session and re-reads 05,01 with a single battery prime; as the 2nd RFCOMM
+    // session in quick succession that read can come back EMPTY (the #81 cold-channel
+    // quirk a standalone `bose devices` call doesn't hit). When it does, `states.active`
+    // is empty and every tile defaulted to offline even though the headphones report the
+    // mac active. Union activeFromAll into active so the warm read always wins — no retry
+    // loop (single-attempt rule), just don't discard data already in hand.
     var deviceStates: [String: String] = [:]
     let activeFromAll = Set(s.connectedDevices.map { activeName(forMac: $0) })
     if let states = transport.getDeviceStates(query: BoseDeviceMap.knownDevices.map { $0.mac }) {
-        let active = Set(states.active.map { activeName(forMac: $0) })
-        let idle = Set(states.connected.map { displayName(forMac: $0) })
+        let active = activeFromAll.union(states.active.map { activeName(forMac: $0) })
+        let idle = Set(states.connected.map { displayName(forMac: $0) }).subtracting(active)
         for dev in BoseDeviceMap.knownDevices {
             deviceStates[dev.name] = active.contains(dev.name) ? "active"
                                    : idle.contains(dev.name) ? "connected" : "offline"


### PR DESCRIPTION
The macOS Bose.app reads device state via `bose info --json`, whose device-grid block deterministically reported the active sink (e.g. `mac`) as `offline` while `bose devices` correctly showed it active — so every tile rendered greyed even with the Mac connected.

**Root cause:** `cmdInfoJSON` calls `getDeviceStates` as the 2nd RFCOMM session right after `getAllState`. The cold-second-session #81 quirk makes its single-attempt 05,01 read come back empty, so `states.active` was empty and all tiles defaulted to offline. `getAllState` already reads 05,01 as its well-warmed 4th in-session read (into `activeFromAll`), but that reliable data was only used in the nil-fallback branch — here `getDeviceStates` returns non-nil-but-empty, so it was discarded.

**Fix:** union `activeFromAll` into the active set so the warm read always wins. No retry loop (respects the single-attempt rule) — just stops discarding data already in hand.

Verified live: `info --json` now reports `mac: active` on every run, matching `bose devices`. CLI parser tests pass.