### PR TITLE
feat: Android UI — auto-pause/auto-answer toggles + favourites display (#123)

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-fix bose connect hang + C1/C2 in-app rename #134
-fix bose connect hang + C1/C2 in-app rename #134
+Android UI: auto-pause/auto-answer toggles + favourites display (#123)
+Android UI: auto-pause/auto-answer toggles + favourites display (#123)
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - fix-connect-hang-rename
+# Agent Progress - android-autopause-fav-ui
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-06-22T19:03:25Z
+# Created: 2026-06-22T19:25:10Z
 
-feature=fix-connect-hang-rename
-name=fix bose connect hang + C1/C2 in-app rename #134
+feature=android-autopause-fav-ui
+name=Android UI: auto-pause/auto-answer toggles + favourites display (#123)
 status=pending
 step=0
 step_name=Not started
-created=2026-06-22T19:03:25Z
+created=2026-06-22T19:25:10Z

--- a/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseProtocol.kt
@@ -107,6 +107,43 @@ object BoseProtocol {
     fun setMultipoint(enabled: Boolean): Boolean =
         Transport.send(BMAP.setMultipoint(if (enabled) 0x07 else 0x00)).isAccepted()
 
+    // ── Auto-pause (01,18) / Auto-answer (01,1B) — SET_GET bool toggles ────────────
+    //
+    // Auto-pause = pause playback when the headphones are removed; auto-answer = answer
+    // a call when they're donned. Both are SET_GET: the set's own RESP carries the new
+    // STATUS byte, so no separate verify-GET (a second back-to-back open intermittently
+    // returns nil). Parse `& 0x01` of the status byte, matching the CLI (cmdAutoPlayPause/
+    // cmdAutoAnswer) and Parsers.parseAllState.
+
+    fun getAutoPlayPause(): Boolean? {
+        val resp = Transport.send(BMAP.getAutoPlayPause()) ?: return null
+        if (resp.size >= 5 && resp[2] == OP_RESP) return (resp[4] and 0x01) != 0
+        return null
+    }
+
+    fun setAutoPlayPause(enabled: Boolean): Boolean {
+        val resp = Transport.send(BMAP.setAutoPlayPause(if (enabled) 1 else 0)) ?: return false
+        return resp.size >= 5 && resp[2] == OP_RESP
+    }
+
+    fun getAutoAnswer(): Boolean? {
+        val resp = Transport.send(BMAP.getAutoAnswer()) ?: return null
+        if (resp.size >= 5 && resp[2] == OP_RESP) return (resp[4] and 0x01) != 0
+        return null
+    }
+
+    fun setAutoAnswer(enabled: Boolean): Boolean {
+        val resp = Transport.send(BMAP.setAutoAnswer(if (enabled) 1 else 0)) ?: return false
+        return resp.size >= 5 && resp[2] == OP_RESP
+    }
+
+    /** GET favourited mode slots (1F,08). Display-only — decoded by the hand-written
+     *  bitmask parser (the SET_GET payload isn't expressible in the codegen DSL). */
+    fun getFavorites(): List<Int>? {
+        val resp = Transport.send(BMAP.getFavorites()) ?: return null
+        return Parsers.parseFavorites(resp)
+    }
+
     // ── EQ (SET_GET; band: 0=bass 1=mid 2=treble, value -10..+10) ─────────────────
 
     data class EqBand(val id: Int, val value: Int)

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -35,6 +35,11 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
 
         // Settings
         val multipointEnabled: Boolean = false,
+        // Auto-pause (01,18) — pause when removed; Auto-answer (01,1B) — answer call when donned.
+        val autoPlayPause: Boolean = false,
+        val autoAnswer: Boolean = false,
+        // Favourited mode slots (1F,08) — display-only, mirroring the Mac app.
+        val favorites: List<Int> = emptyList(),
         // Noise level (1F,06) — the active mode's CNC level + whether it's adjustable
         // (firmware cncMutable: only the custom slots 4/5). modeName labels the hint.
         val noiseLevel: Int = 0,
@@ -107,6 +112,9 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                     BoseProtocol.getFirmwareVersion()?.let { s = s.copy(firmwareVersion = it) }
                     BoseProtocol.getDeviceName()?.let { s = s.copy(deviceName = it) }
                     BoseProtocol.getMultipoint()?.let { s = s.copy(multipointEnabled = it) }
+                    BoseProtocol.getAutoPlayPause()?.let { s = s.copy(autoPlayPause = it) }
+                    BoseProtocol.getAutoAnswer()?.let { s = s.copy(autoAnswer = it) }
+                    BoseProtocol.getFavorites()?.let { s = s.copy(favorites = it) }
                     Composites.readActiveModeConfig()?.let {
                         s = s.copy(noiseLevel = it.cncLevel, noiseAdjustable = it.cncMutable, modeName = it.displayName,
                             spatial = it.spatial, spatialAdjustable = it.spatialMutable)
@@ -230,6 +238,18 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
     fun setEq(bass: Int, mid: Int, treble: Int) = command("Failed to set EQ",
         action = { BoseProtocol.setEq(bass, mid, treble) },
         onSuccess = { _state.value = _state.value.copy(eqBass = bass, eqMid = mid, eqTreble = treble) },
+    )
+
+    /** Pause playback when the headphones are removed (01,18, SET_GET). Optimistic + refresh. */
+    fun setAutoPlayPause(enabled: Boolean) = command("Failed to set auto-pause",
+        action = { BoseProtocol.setAutoPlayPause(enabled) },
+        onSuccess = { _state.value = _state.value.copy(autoPlayPause = enabled) },
+    )
+
+    /** Answer an incoming call when the headphones are donned (01,1B, SET_GET). Optimistic + refresh. */
+    fun setAutoAnswer(enabled: Boolean) = command("Failed to set auto-answer",
+        action = { BoseProtocol.setAutoAnswer(enabled) },
+        onSuccess = { _state.value = _state.value.copy(autoAnswer = enabled) },
     )
 
     /**

--- a/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
+++ b/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
@@ -358,6 +358,8 @@ fun BoseApp(vm: BoseViewModel = viewModel()) {
                         onSetMultipoint = { vm.setMultipoint(it) },
                         onSetNoiseLevel = { vm.setNoiseLevel(it) },
                         onSetSpatial = { vm.setSpatial(it) },
+                        onSetAutoPlayPause = { vm.setAutoPlayPause(it) },
+                        onSetAutoAnswer = { vm.setAutoAnswer(it) },
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
@@ -850,6 +852,8 @@ fun SettingsSection(
     onSetMultipoint: (Boolean) -> Unit,
     onSetNoiseLevel: (Int) -> Unit = {},
     onSetSpatial: (Int) -> Unit = {},
+    onSetAutoPlayPause: (Boolean) -> Unit = {},
+    onSetAutoAnswer: (Boolean) -> Unit = {},
 ) {
     // Device name
     var editingName by remember { mutableStateOf(false) }
@@ -906,6 +910,39 @@ fun SettingsSection(
                 uncheckedThumbColor = BoseDim,
                 uncheckedTrackColor = BoseHair,
             ),
+        )
+    }
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    // Auto-pause (01,18) — pause when the headphones are removed. SET_GET toggle,
+    // mirroring the Mac app's AUTO-PAUSE switch.
+    ToggleRow(
+        label = "Auto-Pause",
+        checked = state.autoPlayPause,
+        onCheckedChange = onSetAutoPlayPause,
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    // Auto-answer (01,1B) — answer a call when the headphones are donned. SET_GET toggle.
+    ToggleRow(
+        label = "Auto-Answer",
+        checked = state.autoAnswer,
+        onCheckedChange = onSetAutoAnswer,
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    // Favourites (1F,08) — display-only, matching the Mac app: which mode slots are
+    // marked favourite. Mapped slot-index → name via favoriteModeName.
+    SettingRow("Favourites") {
+        Text(
+            text = if (state.favorites.isEmpty()) "-"
+            else state.favorites.joinToString(", ") { favoriteModeName(it) },
+            fontSize = 14.sp,
+            color = BoseText,
+            textAlign = TextAlign.End,
         )
     }
 
@@ -1021,6 +1058,49 @@ fun SettingsSection(
             color = BoseText,
         )
     }
+}
+
+/**
+ * A labelled on/off switch row (warm-paper theme), mirroring the Mac app's
+ * MULTIPOINT / AUTO-PAUSE / AUTO-ANSWER toggles. The value text reads On/Off in the
+ * accent colour when on, dim when off.
+ */
+@Composable
+fun ToggleRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    SettingRow(label) {
+        Text(
+            text = if (checked) "On" else "Off",
+            fontSize = 14.sp,
+            color = if (checked) BoseAccent else BoseDim,
+            modifier = Modifier.weight(1f),
+        )
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color(0xFFFFFFFF),
+                checkedTrackColor = BoseAccent,
+                uncheckedThumbColor = BoseDim,
+                uncheckedTrackColor = BoseHair,
+            ),
+        )
+    }
+}
+
+/** Friendly name for a favourited AudioModes slot index (display-only). Mirrors the
+ *  Mac app's favoriteModeName: 0 Quiet … 5 Custom 2, else "Slot N". */
+private fun favoriteModeName(idx: Int): String = when (idx) {
+    0 -> "Quiet"
+    1 -> "Aware"
+    2 -> "Immersion"
+    3 -> "Cinema"
+    4 -> "Custom 1"
+    5 -> "Custom 2"
+    else -> "Slot $idx"
 }
 
 @Composable

--- a/android/app/src/main/java/au/com/jd/bose/Parsers.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Parsers.kt
@@ -31,6 +31,9 @@ object Parsers {
         var audioCodec: String = "",
         var deviceName: String = "",
         var multipointEnabled: Boolean = false,
+        var autoPlayPause: Boolean = false, // 01,18 — pause when removed
+        var autoAnswer: Boolean = false, // 01,1B — answer call when donned
+        var favorites: List<Int> = emptyList(), // 1F,08 — favourited mode slots
         var autoOffTimer: IntArray = IntArray(0),
         var eqBass: Int = 0,
         var eqMid: Int = 0,
@@ -217,6 +220,9 @@ object Parsers {
         }
 
         resp(0x01, 0x0A)?.let { s.multipointEnabled = it[4] != 0 }
+        resp(0x01, 0x18)?.let { if (it.size >= 5) s.autoPlayPause = (it[4] and 0x01) != 0 }
+        resp(0x01, 0x1B)?.let { if (it.size >= 5) s.autoAnswer = (it[4] and 0x01) != 0 }
+        provide.response(0x1F, 0x08)?.let { r -> parseFavorites(r)?.let { s.favorites = it } }
         resp(0x01, 0x0B)?.let { s.autoOffTimer = it.copyOfRange(4, it.size) }
         // No on-head/wear: StatusInEar (02,09) is an EARBUDS function; the QC Ultra 2
         // headphones answer FuncNotSupp. Live worn state isn't exposed over BMAP.

--- a/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
+++ b/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
@@ -188,6 +188,9 @@ class ParsersTest {
             (0x05 to 0x05) to intArrayOf(0x05, 0x05, 0x03, 0x02, 0x1F, 0x14),             // volMax 31, vol 20
             (0x05 to 0x01) to twoDevices,
             (0x01 to 0x0A) to intArrayOf(0x01, 0x0A, 0x03, 0x01, 0x07),                   // multipoint on
+            (0x01 to 0x18) to intArrayOf(0x01, 0x18, 0x03, 0x01, 0x01),                   // auto-pause on
+            (0x01 to 0x1B) to intArrayOf(0x01, 0x1B, 0x03, 0x01, 0x00),                   // auto-answer off
+            (0x1F to 0x08) to intArrayOf(0x1F, 0x08, 0x03, 0x03, 0x0B, 0x00, 0x07),       // favorites 0/1/2
             (0x00 to 0x05) to (intArrayOf(0x00, 0x05, 0x03, 0x05) + "1.2.3".map { it.code }.toIntArray()),
             // EQ RESP: value bytes at absolute indices 6, 10, 14 (signed).
             (0x01 to 0x07) to intArrayOf(
@@ -205,6 +208,9 @@ class ParsersTest {
         assertEquals(31, s.volumeMax)
         assertEquals(2, s.connectedDevices.size)
         assertTrue(s.multipointEnabled)
+        assertTrue(s.autoPlayPause)            // 01,18 status byte 0x01 & 0x01 → on
+        assertFalse(s.autoAnswer)              // 01,1B status byte 0x00 → off
+        assertEquals(listOf(0, 1, 2), s.favorites) // 1F,08 reversed bitmask 00 07
         assertEquals("1.2.3", s.firmware)
         assertEquals(3, s.eqBass)
         assertEquals(0, s.eqMid)


### PR DESCRIPTION
Closes #123 — the last follow-up (optional Android UI), plus live-verified the two pending #123 checks along the way.

## What
Mirrors the macOS app's controls on Android. The BMAP commands (AutoPlayPause 01,18 / AutoAnswer 01,1B / Favorites 1F,08) and pure Kotlin parsers already existed from #120; this wires them into state + UI:
- **Parsers.kt** — `HeadphoneState` gains `autoPlayPause`/`autoAnswer`/`favorites`; `parseAllState` reads 01,18 / 01,1B (`& 0x01`) + 1F,08 (`parseFavorites`), mirroring `cli/Parsers.swift`.
- **BoseProtocol.kt** — `get/setAutoPlayPause`, `get/setAutoAnswer` (SET_GET), `getFavorites` (display-only), via existing generated `BMAP.*` builders.
- **BoseViewModel.kt** — exposes the three in `UiState` + the two setter actions (optimistic + refresh); reads them in the warm bulk session.
- **MainActivity.kt** — `SettingsSection` gains Auto-Pause + Auto-Answer toggles and a read-only Favourites row.
- **ParsersTest.kt** — extends the full-session decode with the CLI's captured-byte corpus.

## Verification
- `assembleDebug` + `testDebugUnitTest` (17 parser tests) green.
- **On-device (S21)**: deployed; toggles reflect live device state (auto-pause Off / auto-answer On / favourites Quiet, Aware, Immersion); tapped Auto-Pause → device flipped on→off round-trip (confirmed via the Mac CLI).
- **#123 eviction check (item 2)**: live-verified with mac+phone held — tapping quest evicted **phone (priority 2)**, mac untouched, phone **restored** on the failed page. Logcat: `Evicting phone (priority 2)` → `Switching to quest` → `Restoring phone (target quest was unreachable)`.
- **#123 info --json fields (item 1a)**: verified earlier.