### PR TITLE
fix: walk-back reconnect review — flag on .active-only + pcall-hardened decision load

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-bose walk-back auto-reconnect on desk return
-bose walk-back auto-reconnect on desk return
+walk-back reconnect review fixes: flag on active-only + pcall-hardened decision load
+walk-back reconnect review fixes: flag on active-only + pcall-hardened decision load
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - bose-walk-back-reconnect
+# Agent Progress - fix-walkback-review
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-07-06T12:06:07Z
+# Created: 2026-07-06T13:18:10Z
 
-feature=bose-walk-back-reconnect
-name=bose walk-back auto-reconnect on desk return
+feature=fix-walkback-review
+name=walk-back reconnect review fixes: flag on active-only + pcall-hardened decision load
 status=pending
 step=0
 step_name=Not started
-created=2026-07-06T12:06:07Z
+created=2026-07-06T13:18:10Z

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -454,10 +454,13 @@ func cmdConnect(_ deviceName: String) {
     _ = transport.oneShot(BMAP.connectDevice(mac: mac), timeout: 5.0)
 
     let outcome = confirmConnect(mac)
-    // Track the last active source for the Hammerspoon walk-back watcher: set iff we
-    // connected the Mac, clear on any other device. Only on a real connection (.none
-    // means it never landed — leave the flag as-is).
-    if outcome == .active || outcome == .idle { setLastActiveMac(isMacDevice(mac)) }
+    // Track the last ACTIVE audio source for the Hammerspoon walk-back watcher.
+    // Only update on `.active` — i.e. when audio actually routed here. On `.idle`
+    // the audio stayed on the prior sink (multipoint), so the active source did NOT
+    // change and the flag must be left reflecting the true source: setting it on an
+    // idle Mac connect would arm a walk-back reconnect that steals audio off the
+    // phone (#139 review). `.none` never landed — also leave as-is.
+    if outcome == .active { setLastActiveMac(isMacDevice(mac)) }
     switch outcome {
     case .active: print("Connected \(deviceName)")
     case .idle:   print("Connected \(deviceName) (idle — audio stayed on the active device; multipoint)")
@@ -482,7 +485,8 @@ func cmdSwap(_ targetName: String) {
     _ = transport.oneShot(BMAP.connectDevice(mac: mac), timeout: 5.0)
 
     let outcome = confirmConnect(mac)
-    if outcome == .active || outcome == .idle { setLastActiveMac(isMacDevice(mac)) }
+    // Only on `.active` — see cmdConnect: an idle Mac connect must not arm walk-back (#139).
+    if outcome == .active { setLastActiveMac(isMacDevice(mac)) }
     switch outcome {
     case .active: print("Swapped to \(targetName)")
     case .idle:   print("Connected \(targetName) (idle — audio stayed on the active device; multipoint)")

--- a/hammerspoon/bose.lua
+++ b/hammerspoon/bose.lua
@@ -270,9 +270,16 @@ local function connectHere()
 end
 
 -- Pure walk-back decision, co-located in this dir. Loaded by absolute repo path (the
--- same convention init.lua uses to dofile bose.lua itself).
-local decideReconnect = dofile(os.getenv("HOME")
+-- same convention init.lua uses to dofile bose.lua itself). pcall-wrapped so a missing
+-- or broken decision file degrades to "walk-back off" instead of throwing out of the
+-- module load and taking down battery-announce / auto-route / hotkeys with it (#139).
+local decideOk, decideReconnect = pcall(dofile, os.getenv("HOME")
   .. "/code/personal/bose/hammerspoon/reconnect_decision.lua")
+if not decideOk or type(decideReconnect) ~= "function" then
+  print("[bose] walk-back decision load failed (" .. tostring(decideReconnect)
+    .. "); disabling walk-back reconnect")
+  decideReconnect = nil
+end
 
 local walkbackLastActivity = hs.timer.secondsSinceEpoch()
 local walkbackLastFire     = -math.huge
@@ -359,7 +366,7 @@ function M.start()
       setMacInput(MAC_MIC)
     end
   end
-  if WALKBACK_ENABLED then
+  if WALKBACK_ENABLED and decideReconnect then
     M.walkbackTap = hs.eventtap.new(
       { hs.eventtap.event.types.keyDown,
         hs.eventtap.event.types.leftMouseDown,


### PR DESCRIPTION
Review follow-up for the walk-back auto-reconnect (PR #138), raised in #139.

**Two findings from the independent code review, fixed:**

1. **`.active`-only flag (cli/main.swift).** `cmdConnect`/`cmdSwap` previously set the `last-active-mac` flag on both `.active` and `.idle`. An idle Mac connect (audio stayed on the phone under multipoint) armed a walk-back reconnect that would steal audio off the phone on return — a concrete instance of the phone-initiated-switch limitation (Open Question #3). Now the flag updates **only on `.active`**, so it tracks the truly-active audio source.

2. **pcall-hardened decision load (hammerspoon/bose.lua).** The absolute-path `dofile` of `reconnect_decision.lua` is now `pcall`-wrapped: a missing/broken file degrades to walk-back-off instead of throwing out of module load and taking down battery-announce / auto-route / hotkeys. Tap creation gated on the decision fn being loaded.

**Verification:** `cli/build.sh` clean · 6/6 Swift + 4/4 Lua tests pass · `bose.lua` parses · pcall degradation proven (missing file → nil, no throw).

Leaves #139 open — the human-gated live walk-away test is still James's to run.