### PR TITLE
refactor: read info --json device grid in one warm session

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-fix-info-json-device-grid-offline
-fix-info-json-device-grid-offline
+fold device probes into getAllState session
+fold device probes into getAllState session
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - fix-device-grid-offline
+# Agent Progress - info-json-one-session
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-22T18:38:40Z
+# Created: 2026-06-22T18:46:34Z
 
-feature=fix-device-grid-offline
-name=fix-info-json-device-grid-offline
+feature=info-json-one-session
+name=fold device probes into getAllState session
 status=pending
 step=0
 step_name=Not started
-created=2026-06-22T18:38:40Z
+created=2026-06-22T18:46:34Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,9 @@ explicit user action.
   (Developer-ID signed → `/Applications`; no LaunchAgent). In-window keys: ⌘1-6
   ANC modes (slots 0-5), ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M connect Mac. Global hotkeys stay in
   Hammerspoon. The `--json` read seam lives in `cli/main.swift` (`cmdInfoJSON`, pure
-  formatting over `getAllState` + `getDeviceStates`). It surfaces — but does not fix —
+  formatting over `getAllStateWithDevices` — bulk state + the device grid's active sink
+  AND idle ACL probes in ONE warm session, so neither is lost to the cold-second-session
+  quirk a separate `getDeviceStates` call hit, #132). It surfaces — but does not fix —
   the #83 flight/ancDepth behaviour; that fix lands in the CLI and the app inherits it.
 - `raycast/bose-connect.sh` / `bose-disconnect.sh` -- Raycast script commands with a device dropdown → `bose connect|disconnect <device>`
 - `raycast/bose-status.sh` / `bose-full-status.sh` -- `bose status` / `bose info`

--- a/cli/Composites.swift
+++ b/cli/Composites.swift
@@ -29,6 +29,31 @@ extension Transport {
         }
     }
 
+    /// Bulk state AND per-device idle ACL in ONE RFCOMM session — the read seam for
+    /// `info --json`. `parseAllState` warms the channel and lands the active sink in
+    /// `state.connectedDevices` (its 4th read, 05,01); the per-device 04,05 idle probes
+    /// then run in that SAME warm session. Doing it as a single session (vs `getAllState`
+    /// followed by a separate `getDeviceStates`) is why neither the active sink nor the
+    /// idle set can be lost to the cold-second-session quirk that dropped every tile to
+    /// offline (#132) — and it costs one fewer RFCOMM open/drain/teardown. The headphones
+    /// answer 04,05 about a paired device promptly even when that device is offline, so
+    /// the probe loop doesn't stall. `idle` = ACL up but NOT the active sink. Returns nil
+    /// only if the session can't open (headphones unreachable).
+    func getAllStateWithDevices(query devices: [[UInt8]]) -> (state: HeadphoneState, idle: [[UInt8]])? {
+        session { ch, t in
+            let state = parseAllState { block, function in t.send(ch, [block, function, 0x01, 0x00], timeout: 2.0) }
+            let activeKeys = Set(state.connectedDevices.map { macKey($0) })
+            var idle: [[UInt8]] = []
+            for mac in devices where !activeKeys.contains(macKey(mac)) {
+                if let r = t.send(ch, BMAP.getDeviceInfo(mac: mac), timeout: 2.0),
+                   parseDeviceInfo(r)?.connected == true {
+                    idle.append(mac)
+                }
+            }
+            return (state, idle)
+        }
+    }
+
     /// Three-state device readout in ONE RFCOMM session:
     ///   `active`    — audio sink (05,01 ground truth)
     ///   `connected` — ACL up (per-device 04,05) but NOT the active sink

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -131,32 +131,25 @@ func cmdInfoJSON() {
         print(str)
     }
 
-    guard let s = transport.getAllState() else { emit(["connected": false]); return }
+    // Bulk state AND device grid from ONE warm RFCOMM session. The active sink comes from
+    // parseAllState's warm 05,01 read; the idle (ACL-up-but-not-sink) devices from
+    // per-device 04,05 probes in the SAME session. Reading both in one session is what
+    // keeps either from being lost to the cold-second-session quirk that a separate
+    // getDeviceStates call hit — it dropped every tile to offline despite `bose devices`
+    // showing the mac active (#132). `bose devices` stays on getDeviceStates: as a
+    // standalone session-1 read it's already warm, and it skips the bulk reads it doesn't need.
+    guard let (s, idleDevices) = transport.getAllStateWithDevices(
+        query: BoseDeviceMap.knownDevices.map { $0.mac }
+    ) else { emit(["connected": false]); return }
 
-    // Per-device 3-state, resolved by NAME (same logic as cmdDevices, #81). If the
-    // dedicated probe is unreachable, fall back to active-only from getAllState.
-    //
-    // `getAllState` reads 05,01 as its 4th in-session read — well-warmed, reliably
-    // returns the active sink (→ activeFromAll). The dedicated `getDeviceStates` opens
-    // a FRESH session and re-reads 05,01 with a single battery prime; as the 2nd RFCOMM
-    // session in quick succession that read can come back EMPTY (the #81 cold-channel
-    // quirk a standalone `bose devices` call doesn't hit). When it does, `states.active`
-    // is empty and every tile defaulted to offline even though the headphones report the
-    // mac active. Union activeFromAll into active so the warm read always wins — no retry
-    // loop (single-attempt rule), just don't discard data already in hand.
+    // Per-device 3-state, resolved by NAME (same logic as cmdDevices, #81). Active wins
+    // over idle when a device resolves to both.
     var deviceStates: [String: String] = [:]
-    let activeFromAll = Set(s.connectedDevices.map { activeName(forMac: $0) })
-    if let states = transport.getDeviceStates(query: BoseDeviceMap.knownDevices.map { $0.mac }) {
-        let active = activeFromAll.union(states.active.map { activeName(forMac: $0) })
-        let idle = Set(states.connected.map { displayName(forMac: $0) }).subtracting(active)
-        for dev in BoseDeviceMap.knownDevices {
-            deviceStates[dev.name] = active.contains(dev.name) ? "active"
-                                   : idle.contains(dev.name) ? "connected" : "offline"
-        }
-    } else {
-        for dev in BoseDeviceMap.knownDevices {
-            deviceStates[dev.name] = activeFromAll.contains(dev.name) ? "active" : "offline"
-        }
+    let active = Set(s.connectedDevices.map { activeName(forMac: $0) })
+    let idle = Set(idleDevices.map { displayName(forMac: $0) }).subtracting(active)
+    for dev in BoseDeviceMap.knownDevices {
+        deviceStates[dev.name] = active.contains(dev.name) ? "active"
+                               : idle.contains(dev.name) ? "connected" : "offline"
     }
 
     // Active mode's noise config (1F,06) — drives the app's noise slider. Its own warm


### PR DESCRIPTION
Follow-up to #132. Collapses `cmdInfoJSON`'s two RFCOMM sessions (`getAllState` then `getDeviceStates`) into a single `getAllStateWithDevices` read.

**Why:** #132 fixed the active sink (mac) showing offline by recovering it from `getAllState`'s warm 05,01. But the *idle* state (○ phone — ACL up, not the sink) still came only from the cold second `getDeviceStates` session, so a connected-but-not-active second device showed grey instead of blue in the app.

**Fix:** `parseAllState` warms the channel and lands the active sink; the per-device 04,05 idle probes now run in that SAME session. One session → neither active nor idle can be lost to the cold-second-session quirk, and it drops a full connect/drain/teardown cycle. `bose devices` stays on `getDeviceStates` (already warm as a standalone session-1 read).

Verified live: `info --json` now reports `mac: active` + `phone: connected` on every run, matching `bose devices` (`● mac ○ phone`) exactly. Parser tests pass.