### PR TITLE
feat: draggable device sidebar (3-col) + Mac as a plain device

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-remove walk-back auto-reconnect too aggressive
-remove walk-back auto-reconnect too aggressive
+device sidebar 3-col drag-priority + connect reliability
+device sidebar 3-col drag-priority + connect reliability
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - remove-walkback-reconnect
+# Agent Progress - device-sidebar
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-07-13T02:34:37Z
+# Created: 2026-07-13T03:01:24Z
 
-feature=remove-walkback-reconnect
-name=remove walk-back auto-reconnect too aggressive
+feature=device-sidebar
+name=device sidebar 3-col drag-priority + connect reliability
 status=pending
 step=0
 step_name=Not started
-created=2026-07-13T02:34:37Z
+created=2026-07-13T03:01:24Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,13 @@ is three thin front-ends that shell out to the `cli/` binary (`~/bin/bose`), so
 nothing runs in the background and the Mac only touches the headphones on an
 explicit user action.
 - `macos/BoseControl/` -- **Bose.app**: a windowed SwiftUI app (warm-paper light
-  two-panel: battery/ANC mode/Immersive Audio (spatial Off/Still/Motion)/volume/multipoint + auto-pause/auto-answer toggles
-  (01,18 / 01,1B) + a favourites display (1F,08, read-only) + a **reorderable device grid** + EQ). The light
+  **three-panel**: left = settings (battery/ANC mode/Immersive Audio (spatial Off/Still/Motion)/volume/multipoint + auto-pause/auto-answer toggles
+  (01,18 / 01,1B) + a favourites display (1F,08, read-only)); middle = a **draggable device sidebar** (a vertical
+  list of device rows — **drag up/down to rank priority**, index 0 = primary/① and 1 = secondary/② for the
+  multipoint pair; **tap a row to connect** that device as the active sink; a rank badge + a live state dot
+  ● active / ● held / ○ offline per row, so the badge shows your ranked preference and the dot shows reality;
+  drag persists `priority.json` via `bose priority --set` and does NOT touch the radio — connecting is only ever
+  an explicit tap; right-click → Disconnect); right = EQ. The light
   theme (burnt-orange `#AF3A03` accent on warm paper, from the Midterm `paper-hc` palette)
   is shared with the Android app; macOS colours live in `ContentView.swift`, Android in
   `MainActivity.kt` (`BoseAccent`/`BoseConnected`/…). Six ANC
@@ -223,15 +228,23 @@ devices first**, then pages the target — and **restores the evicted device if 
 fails to connect** (`evictLowestPriorityIfFull` / `restoreEvicted` in `cli/main.swift`).
 Mac app / Raycast / Hammerspoon inherit this (they shell `bose`). **Runtime override:** a
 user-chosen order in `~/.config/bose/priority.json` (`bose priority --set …`, or the Mac
-app's **drag-to-reorder device grid** — index 0 = primary/active, 1 = secondary/held) takes
+app's **draggable device sidebar** — drag up/down to rank, index 0 = primary, 1 = secondary;
+dragging only sets priority, tapping a row connects) takes
 precedence over the compiled priorities for victim selection (`effectiveRank`, `cli/Priority.swift`).
 `bose pair <primary> <secondary>` connects exactly that pair (evict others → secondary held →
 primary active). The order is host-side only — never pushed to the headphones (no firmware
 priority hierarchy). **Android now replicates
 it too**: pure victim selection in `android/.../Eviction.kt` (`evictionVictim`, JVM-unit-
 tested), held-state read via `Composites.getDeviceStates`, wired into `BoseService.switchDevice`
-(evict-then-page, restore on failure). Android can't run the Mac's host-side blueutil step, so
-it only sends the BMAP disconnect/connect — correct from the phone's side.
+(evict-then-page, restore on failure).
+
+**The Mac is a plain device — no host-side A2DP dance (2026-07-13).** `connect`/`swap`/
+`disconnect`/`pair`/eviction previously special-cased the Mac with a `blueutil --connect/
+--disconnect` step (+ a 1.5s settle) to bring up the macOS-side A2DP link. That was removed —
+the Mac now goes through the exact same BMAP connect/disconnect as any other device (the
+headphones page it; macOS establishes A2DP on its side). This kills the blueutil-timing
+flakiness that made "connect Mac" unreliable, at the cost of relying on macOS to accept the
+page (verify on hardware). `isMacDevice`/`runBlueutil` are gone from the CLI.
 
 **Cycle order** (bose): `mac → quest → ipad → iphone → tv → appletv → phone`
 

--- a/cli/Transport.swift
+++ b/cli/Transport.swift
@@ -20,27 +20,6 @@ import CoreBluetooth
 
 let RFCOMM_CHANNEL: BluetoothRFCOMMChannelID = 2  // SPP (BMAP) — resolved via SDP
 
-/// Run blueutil CLI for A2DP connect/disconnect (IOBluetooth doesn't expose this).
-/// Ported from v1. Used only on the explicit "switch to mac" path.
-@discardableResult
-func runBlueutil(_ args: [String], path: String = "/opt/homebrew/bin/blueutil") -> (Int32, String) {
-    let proc = Process()
-    proc.executableURL = URL(fileURLWithPath: path)
-    proc.arguments = args
-    let pipe = Pipe()
-    proc.standardOutput = pipe
-    proc.standardError = pipe
-    do {
-        try proc.run()
-        proc.waitUntilExit()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let out = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return (proc.terminationStatus, out)
-    } catch {
-        return (1, "")
-    }
-}
-
 enum TransportError: Error, CustomStringConvertible {
     case deviceNotFound
     case connectionFailed(IOReturn)

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -48,10 +48,6 @@ func activeName(forMac mac: [UInt8]) -> String {
     BoseDeviceMap.name(forMac: mac) ?? "mac"
 }
 
-func isMacDevice(_ mac: [UInt8]) -> Bool {
-    BoseDeviceMap.mac("mac") == mac
-}
-
 // MARK: - Commands
 
 /// status / s — full snapshot in ONE RFCOMM session via the getAllState composite.
@@ -433,7 +429,6 @@ func evictLowestPriorityIfFull(target: [UInt8]) -> BoseDevice? {
             < effectiveRank($1.name, order: order, compiledPriority: $1.priority)
     }) else { return nil }
     _ = transport.oneShot(BMAP.disconnectDevice(mac: victim.mac))
-    if isMacDevice(victim.mac) { runBlueutil(["--disconnect", Headphone.mac]) }
     print("Evicted \(victim.name) (priority \(victim.priority)) to free a multipoint slot")
     Thread.sleep(forTimeInterval: 0.8)           // let the slot clear before paging the target
     return victim
@@ -442,7 +437,6 @@ func evictLowestPriorityIfFull(target: [UInt8]) -> BoseDevice? {
 /// Re-page a device we evicted, after the target connect failed — restores the prior pair.
 func restoreEvicted(_ victim: BoseDevice, failedTarget: String) {
     _ = transport.oneShot(BMAP.connectDevice(mac: victim.mac))
-    if isMacDevice(victim.mac) { runBlueutil(["--connect", Headphone.mac]) }
     print("Restored \(victim.name) (target \(failedTarget) was unreachable)")
 }
 
@@ -450,12 +444,6 @@ func restoreEvicted(_ victim: BoseDevice, failedTarget: String) {
 func cmdConnect(_ deviceName: String) {
     let mac = macForName(deviceName)
     let evicted = evictLowestPriorityIfFull(target: mac)
-
-    // For the Mac itself, ensure A2DP first (macOS link), like v1/the app.
-    if isMacDevice(mac) {
-        runBlueutil(["--connect", Headphone.mac])
-        Thread.sleep(forTimeInterval: 1.5)
-    }
 
     _ = transport.oneShot(BMAP.connectDevice(mac: mac), timeout: 5.0)
 
@@ -475,11 +463,6 @@ func cmdConnect(_ deviceName: String) {
 func cmdSwap(_ targetName: String) {
     let mac = macForName(targetName)
     let evicted = evictLowestPriorityIfFull(target: mac)
-
-    if isMacDevice(mac) {
-        runBlueutil(["--connect", Headphone.mac])
-        Thread.sleep(forTimeInterval: 1.5)
-    }
 
     _ = transport.oneShot(BMAP.connectDevice(mac: mac), timeout: 5.0)
 
@@ -542,11 +525,6 @@ func cmdDisconnect(_ deviceName: String) {
 
     _ = transport.oneShot(BMAP.disconnectDevice(mac: mac))
 
-    // If disconnecting Mac, also drop the Mac BT stack link.
-    if isMacDevice(mac) {
-        runBlueutil(["--disconnect", Headphone.mac])
-    }
-
     print("Disconnected \(deviceName)")
 }
 
@@ -593,7 +571,6 @@ func cmdPair(_ primary: String, _ secondary: String) {
         var evictedAny = false
         for m in held where !keep.contains(macString(m)) {
             _ = transport.oneShot(BMAP.disconnectDevice(mac: m))
-            if isMacDevice(m) { runBlueutil(["--disconnect", Headphone.mac]) }
             print("Evicted \(displayName(forMac: m)) to free a slot for the pair")
             evictedAny = true
         }
@@ -602,7 +579,6 @@ func cmdPair(_ primary: String, _ secondary: String) {
 
     // Page the secondary first (settles held), then the primary (should become active).
     func page(_ mac: [UInt8]) -> ConnectOutcome {
-        if isMacDevice(mac) { runBlueutil(["--connect", Headphone.mac]); Thread.sleep(forTimeInterval: 1.5) }
         _ = transport.oneShot(BMAP.connectDevice(mac: mac), timeout: 5.0)
         return confirmConnect(mac)
     }

--- a/docs/plans/2026-07-13-device-sidebar-design.md
+++ b/docs/plans/2026-07-13-device-sidebar-design.md
@@ -1,0 +1,58 @@
+# Device sidebar + Mac-as-plain-device — design (2026-07-13)
+
+## Problem
+
+Two issues with the Bose.app multipoint control:
+
+1. The device picker was a 3-column `LazyVGrid` with drag-to-reorder. In a grid,
+   "drag to set priority" reads ambiguously (up/down/left/right), and **every drag
+   that changed the top-2 fired a live `pair` connect** (`applyOrder` → `applyPair`),
+   so drags raced against connects — especially with the Avantree Audikast re-paging
+   its slot aggressively. It "didn't work properly."
+2. Connecting the **Mac** was unreliable. The CLI special-cased the Mac with a
+   `blueutil --connect` (+1.5s sleep) A2DP dance on every connect/swap/pair/evict.
+
+## Decisions (with James)
+
+- **Layout:** a dedicated **3-column** window — Settings │ Devices sidebar │ EQ.
+- **Drag semantics:** dragging **sets priority only** (persists `priority.json`, no
+  radio activity). Connecting is an explicit **tap** on a device row. This decouples
+  ranking from connecting and removes the drag-races-connect bug.
+- **Mac:** strip **all** Mac special-casing — treat it exactly like any other device
+  (plain BMAP connect/disconnect, no blueutil, no sleeps).
+
+## Design
+
+### Layout (`ContentView.swift`)
+`connectedLayout` becomes a 3-panel `HStack`: `leftPanel` (260) │ divider │
+`deviceSidebar` (220) │ divider │ `eqPanel` (flex). Window min-width 700→800.
+
+### Device sidebar
+- `deviceList`: a vertical `VStack` of `deviceRow`s in `deviceOrder`, each with
+  `.onDrag`/`.onDrop` via the existing `DeviceDropDelegate` (axis-agnostic; vertical
+  is unambiguous). `onCommit` = `applyOrder` = **`manager.setPriority` only**.
+- `deviceRow`: `[rank badge] [icon] label … [state dot]`, ~38px tall. Badge = ①/②
+  filled for the top-2 (pair preference), faint rank number below. Dot = live state
+  (● active / ● held / ○ offline). Tap → `manager.connectDevice`. Right-click →
+  Disconnect. The badge shows your **ranked preference**; the dot shows **reality** —
+  they intentionally differ when the ranked device isn't the current sink.
+- Removed: `deviceButton` (grid tile), `moveDevice` + the Make-Primary/Secondary menu
+  (drag replaces them), `appliedTop2` state, the auto-`applyPair` on reorder.
+
+### Mac-as-plain-device (`cli/main.swift`, `cli/Transport.swift`)
+Removed every `isMacDevice(…) { runBlueutil(…) }` site across `cmdConnect`, `cmdSwap`,
+`cmdDisconnect`, `cmdPair` (evict + page), `evictLowestPriorityIfFull`, `restoreEvicted`.
+Deleted the now-dead `isMacDevice` and `runBlueutil` helpers.
+
+## Testing / verification
+
+- `cli/run-tests.sh` = 18 pass (priority/profile logic unchanged).
+- App builds + Developer-ID signs; 3-column layout verified via AX screenshot.
+- **Hardware, James to confirm:** that plain-BMAP `connect mac` reliably routes Mac
+  audio without the blueutil link. The Audikast re-page race is radio timing — powering
+  the transmitter off remains the durable lever.
+
+## Out of scope
+- No resident watcher / auto-reconnect (banned #61-#69; walk-back removed #139).
+- No firmware priority push (`ConnectionPriority 0x10` is FuncNotSupp).
+- Android app unchanged.

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -1,5 +1,6 @@
-/// ContentView: Warm-paper two-panel layout for Bose headphone control.
-/// Left panel = status sidebar (220px), right panel = device grid + EQ.
+/// ContentView: Warm-paper three-panel layout for Bose headphone control.
+/// Left = status sidebar (260px), middle = device sidebar (a draggable vertical list —
+/// drag to rank priority, index 0 = primary; tap to connect), right = EQ.
 /// Light theme — burnt-orange accent on warm paper (drawn from the Midterm "paper-hc"
 /// terminal theme), matching the Android app.
 
@@ -84,8 +85,6 @@ struct ContentView: View {
     // `bose priority` order on appear. `draggingId` tracks the in-flight drag.
     @State private var deviceOrder: [String] = deviceButtons.map { $0.id }
     @State private var draggingId: String? = nil
-    // The top-2 we last connected as a pair — so reordering positions 3-8 doesn't re-page.
-    @State private var appliedTop2: [String] = []
 
     var body: some View {
         Group {
@@ -99,7 +98,7 @@ struct ContentView: View {
         // width/height + .windowResizability(.contentSize) pinned it to one exact size. The
         // ideal is the bigger default; maxWidth/Height .infinity let the panels fill when
         // dragged larger; the min keeps the two-column layout + hints from clipping.
-        .frame(minWidth: 700, idealWidth: 760, maxWidth: .infinity,
+        .frame(minWidth: 800, idealWidth: 860, maxWidth: .infinity,
                minHeight: 480, idealHeight: 560, maxHeight: .infinity)
         .background(paperColor)
         .preferredColorScheme(.light)
@@ -108,7 +107,7 @@ struct ContentView: View {
             syncSliders()
             installShortcuts()
             // Load the saved multipoint priority order; append any devices missing from it
-            // (e.g. a newly-added tile) so the grid always shows every device.
+            // (e.g. a newly-added device) so the list always shows every device.
             manager.loadPriorityOrder { saved in
                 guard !saved.isEmpty else { return }
                 let all = deviceButtons.map { $0.id }
@@ -177,13 +176,16 @@ struct ContentView: View {
             leftPanel
                 .frame(width: 260)  // wide enough for the fixed-mode hints to wrap cleanly
 
-            // Divider
-            Rectangle()
-                .fill(dividerColor)
-                .frame(width: 1)
+            Rectangle().fill(dividerColor).frame(width: 1)
 
-            // Right panel — device grid + EQ
-            rightPanel
+            // Middle panel — device sidebar (draggable priority list)
+            deviceSidebar
+                .frame(width: 220)
+
+            Rectangle().fill(dividerColor).frame(width: 1)
+
+            // Right panel — EQ
+            eqPanel
                 .frame(maxWidth: .infinity)
         }
         .padding(.top, 28)  // clear transparent title bar
@@ -387,39 +389,67 @@ struct ContentView: View {
         }
     }
 
-    // MARK: - Right Panel (Device Grid + EQ)
+    // MARK: - Middle Panel (Device Sidebar — draggable priority list)
 
-    private var rightPanel: some View {
-        VStack(alignment: .leading, spacing: 14) {
+    private var deviceSidebar: some View {
+        VStack(alignment: .leading, spacing: 10) {
             Text("DEVICES")
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundColor(secondaryColor)
                 .tracking(1)
 
-            deviceGrid
+            deviceList
 
-            Text("EQUALIZER")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundColor(secondaryColor)
-                .tracking(1)
-                .padding(.top, 4)
+            Text("Drag to rank · tap to connect")
+                .font(.system(size: 9))
+                .foregroundColor(offlineColor)
 
-            eqPresets
-            eqSliders
+            Spacer(minLength: 0)
+
+            // State legend
+            HStack(spacing: 12) {
+                legendDot(boseAccent, "active")
+                legendDot(connectedColor, "held")
+                legendDot(offlineColor.opacity(0.5), "offline")
+            }
+            .font(.system(size: 9))
+            .foregroundColor(secondaryColor)
         }
         .padding(16)
     }
 
-    /// Tiles in the user's priority order (index 0 = primary, 1 = secondary, rest = eviction).
+    private func legendDot(_ color: Color, _ label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 7, height: 7)
+            Text(label)
+        }
+    }
+
+    // MARK: - Right Panel (EQ)
+
+    private var eqPanel: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("EQUALIZER")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(secondaryColor)
+                .tracking(1)
+
+            eqPresets
+            eqSliders
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+    }
+
+    /// Rows in the user's priority order (index 0 = primary, 1 = secondary, rest = eviction).
     private var orderedButtons: [DeviceButton] {
         deviceOrder.compactMap { id in deviceButtons.first { $0.id == id } }
     }
 
-    private var deviceGrid: some View {
-        let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
-        return LazyVGrid(columns: columns, spacing: 8) {
+    private var deviceList: some View {
+        VStack(spacing: 6) {
             ForEach(Array(orderedButtons.enumerated()), id: \.element.id) { idx, button in
-                deviceButton(button, index: idx)
+                deviceRow(button, index: idx)
                     .onDrag {
                         draggingId = button.id
                         return NSItemProvider(object: button.id as NSString)
@@ -433,85 +463,85 @@ struct ContentView: View {
         }
     }
 
-    /// Persist the new order and, if the top-2 (the multipoint pair) changed, connect it now.
+    /// Persist the new priority order (index 0 = primary). Dragging ONLY ranks — it does
+    /// not touch the radio. Connecting is an explicit tap on a row (see deviceRow's action).
     private func applyOrder() {
         manager.setPriority(deviceOrder)
-        let top2 = Array(deviceOrder.prefix(2))
-        guard top2.count == 2, top2 != appliedTop2 else { return }
-        appliedTop2 = top2
-        manager.applyPair(primary: top2[0], secondary: top2[1])
     }
 
-    /// Move a device to a slot (used by the right-click Make Primary/Secondary actions).
-    private func moveDevice(_ id: String, to index: Int) {
-        guard let from = deviceOrder.firstIndex(of: id) else { return }
-        deviceOrder.remove(at: from)
-        deviceOrder.insert(id, at: min(index, deviceOrder.count))
-        applyOrder()
-    }
-
-    private func deviceButton(_ button: DeviceButton, index: Int) -> some View {
+    /// One device row: [rank badge] [icon] label … [state dot]. Tap connects it; drag ranks.
+    private func deviceRow(_ button: DeviceButton, index: Int) -> some View {
         let state = manager.deviceStates[button.id] ?? "offline"
         let isConnecting = manager.connectingDevice == button.id
         let isActive = state == "active"
         let isConnected = state == "connected"
-        // Another tile is mid-connect — dim this one and ignore taps until it settles.
+        // Another row is mid-connect — dim this one and ignore taps until it settles.
         let isBlocked = manager.connectingDevice != nil && !isConnecting
 
+        let dotColor: Color = isActive ? boseAccent
+            : (isConnected ? connectedColor : offlineColor.opacity(0.5))
         let textColor: Color = (isActive || isConnecting) ? boseAccent
-            : (isConnected ? connectedColor : offlineColor)
+            : (isConnected ? inkColor : secondaryColor)
         let bg: Color = (isActive || isConnecting) ? activeBg : cardColor
         let borderColor: Color = (isActive || isConnecting) ? boseAccent.opacity(0.7) : hairColor
 
         return Button(action: { manager.connectDevice(button.id) }) {
-            VStack(spacing: 3) {
+            HStack(spacing: 9) {
+                // Rank badge — 1/2 filled for the multipoint pair, faint number below.
+                ZStack {
+                    if index <= 1 {
+                        Circle().fill(index == 0 ? boseAccent : connectedColor)
+                            .frame(width: 16, height: 16)
+                        Text(index == 0 ? "1" : "2")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundColor(paperColor)
+                    } else {
+                        Text("\(index + 1)")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(offlineColor)
+                    }
+                }
+                .frame(width: 16)
+
+                Image(systemName: button.symbol)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundColor(textColor)
+                    .frame(width: 20)
+
+                Text(button.label)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(textColor)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+
+                Spacer(minLength: 4)
+
                 if isConnecting {
                     ProgressView()
                         .controlSize(.small)
-                        .scaleEffect(0.7)
-                        .frame(height: 18)
+                        .scaleEffect(0.6)
+                        .frame(width: 12, height: 12)
                 } else {
-                    Image(systemName: button.symbol)
-                        .font(.system(size: 18, weight: .regular))
-                        .foregroundColor(textColor)
+                    Circle().fill(dotColor).frame(width: 8, height: 8)
                 }
-                Text(isConnecting ? "Connecting…" : button.label)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(textColor)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.center)
-                    .minimumScaleFactor(0.7)
             }
+            .padding(.horizontal, 10)
+            .frame(height: 38)
             .frame(maxWidth: .infinity)
-            .frame(height: 52)
             .background(bg)
             .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(borderColor, lineWidth: 1)
+                RoundedRectangle(cornerRadius: 9).stroke(borderColor, lineWidth: 1)
             )
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .contentShape(RoundedRectangle(cornerRadius: 10))  // whole tile is the hit area
-            // Multipoint role badge: 1 = Primary (active audio), 2 = Secondary (held).
-            .overlay(alignment: .topLeading) {
-                if index <= 1 {
-                    Text(index == 0 ? "1" : "2")
-                        .font(.system(size: 8, weight: .bold))
-                        .foregroundColor(paperColor)
-                        .frame(width: 13, height: 13)
-                        .background(Circle().fill(index == 0 ? boseAccent : connectedColor))
-                        .padding(4)
-                        .help(index == 0 ? "Primary — active audio" : "Secondary — held on multipoint")
-                }
-            }
+            .clipShape(RoundedRectangle(cornerRadius: 9))
+            .contentShape(RoundedRectangle(cornerRadius: 9))  // whole row is the hit area
         }
         .buttonStyle(.plain)
         .disabled(isBlocked)
-        .opacity(isBlocked ? 0.4 : (state == "offline" && !isConnecting ? 0.6 : 1.0))
-        // Drag a tile to reorder, or use these — index 0 = Primary, 1 = Secondary.
+        .opacity(isBlocked ? 0.4 : (state == "offline" && !isConnecting ? 0.7 : 1.0))
+        .help(index == 0 ? "Primary — drag to rank, tap to connect"
+            : index == 1 ? "Secondary — drag to rank, tap to connect"
+            : "Drag up to rank · tap to connect")
         .contextMenu {
-            Button("Make Primary") { moveDevice(button.id, to: 0) }
-            Button("Make Secondary") { moveDevice(button.id, to: 1) }
-            Divider()
             Button("Disconnect") { manager.disconnectDevice(button.id) }
         }
     }


### PR DESCRIPTION
Rebuilds the multipoint device picker as a **draggable vertical sidebar** and strips all Mac special-casing.

**UI:** 3-column window (Settings | Devices | EQ). Devices are a vertical list in priority order — **drag to rank** (persists priority.json, no radio activity), **tap to connect**. Each row: rank badge (①② = the pair) + live state dot (active/held/offline). Removes the auto-pair-connect-on-drag that raced the Audikast.

**CLI:** the Mac is now a plain device — same BMAP connect/disconnect as any other, no `blueutil` A2DP dance / 1.5s sleeps. Deletes dead `isMacDevice`/`runBlueutil`.

Verified: `cli/run-tests.sh` 18 pass; app builds + Developer-ID signs; 3-col layout confirmed via screenshot. Hardware confirm (James): plain-BMAP `connect mac` routing.

Design: docs/plans/2026-07-13-device-sidebar-design.md