### PR TITLE
feat(multipoint): pair picker — reorderable device grid + priority/pair CLI

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-add Avantree Audikast Plus to device map
-add Avantree Audikast Plus to device map
+multipoint primary/secondary pair picker
+multipoint primary/secondary pair picker
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - add-audikast-device
+# Agent Progress - multipoint-pair-picker
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-07-12T14:57:06Z
+# Created: 2026-07-12T15:25:21Z
 
-feature=add-audikast-device
-name=add Avantree Audikast Plus to device map
+feature=multipoint-pair-picker
+name=multipoint primary/secondary pair picker
 status=pending
 step=0
 step_name=Not started
-created=2026-07-12T14:57:06Z
+created=2026-07-12T15:25:21Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ nothing runs in the background and the Mac only touches the headphones on an
 explicit user action.
 - `macos/BoseControl/` -- **Bose.app**: a windowed SwiftUI app (warm-paper light
   two-panel: battery/ANC mode/Immersive Audio (spatial Off/Still/Motion)/volume/multipoint + auto-pause/auto-answer toggles
-  (01,18 / 01,1B) + a favourites display (1F,08, read-only) + device grid + EQ). The light
+  (01,18 / 01,1B) + a favourites display (1F,08, read-only) + a **reorderable device grid** + EQ). The light
   theme (burnt-orange `#AF3A03` accent on warm paper, from the Midterm `paper-hc` palette)
   is shared with the Android app; macOS colours live in `ContentView.swift`, Android in
   `MainActivity.kt` (`BoseAccent`/`BoseConnected`/…). Six ANC
@@ -75,7 +75,7 @@ explicit user action.
 - Companion device registered for background FGS privileges
 
 ### CLI (`cli/`) — regenerated on the shared layer
-- `cli/main.swift` -- `bose` command surface (status/battery/anc/anc-level/spatial/mode-name/devices/connect/disconnect/swap/volume/multipoint/auto-pause/auto-answer/favorites/play-pause-next-prev/eq/raw). `mode-name [--slot 4|5] [name]` renames a custom mode via the 1F,06 RMW (name field, SET payload [3..34]) — custom slots only (`userConfigurable`; presets are locked, firmware ignores the write). Without `--slot` it targets the ACTIVE mode (`setActiveModeName`); with `--slot 4`/`5` it renames C1/C2 **in place without changing the active mode** (`setModeName`, used by the Mac app's right-click rename). Both share `renameModeSlot`. The name persists on-device and shows in the Bose app too. `info --json` emits `custom1Name`/`custom2Name` (slot 4/5 stored names) AND the active mode config (modeName/noiseLevel/spatial/adjustable) — all read in the SAME warm session as the bulk state, folded into `getAllStateWithDevices` (a separate `readModeInfo` call ran as a cold SECOND session and reliably came back empty, blanking the slider/spatial/C1-C2 names, #134). The Mac app labels the C1/C2 buttons with the names (falling back to "C1"/"C2" when unset = "None") and renames them via right-click → Rename… → `mode-name --slot`. The Android app does the same display on its mode selector — `Composites.readCustomModeNames()` (slots 4/5) → `BoseViewModel` `custom1Name`/`custom2Name` → `AncSection` label. (Display only on Android; renaming is Mac/CLI via `mode-name`.) **No inline byte parsing** — every command routes through the generated `BMAP.*` builders. `connect`/`swap` poll-confirm via `getConnectedDevices` (ACK is never success); volume uses the generated SET_GET builder.
+- `cli/main.swift` -- `bose` command surface (status/battery/anc/anc-level/spatial/mode-name/devices/connect/disconnect/swap/pair/priority/volume/multipoint/auto-pause/auto-answer/favorites/play-pause-next-prev/eq/raw). `pair <primary> <secondary>` = the multipoint-pair composite (evict others → connect secondary held → primary active); `priority [--set n… | --clear]` shows/sets the runtime eviction order in `~/.config/bose/priority.json` (index 0 = primary). Pure order logic in `cli/Priority.swift` (`PriorityOrder` + `effectiveRank`, unit-tested); `evictLowestPriorityIfFull` ranks by it (runtime order overrides the compiled devices.toml priority, graceful fallback when absent). `mode-name [--slot 4|5] [name]` renames a custom mode via the 1F,06 RMW (name field, SET payload [3..34]) — custom slots only (`userConfigurable`; presets are locked, firmware ignores the write). Without `--slot` it targets the ACTIVE mode (`setActiveModeName`); with `--slot 4`/`5` it renames C1/C2 **in place without changing the active mode** (`setModeName`, used by the Mac app's right-click rename). Both share `renameModeSlot`. The name persists on-device and shows in the Bose app too. `info --json` emits `custom1Name`/`custom2Name` (slot 4/5 stored names) AND the active mode config (modeName/noiseLevel/spatial/adjustable) — all read in the SAME warm session as the bulk state, folded into `getAllStateWithDevices` (a separate `readModeInfo` call ran as a cold SECOND session and reliably came back empty, blanking the slider/spatial/C1-C2 names, #134). The Mac app labels the C1/C2 buttons with the names (falling back to "C1"/"C2" when unset = "None") and renames them via right-click → Rename… → `mode-name --slot`. The Android app does the same display on its mode selector — `Composites.readCustomModeNames()` (slots 4/5) → `BoseViewModel` `custom1Name`/`custom2Name` → `AncSection` label. (Display only on Android; renaming is Mac/CLI via `mode-name`.) **No inline byte parsing** — every command routes through the generated `BMAP.*` builders. `connect`/`swap` poll-confirm via `getConnectedDevices` (ACK is never success); volume uses the generated SET_GET builder.
 - `cli/Transport.swift` -- IOBluetooth RFCOMM transport (per-command open/drain-300ms/close, cold-start warm-up, serial queue).
 - `cli/Composites.swift` -- live-channel composites (cncLevel RMW, connectedDevices list, getAllState single-session).
 - `cli/Parsers.swift` -- pure, hardware-free response parsers; `cli/Tests/main.swift` + `cli/run-tests.sh` are the standalone unit tests (same captured-byte corpus as Android `Parsers.kt`).
@@ -221,7 +221,13 @@ CLI's `connect`/`swap` enforce the hierarchy in software: when both slots are fu
 the target isn't already connected, it **disconnects the lowest-priority of the two held
 devices first**, then pages the target — and **restores the evicted device if the target
 fails to connect** (`evictLowestPriorityIfFull` / `restoreEvicted` in `cli/main.swift`).
-Mac app / Raycast / Hammerspoon inherit this (they shell `bose`). **Android now replicates
+Mac app / Raycast / Hammerspoon inherit this (they shell `bose`). **Runtime override:** a
+user-chosen order in `~/.config/bose/priority.json` (`bose priority --set …`, or the Mac
+app's **drag-to-reorder device grid** — index 0 = primary/active, 1 = secondary/held) takes
+precedence over the compiled priorities for victim selection (`effectiveRank`, `cli/Priority.swift`).
+`bose pair <primary> <secondary>` connects exactly that pair (evict others → secondary held →
+primary active). The order is host-side only — never pushed to the headphones (no firmware
+priority hierarchy). **Android now replicates
 it too**: pure victim selection in `android/.../Eviction.kt` (`evictionVictim`, JVM-unit-
 tested), held-state read via `Composites.getDeviceStates`, wired into `BoseService.switchDevice`
 (evict-then-page, restore on failure). Android can't run the Mac's host-side blueutil step, so
@@ -349,6 +355,7 @@ surface. Keep this in sync when adding a verb or control.
 | Auto-answer | **01,1B** | ✅ `auto-answer` | ✅ `bose-auto-answer` | — | — |
 | Favorites | **1F,08** | ✅ `favorites` | 👁 `bose-favorites` | — | — (parser only, no UI) |
 | Connect device | 04,01 | ✅ `connect`/`swap` | ✅ `bose-connect` | Opt+B opens app (Opt+⇧B/Opt+J disabled 2026-06-20) | ✅ widget/tile/picker |
+| Multipoint pair / priority | host-side (priority.json) | ✅ `pair` / `priority` | — | — | — (compiled `Eviction.kt` only) |
 | Disconnect device | 04,02 | ✅ `disconnect` | ✅ `bose-disconnect` | 👁 (toggle path) | — |
 | Device info (ACL) | 04,05 | 👁 `devices` (○ state) | — | — | 👁 widget colour |
 | Connected devices | 05,01 | 👁 `devices`/`status`/`info` | 👁 (in status) | 👁 toggle-direction | 👁 widget/tile active |

--- a/cli/Priority.swift
+++ b/cli/Priority.swift
@@ -1,0 +1,57 @@
+/// Runtime multipoint priority order — a user-chosen ordering of device NAMES that
+/// overrides the compiled `devices.toml` priorities for eviction victim selection, and
+/// names the intended multipoint PAIR (index 0 = primary/active, index 1 = secondary/held).
+///
+/// Written by the Mac app's drag-to-reorder (via `bose priority --set …`) and by the
+/// `bose priority` verb; read by `evictLowestPriorityIfFull`. Foundation-only, so the
+/// pure ranking logic unit-tests without hardware. Storage mirrors the profiles/state
+/// dir: `$BOSE_STATE_DIR` override (tests) → `~/.config/bose/priority.json`. A missing or
+/// unreadable file means "no override" → the compiled devices.toml hierarchy stands.
+///
+/// The firmware has NO device-priority hierarchy (`ConnectionPriority 0x10` = FuncNotSupp),
+/// so this order is enforced entirely host-side by the CLI's `connect`/`swap`/`pair`
+/// eviction — never pushed to the headphones.
+
+import Foundation
+
+struct PriorityOrder: Codable, Equatable {
+    var order: [String]   // device names, best (primary) first; lowercased
+
+    static func defaultPath() -> String { boseStateDir() + "/priority.json" }
+
+    /// Load, returning an empty order (= no override) for any missing/unreadable/invalid file.
+    static func load(_ path: String = defaultPath()) -> PriorityOrder {
+        guard let data = FileManager.default.contents(atPath: path),
+              let po = try? JSONDecoder().decode(PriorityOrder.self, from: data) else {
+            return PriorityOrder(order: [])
+        }
+        return po
+    }
+
+    func save(_ path: String = defaultPath()) throws {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.prettyPrinted, .sortedKeys]   // deterministic, like ProfileStore
+        var data = try enc.encode(self)
+        data.append(0x0A)  // trailing newline
+        let dir = (path as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try data.write(to: URL(fileURLWithPath: path))
+    }
+
+    static func clear(_ path: String = defaultPath()) {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+}
+
+/// Effective eviction rank for a device: LOWER = keep longer, HIGHER = evict first (same
+/// polarity as the compiled `priority`). A device listed in `order` ranks by its index
+/// (0 = primary, kept longest). An UNLISTED device sorts after every listed one
+/// (`order.count` base) and then keeps the compiled devices.toml hierarchy among the
+/// unlisted, so a partial or empty order degrades gracefully to the static priorities.
+/// Pure — unit-tested.
+func effectiveRank(_ name: String, order: [String], compiledPriority: Int) -> Int {
+    if let i = order.firstIndex(where: { $0.lowercased() == name.lowercased() }) {
+        return i
+    }
+    return order.count + compiledPriority
+}

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -317,6 +317,43 @@ check(!lastActiveMacIsSet(), "flag: lastActiveMacIsSet false after clear")
 
 try? FileManager.default.removeItem(atPath: tmpState)
 
+// ── priority: effectiveRank + victim selection + round-trip ─────────────────────
+
+// Listed device ranks by its index (0 = primary, kept longest).
+check(effectiveRank("ipad", order: ["ipad", "mac"], compiledPriority: 4) == 0,
+      "rank: listed primary = index 0")
+check(effectiveRank("mac", order: ["ipad", "mac"], compiledPriority: 1) == 1,
+      "rank: listed secondary = index 1")
+// Unlisted device sorts AFTER all listed ones, then by compiled priority.
+check(effectiveRank("audikast", order: ["ipad", "mac"], compiledPriority: 8) == 10,
+      "rank: unlisted = order.count + compiledPriority")
+// Empty order = pure compiled fallback (index-free).
+check(effectiveRank("phone", order: [], compiledPriority: 2) == 2,
+      "rank: empty order falls back to compiled priority")
+
+// Victim selection mirrors `held.max(by: effectiveRank<)`: the WORST-ranked held device.
+func victim(_ held: [(String, Int)], _ order: [String]) -> String? {
+    held.max(by: {
+        effectiveRank($0.0, order: order, compiledPriority: $0.1)
+            < effectiveRank($1.0, order: order, compiledPriority: $1.1)
+    })?.0
+}
+// Default (no override): audikast (compiled 8) is evicted over mac (1).
+check(victim([("mac", 1), ("audikast", 8)], []) == "audikast",
+      "victim: compiled default evicts the lowest-priority (audikast)")
+// Runtime order FLIPS it: user keeps audikast (listed) → mac (unlisted) is evicted instead.
+check(victim([("mac", 1), ("audikast", 8)], ["ipad", "audikast"]) == "mac",
+      "victim: runtime order overrides compiled — unlisted mac evicted, listed audikast kept")
+
+// PriorityOrder round-trips through disk (BOSE_STATE_DIR override).
+let tmpPrio = NSTemporaryDirectory() + "bose-prio-test-\(ProcessInfo.processInfo.processIdentifier)"
+setenv("BOSE_STATE_DIR", tmpPrio, 1)
+try? PriorityOrder(order: ["ipad", "mac", "phone"]).save()
+check(PriorityOrder.load().order == ["ipad", "mac", "phone"], "priority.json: save/load round-trip")
+PriorityOrder.clear()
+check(PriorityOrder.load().order == [], "priority.json: clear reverts to empty (compiled default)")
+try? FileManager.default.removeItem(atPath: tmpPrio)
+
 // ── summary ─────────────────────────────────────────────────────────────────────
 
 if failures == 0 {

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -40,6 +40,7 @@ swiftc -O \
     "$SCRIPT_DIR/Transport.swift" \
     "$SCRIPT_DIR/Parsers.swift" \
     "$SCRIPT_DIR/Profiles.swift" \
+    "$SCRIPT_DIR/Priority.swift" \
     "$SCRIPT_DIR/Composites.swift" \
     "$SCRIPT_DIR/main.swift" \
     -framework IOBluetooth \

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -425,7 +425,13 @@ func evictLowestPriorityIfFull(target: [UInt8]) -> BoseDevice? {
     if heldKeys.contains(targetKey) { return nil }   // already connected — nothing to evict
     if heldKeys.count < 2 { return nil }             // a slot is free — no eviction needed
     let held = BoseDeviceMap.knownDevices.filter { heldKeys.contains(macString($0.mac)) }
-    guard let victim = held.max(by: { $0.priority < $1.priority }) else { return nil }
+    // Rank by the user's runtime order (priority.json) when present, else the compiled
+    // devices.toml priority — evict the WORST-ranked (highest effectiveRank) held device.
+    let order = PriorityOrder.load().order
+    guard let victim = held.max(by: {
+        effectiveRank($0.name, order: order, compiledPriority: $0.priority)
+            < effectiveRank($1.name, order: order, compiledPriority: $1.priority)
+    }) else { return nil }
     _ = transport.oneShot(BMAP.disconnectDevice(mac: victim.mac))
     if isMacDevice(victim.mac) { runBlueutil(["--disconnect", Headphone.mac]) }
     print("Evicted \(victim.name) (priority \(victim.priority)) to free a multipoint slot")
@@ -554,6 +560,74 @@ func cmdDisconnect(_ deviceName: String) {
     }
 
     print("Disconnected \(deviceName)")
+}
+
+/// priority [--set n1 n2 …] [--clear] — the runtime multipoint order (priority.json).
+/// Bare: print the saved order (or the compiled default). `--set`: validate + persist a
+/// new order (index 0 = primary). `--clear`: revert to the devices.toml hierarchy.
+/// Host-side only — never pushed to the headphones (firmware has no priority hierarchy).
+func cmdPriority(_ a: [String]) {
+    if a.isEmpty {
+        let order = PriorityOrder.load().order
+        print(order.isEmpty
+            ? "priority: (default — devices.toml hierarchy)"
+            : "priority: " + order.joined(separator: " "))
+        return
+    }
+    if a[0] == "--clear" {
+        PriorityOrder.clear()
+        print("priority cleared (reverted to devices.toml hierarchy)")
+        return
+    }
+    var names = a
+    if names.first == "--set" { names.removeFirst() }
+    guard !names.isEmpty else { fail("priority --set needs device names") }
+    for n in names where BoseDeviceMap.device(n) == nil { fail("unknown device: \(n)") }
+    do { try PriorityOrder(order: names.map { $0.lowercased() }).save() }
+    catch { fail("could not save priority: \(error)") }
+    print("priority set: " + names.joined(separator: " "))
+}
+
+/// pair <primary> <secondary> — make exactly these two the multipoint pair: evict any
+/// OTHER held device, connect the secondary (held), then the primary (active). The Mac
+/// app's drag-reorder shells this when the top-2 changes. The firmware has no priority
+/// lock, so an aggressive re-pager (e.g. the Audikast) or a sleeping target can still win
+/// the slot — we report the honest outcome rather than fight it with a retry loop.
+func cmdPair(_ primary: String, _ secondary: String) {
+    let pMac = macForName(primary)
+    let sMac = macForName(secondary)
+    if macString(pMac) == macString(sMac) { fail("pair needs two different devices") }
+    let keep = Set([macString(pMac), macString(sMac)])
+
+    // Evict everything that isn't the intended pair so both slots are free for them.
+    if let st = transport.getDeviceStates(query: BoseDeviceMap.knownDevices.map { $0.mac }) {
+        let held = st.active + st.connected
+        var evictedAny = false
+        for m in held where !keep.contains(macString(m)) {
+            _ = transport.oneShot(BMAP.disconnectDevice(mac: m))
+            if isMacDevice(m) { runBlueutil(["--disconnect", Headphone.mac]) }
+            print("Evicted \(displayName(forMac: m)) to free a slot for the pair")
+            evictedAny = true
+        }
+        if evictedAny { Thread.sleep(forTimeInterval: 0.8) }   // let the slots clear
+    }
+
+    // Page the secondary first (settles held), then the primary (should become active).
+    func page(_ mac: [UInt8]) -> ConnectOutcome {
+        if isMacDevice(mac) { runBlueutil(["--connect", Headphone.mac]); Thread.sleep(forTimeInterval: 1.5) }
+        _ = transport.oneShot(BMAP.connectDevice(mac: mac), timeout: 5.0)
+        return confirmConnect(mac)
+    }
+    let sOut = page(sMac)
+    let pOut = page(pMac)
+    if pOut == .active { setLastActiveMac(isMacDevice(pMac)) }
+
+    let secNote = sOut == .none ? "not connected" : "held"
+    switch pOut {
+    case .active: print("Paired: \(primary) (active) + \(secondary) (\(secNote))")
+    case .idle:   print("Paired: \(primary) (connected, idle) + \(secondary) (\(secNote))")
+    case .none:   fail("pair: \(primary) did not connect (target asleep, or a device is re-grabbing the slot — power it off)")
+    }
 }
 
 /// volume / vol / v [level] — generated setVolume uses SET_GET (05,05,02). The v1
@@ -731,6 +805,8 @@ func usage() {
       bose connect <device>     Route audio to device (poll-confirmed)
       bose disconnect <device>  Disconnect a device
       bose swap <device>        Route audio to device (multipoint; keeps others)
+      bose pair <primary> <secondary>  Make these two the multipoint pair (primary active, secondary held; evicts others)
+      bose priority [--set n… | --clear]  Show/set the runtime eviction order (index 0 = primary); drives connect/swap/pair eviction
       bose anc [mode]           Get/set ANC (quiet/aware/immersion/cinema/custom1/custom2, or slot 0-5)
       bose anc-level [0-10]     Get/set active mode's noise level (0=max cancel … 10=transparent; custom modes only)
       bose spatial [off|still|motion]  Get/set Immersive Audio on the active mode (custom modes only)
@@ -779,6 +855,10 @@ case "devices":                cmdDevices()
 case "connect", "c":           cmdConnect(requireArg("device"))
 case "disconnect", "d":        cmdDisconnect(requireArg("device"))
 case "swap":                   cmdSwap(requireArg("device"))
+case "priority", "prio":       cmdPriority(args.count >= 3 ? Array(args[2...]) : [])
+case "pair":
+    guard args.count >= 4 else { fail("pair needs <primary> <secondary>") }
+    cmdPair(args[2], args[3])
 case "volume", "vol", "v":     cmdVolume(args.count >= 3 ? args[2] : nil)
 case "multipoint", "mp":       cmdMultipoint(args.count >= 3 ? args[2] : nil)
 case "auto-pause", "autopause": cmdAutoPlayPause(args.count >= 3 ? args[2] : nil)

--- a/cli/run-tests.sh
+++ b/cli/run-tests.sh
@@ -18,6 +18,7 @@ swiftc \
     "$GEN_DIR/BMAP.generated.swift" \
     "$SCRIPT_DIR/Parsers.swift" \
     "$SCRIPT_DIR/Profiles.swift" \
+    "$SCRIPT_DIR/Priority.swift" \
     "$SCRIPT_DIR/Tests/main.swift" \
     -o "$BIN"
 

--- a/docs/plans/2026-07-13-multipoint-pair-picker-design.md
+++ b/docs/plans/2026-07-13-multipoint-pair-picker-design.md
@@ -1,0 +1,65 @@
+# Multipoint pair picker — design (as built)
+
+**Date:** 2026-07-13 · **Status:** implemented
+
+## Problem
+
+The QC Ultra 2 holds **exactly 2** multipoint devices, and the firmware has **no
+device-priority hierarchy** (`ConnectionPriority 0x10` = FuncNotSupp) — it evicts by its
+own LRU. The CLI already enforces a *compiled* priority (`devices.toml`) in software on a
+full-multipoint connect, but James had no way to pick, at runtime, **which two devices are
+the pair** (and which is primary/active vs secondary/held), nor to reorder eviction
+priority without editing the spec + rebuilding.
+
+## Decision
+
+**Approach A — the CLI owns all logic; the app is a thin front-end.** A runtime order file
+(`~/.config/bose/priority.json`) overrides the compiled priorities. Reordering the device
+grid in the app persists that order and connects the top-2 as the pair.
+
+- **Behaviour (chosen):** reorder → *persist* the order **and** *connect the pair now*
+  (evict others, secondary held, primary active). Top-2 unchanged → persist only, no re-page.
+- **UI (chosen):** reorder the **whole device grid** — index 0 = Primary (active), 1 =
+  Secondary (held), rest = eviction order. Drag tiles, or right-click → Make Primary /
+  Make Secondary / Disconnect. Primary/Secondary shown as a small "1"/"2" badge.
+
+## Components
+
+### CLI (`cli/`)
+- **`Priority.swift`** (pure, Foundation-only, unit-tested): `PriorityOrder` load/save
+  (`priority.json`, `$BOSE_STATE_DIR` override) + `effectiveRank(name, order, compiledPriority)` —
+  listed device ranks by index; unlisted sorts after all listed, then by compiled priority
+  (graceful degradation to devices.toml when the file is absent/partial).
+- **`main.swift`**:
+  - `evictLowestPriorityIfFull` now picks the victim by `effectiveRank` (runtime order wins,
+    compiled fallback).
+  - `bose priority [--set n… | --clear]` — show/set/clear the runtime order.
+  - `bose pair <primary> <secondary>` — composite: evict all non-pair held devices → connect
+    secondary (held) → connect primary (active), reporting the honest outcome. Reuses the
+    verified `confirmConnect` poll (ACK ≠ success).
+
+### App (`macos/BoseControl/`)
+- **`BoseManager`**: `loadPriorityOrder`, `setPriority` (writes via `bose priority --set`),
+  `disconnectDevice`, `applyPair` (shells `bose pair`, spins the primary tile).
+- **`ContentView`**: device grid is drag-reorderable (`DeviceDropDelegate`); "1"/"2" role
+  badges; right-click context menu (Make Primary / Make Secondary / Disconnect). On reorder:
+  persist + `applyPair` iff the top-2 changed.
+
+## Deliberately NOT built
+
+- **No resident "kick the Audikast" watcher.** A background poller that disconnects an
+  aggressive re-pager is exactly the banned anti-pattern (#61–#69 audio dropouts). The picker
+  is user-initiated; an aggressive transmitter is defeated by powering it off, not software.
+- Firmware priority push (impossible — FuncNotSupp).
+
+## Honest limits
+
+The firmware has no priority lock, so `pair` can still lose the slot to an instant re-pager
+(e.g. the Avantree Audikast) or a sleeping target. It reports the real outcome; the order
+persists regardless of whether the live connect landed.
+
+## Testing
+
+Pure unit tests (`cli/Tests`, hardware-free): `effectiveRank` (listed/unlisted/empty),
+victim selection (compiled default vs runtime override flip), `priority.json` round-trip +
+clear. All pass. Live `bose pair` intentionally not exercised in CI (mutates real BT links).

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -370,6 +370,54 @@ final class BoseManager: ObservableObject {
         }
     }
 
+    // MARK: - Multipoint priority / pair
+
+    /// Load the saved runtime priority order (`bose priority`) for the reorderable grid.
+    /// Returns [] when no override is saved (the app then falls back to the tile default).
+    func loadPriorityOrder(_ completion: @escaping ([String]) -> Void) {
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            let out = self.run(["priority"]).out
+            var order: [String] = []
+            if let r = out.range(of: "priority:") {
+                let rest = out[r.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !rest.hasPrefix("(") {          // "(default — …)" means no override
+                    order = rest.split(separator: " ").map(String.init)
+                }
+            }
+            DispatchQueue.main.async { completion(order) }
+        }
+    }
+
+    /// Persist the runtime eviction order (index 0 = primary). Writes priority.json only —
+    /// no device I/O, so no refresh.
+    func setPriority(_ order: [String]) {
+        queue.async { [weak self] in _ = self?.run(["priority", "--set"] + order) }
+    }
+
+    /// Disconnect a single device (right-click → Disconnect). Refreshes state after.
+    func disconnectDevice(_ name: String) {
+        write(["disconnect", name])
+    }
+
+    /// Apply the multipoint pair now: evict others, connect secondary (held) then primary
+    /// (active). Spins the primary tile while it runs (mirrors connectDevice), then refreshes.
+    func applyPair(primary: String, secondary: String) {
+        guard connectingDevice == nil else { return }
+        connectingDevice = primary
+        isRefreshing = true
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            _ = self.run(["pair", primary, secondary])
+            let snapshot = Self.parse(self.run(["info", "--json"]).out)
+            DispatchQueue.main.async {
+                self.apply(snapshot)
+                self.connectingDevice = nil
+                self.isRefreshing = false
+            }
+        }
+    }
+
     /// Run a write verb, then read `info` a few times until `confirm` reports the new
     /// value has landed (applying each snapshot so the rest of the UI stays fresh). This
     /// is a BOUNDED, self-terminating post-write settle — it returns the instant the

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -39,6 +39,30 @@ private let deviceButtons: [DeviceButton] = [
     DeviceButton(id: "audikast", label: "Avantree Audikast", symbol: "antenna.radiowaves.left.and.right"),
 ]
 
+/// Live grid reorder: as a dragged tile passes over another, move it there; on drop,
+/// commit (persist the order + connect the pair if the top-2 changed).
+private struct DeviceDropDelegate: DropDelegate {
+    let targetId: String
+    @Binding var draggingId: String?
+    @Binding var order: [String]
+    let onCommit: () -> Void
+
+    func dropEntered(info: DropInfo) {
+        guard let dragging = draggingId, dragging != targetId,
+              let from = order.firstIndex(of: dragging),
+              let to = order.firstIndex(of: targetId) else { return }
+        withAnimation(.easeInOut(duration: 0.15)) {
+            order.move(fromOffsets: IndexSet(integer: from), toOffset: to > from ? to + 1 : to)
+        }
+    }
+    func dropUpdated(info: DropInfo) -> DropProposal? { DropProposal(operation: .move) }
+    func performDrop(info: DropInfo) -> Bool {
+        draggingId = nil
+        onCommit()
+        return true
+    }
+}
+
 // MARK: - Main View
 
 struct ContentView: View {
@@ -54,6 +78,14 @@ struct ContentView: View {
     @State private var renameSlot: Int = 4
     @State private var renameText: String = ""
     @State private var showRename: Bool = false
+
+    // Multipoint pair picker: device order (index 0 = primary/active, 1 = secondary/held,
+    // rest = eviction order). Seeded from the tile default, overridden by the saved
+    // `bose priority` order on appear. `draggingId` tracks the in-flight drag.
+    @State private var deviceOrder: [String] = deviceButtons.map { $0.id }
+    @State private var draggingId: String? = nil
+    // The top-2 we last connected as a pair — so reordering positions 3-8 doesn't re-page.
+    @State private var appliedTop2: [String] = []
 
     var body: some View {
         Group {
@@ -75,6 +107,13 @@ struct ContentView: View {
             manager.refreshState()
             syncSliders()
             installShortcuts()
+            // Load the saved multipoint priority order; append any devices missing from it
+            // (e.g. a newly-added tile) so the grid always shows every device.
+            manager.loadPriorityOrder { saved in
+                guard !saved.isEmpty else { return }
+                let all = deviceButtons.map { $0.id }
+                deviceOrder = saved.filter { all.contains($0) } + all.filter { !saved.contains($0) }
+            }
         }
         .onReceive(manager.objectWillChange) { _ in
             DispatchQueue.main.async { syncSliders() }
@@ -371,16 +410,47 @@ struct ContentView: View {
         .padding(16)
     }
 
+    /// Tiles in the user's priority order (index 0 = primary, 1 = secondary, rest = eviction).
+    private var orderedButtons: [DeviceButton] {
+        deviceOrder.compactMap { id in deviceButtons.first { $0.id == id } }
+    }
+
     private var deviceGrid: some View {
         let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
         return LazyVGrid(columns: columns, spacing: 8) {
-            ForEach(deviceButtons) { button in
-                deviceButton(button)
+            ForEach(Array(orderedButtons.enumerated()), id: \.element.id) { idx, button in
+                deviceButton(button, index: idx)
+                    .onDrag {
+                        draggingId = button.id
+                        return NSItemProvider(object: button.id as NSString)
+                    }
+                    .onDrop(of: [.text], delegate: DeviceDropDelegate(
+                        targetId: button.id,
+                        draggingId: $draggingId,
+                        order: $deviceOrder,
+                        onCommit: applyOrder))
             }
         }
     }
 
-    private func deviceButton(_ button: DeviceButton) -> some View {
+    /// Persist the new order and, if the top-2 (the multipoint pair) changed, connect it now.
+    private func applyOrder() {
+        manager.setPriority(deviceOrder)
+        let top2 = Array(deviceOrder.prefix(2))
+        guard top2.count == 2, top2 != appliedTop2 else { return }
+        appliedTop2 = top2
+        manager.applyPair(primary: top2[0], secondary: top2[1])
+    }
+
+    /// Move a device to a slot (used by the right-click Make Primary/Secondary actions).
+    private func moveDevice(_ id: String, to index: Int) {
+        guard let from = deviceOrder.firstIndex(of: id) else { return }
+        deviceOrder.remove(at: from)
+        deviceOrder.insert(id, at: min(index, deviceOrder.count))
+        applyOrder()
+    }
+
+    private func deviceButton(_ button: DeviceButton, index: Int) -> some View {
         let state = manager.deviceStates[button.id] ?? "offline"
         let isConnecting = manager.connectingDevice == button.id
         let isActive = state == "active"
@@ -421,10 +491,29 @@ struct ContentView: View {
             )
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .contentShape(RoundedRectangle(cornerRadius: 10))  // whole tile is the hit area
+            // Multipoint role badge: 1 = Primary (active audio), 2 = Secondary (held).
+            .overlay(alignment: .topLeading) {
+                if index <= 1 {
+                    Text(index == 0 ? "1" : "2")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundColor(paperColor)
+                        .frame(width: 13, height: 13)
+                        .background(Circle().fill(index == 0 ? boseAccent : connectedColor))
+                        .padding(4)
+                        .help(index == 0 ? "Primary — active audio" : "Secondary — held on multipoint")
+                }
+            }
         }
         .buttonStyle(.plain)
         .disabled(isBlocked)
         .opacity(isBlocked ? 0.4 : (state == "offline" && !isConnecting ? 0.6 : 1.0))
+        // Drag a tile to reorder, or use these — index 0 = Primary, 1 = Secondary.
+        .contextMenu {
+            Button("Make Primary") { moveDevice(button.id, to: 0) }
+            Button("Make Secondary") { moveDevice(button.id, to: 1) }
+            Divider()
+            Button("Disconnect") { manager.disconnectDevice(button.id) }
+        }
     }
 
     private struct EqPreset {


### PR DESCRIPTION
Lets James pick the multipoint **primary/secondary pair** by reordering the device grid (index 0 = primary/active, 1 = secondary/held, rest = eviction order). Reorder → persists to `~/.config/bose/priority.json` + connects the pair.

- **CLI (owns the logic):** `cli/Priority.swift` (`PriorityOrder` + `effectiveRank`, unit-tested); `bose priority [--set…|--clear]` and `bose pair <primary> <secondary>`; eviction now ranks by the runtime order (compiled devices.toml fallback).
- **App (thin front-end):** drag-to-reorder grid + 1/2 role badges + right-click Make Primary/Secondary/Disconnect; shells `priority`/`pair`.
- **Not built:** no resident 'kick the aggressive transmitter' watcher (banned #61–#69 dropout pattern); firmware has no priority push (FuncNotSupp).
- 12 unit tests pass; app builds + renders (badges verified live). Live `pair` not fired in CI (mutates real BT). Design doc in `docs/plans/`.