### PR TITLE
feat(devices): add Avantree Audikast Plus to the device map

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-walk-back reconnect review fixes: flag on active-only + pcall-hardened decision load
-walk-back reconnect review fixes: flag on active-only + pcall-hardened decision load
+add Avantree Audikast Plus to device map
+add Avantree Audikast Plus to device map
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - fix-walkback-review
+# Agent Progress - add-audikast-device
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-07-06T13:18:10Z
+# Created: 2026-07-12T14:57:06Z
 
-feature=fix-walkback-review
-name=walk-back reconnect review fixes: flag on active-only + pcall-hardened decision load
+feature=add-audikast-device
+name=add Avantree Audikast Plus to device map
 status=pending
 step=0
 step_name=Not started
-created=2026-07-06T13:18:10Z
+created=2026-07-12T14:57:06Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,11 +206,15 @@ own MAC. Use `getConnectedDevices` (05,01) for audio-active devices and
 | tv | 14:C1:4E:B7:CB:68 | macOS only | Chromecast |
 | appletv | 48:E1:5C:5D:33:B6 | macOS + S21 in-app | Katrina's Apple TV 4K (label "Katrina's Apple TV"; `widget=false` → no home-screen widget) |
 | quest | 78:C4:FA:C8:5C:3D | yes | Meta Quest 3 |
+| audikast | 00:1D:43:B8:03:01 | macOS tile only | Avantree Audikast Plus BT transmitter (TV → headphones), Shenzhen G-link OUI. Lowest priority (evicted first); deliberately NOT in cycle_order (never cycle audio to a transmitter) |
 
 A device's optional `label` (devices.toml) is the friendly display name shared by the Mac app + S21 in-app tile; absent → fall back to the key.
 
 **Connection priority** (`priority` in devices.toml; 1 = highest):
-`1 mac → 2 phone → 3 appletv → 4 ipad → 5 quest → 6 tv → 7 iphone`.
+`1 mac → 2 phone → 3 appletv → 4 ipad → 5 quest → 6 tv → 7 iphone → 8 audikast`.
+The codegen (`emit_devices.py` `_device_order`) emits `knownDevices` as cycle_order first,
+then any non-cycle devices (e.g. `audikast`) — so a source-only device gets a tile + eviction
+priority without ever being a cycle target.
 The headset holds 2 devices (multipoint) and the firmware only evicts by its own LRU
 (`ConnectionPriority 0x10` is FuncNotSupp — see `docs/reverse-engineering.md`). So the
 CLI's `connect`/`swap` enforce the hierarchy in software: when both slots are full and

--- a/android/app/src/generated/java/au/com/jd/bose/Devices.generated.kt
+++ b/android/app/src/generated/java/au/com/jd/bose/Devices.generated.kt
@@ -35,7 +35,7 @@ data class BoseDevice(
 
 /** Single source of truth for the paired device map (from devices.toml). */
 object BoseDeviceMap {
-    /** All known devices, in cycle order. */
+    /** All known devices: cycle-order first, then source-only extras. */
     val knownDevices: List<BoseDevice> = listOf(
         BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true, label = null, priority = 1),
         BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null, priority = 5),
@@ -44,6 +44,7 @@ object BoseDeviceMap {
         BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null, priority = 6),
         BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV", priority = 3),
         BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null, priority = 2),
+        BoseDevice("audikast", byteArrayOf(0x00, 0x1D, 0x43, 0xB8.toByte(), 0x03, 0x01), widget = false, label = "Avantree Audikast Plus", priority = 8),
     )
 
     /** name -> device, insertion-ordered to match cycle order. */

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -36,6 +36,7 @@ private let deviceButtons: [DeviceButton] = [
     DeviceButton(id: "tv", label: "TV", symbol: "tv"),
     DeviceButton(id: "appletv", label: "Katrina's Apple TV", symbol: "appletv"),
     DeviceButton(id: "quest", label: "Quest", symbol: "visionpro"),
+    DeviceButton(id: "audikast", label: "Avantree Audikast", symbol: "antenna.radiowaves.left.and.right"),
 ]
 
 // MARK: - Main View

--- a/protocol/codegen/emit_devices.py
+++ b/protocol/codegen/emit_devices.py
@@ -43,6 +43,18 @@ def _dash(mac: str) -> str:
     return mac.replace(":", "-")
 
 
+def _device_order(spec: dict) -> list[str]:
+    """Names for `knownDevices`: cycle_order first, then any devices not in the
+    cycle (alpha-sorted for determinism). Decouples the device *list* from the
+    switch *cycle* — a source-only device (e.g. a TV transmitter) is a known
+    device with a tile + eviction priority, but is deliberately absent from
+    cycle_order so `bose` cycling never routes audio to it.
+    """
+    cycle = spec["cycle_order"]
+    extras = sorted(n for n in spec["devices"] if n not in cycle)
+    return list(cycle) + extras
+
+
 def emit_devices_swift(spec: dict) -> str:
     headphone_mac = spec["headphone_mac"]
     headphone_name = spec["headphone_name"]
@@ -74,8 +86,8 @@ def emit_devices_swift(spec: dict) -> str:
     lines.append("")
     lines.append("enum BoseDeviceMap {")
     lines.append("    static let knownDevices: [BoseDevice] = [")
-    # Emit in cycle order so the list is deterministic and matches switch order.
-    for name in cycle:
+    # Cycle-order devices first, then any source-only extras (not in the cycle).
+    for name in _device_order(spec):
         d = devices[name]
         widget = "true" if d.get("widget", False) else "false"
         label = d.get("label")
@@ -144,9 +156,9 @@ def emit_devices_kotlin(spec: dict) -> str:
     lines.append("")
     lines.append("/** Single source of truth for the paired device map (from devices.toml). */")
     lines.append("object BoseDeviceMap {")
-    lines.append("    /** All known devices, in cycle order. */")
+    lines.append("    /** All known devices: cycle-order first, then source-only extras. */")
     lines.append("    val knownDevices: List<BoseDevice> = listOf(")
-    for name in cycle:
+    for name in _device_order(spec):
         d = devices[name]
         widget = "true" if d.get("widget", False) else "false"
         label = d.get("label")

--- a/protocol/generated/Devices.generated.kt
+++ b/protocol/generated/Devices.generated.kt
@@ -35,7 +35,7 @@ data class BoseDevice(
 
 /** Single source of truth for the paired device map (from devices.toml). */
 object BoseDeviceMap {
-    /** All known devices, in cycle order. */
+    /** All known devices: cycle-order first, then source-only extras. */
     val knownDevices: List<BoseDevice> = listOf(
         BoseDevice("mac", byteArrayOf(0xBC.toByte(), 0xD0.toByte(), 0x74, 0x11, 0xDB.toByte(), 0x27), widget = true, label = null, priority = 1),
         BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null, priority = 5),
@@ -44,6 +44,7 @@ object BoseDeviceMap {
         BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null, priority = 6),
         BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV", priority = 3),
         BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null, priority = 2),
+        BoseDevice("audikast", byteArrayOf(0x00, 0x1D, 0x43, 0xB8.toByte(), 0x03, 0x01), widget = false, label = "Avantree Audikast Plus", priority = 8),
     )
 
     /** name -> device, insertion-ordered to match cycle order. */

--- a/protocol/generated/Devices.generated.swift
+++ b/protocol/generated/Devices.generated.swift
@@ -33,6 +33,7 @@ enum BoseDeviceMap {
         BoseDevice(name: "tv", mac: [0x14, 0xC1, 0x4E, 0xB7, 0xCB, 0x68], widget: false, label: nil, priority: 6),
         BoseDevice(name: "appletv", mac: [0x48, 0xE1, 0x5C, 0x5D, 0x33, 0xB6], widget: false, label: "Katrina's Apple TV", priority: 3),
         BoseDevice(name: "phone", mac: [0xA8, 0x76, 0x50, 0xD3, 0xB1, 0x1B], widget: true, label: nil, priority: 2),
+        BoseDevice(name: "audikast", mac: [0x00, 0x1D, 0x43, 0xB8, 0x03, 0x01], widget: false, label: "Avantree Audikast Plus", priority: 8),
     ]
 
     static let cycleOrder = ["mac", "quest", "ipad", "iphone", "tv", "appletv", "phone"]

--- a/protocol/spec/devices.toml
+++ b/protocol/spec/devices.toml
@@ -51,3 +51,10 @@ priority = 3
 label = "Katrina's Apple TV"
 widget = false          # macOS app + S21 in-app tile only — no Android home-screen widget
 notes = "Lounge Room Apple TV 4K (gen 3)"
+
+[devices.audikast]
+mac = "00:1D:43:B8:03:01"          # captured live from connected_devices (05,01); 00:1D:43 = Shenzhen G-link OUI (Avantree ODM)
+priority = 8                        # LOWEST — a source, not a sink; evicted first so it can never block mac/ipad/etc.
+label = "Avantree Audikast Plus"
+widget = false          # macOS app tile only — a TV transmitter, not an Android home-screen button
+notes = "Avantree Audikast Plus BT transmitter (TV → headphones). Re-pages aggressively; kept lowest priority so `connect`/`swap` evict it first. Intentionally NOT in cycle_order — never cycle audio to a transmitter."


### PR DESCRIPTION
Adds the Avantree Audikast Plus BT transmitter (MAC `00:1D:43:B8:03:01`, Shenzhen G-link OUI) to the device map so it's **visible + evictable** — it was silently holding a multipoint slot and blocking the iPad.

- `devices.toml`: `[devices.audikast]` — priority 8 (lowest → evicted first), `widget=false`, deliberately **not** in `cycle_order` (never cycle audio to a transmitter).
- `emit_devices.py`: `_device_order` decouples `knownDevices` (all devices) from `cycle_order` (switch cycle) so a source-only device gets a tile + eviction priority.
- Regenerated Swift/Kotlin maps + synced Android committed copy.
- macOS app: Avantree Audikast tile (antenna symbol) — verified rendering live.
- CLAUDE.md Device Map + priority docs.