### PR TITLE
feat: cached-first info reads — ACL gate + shared state cache

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-device sidebar 3-col drag-priority + connect reliability
-device sidebar 3-col drag-priority + connect reliability
+Cached-first info reads with ACL gate and state cache
+Cached-first info reads with ACL gate and state cache
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - device-sidebar
+# Agent Progress - cached-first-info
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-07-13T03:01:24Z
+# Created: 2026-07-18T04:18:41Z
 
-feature=device-sidebar
-name=device sidebar 3-col drag-priority + connect reliability
+feature=cached-first-info
+name=Cached-first info reads with ACL gate and state cache
 status=pending
 step=0
 step_name=Not started
-created=2026-07-13T03:01:24Z
+created=2026-07-18T04:18:41Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,17 @@ explicit user action.
   It is a **thin front-end that shells `bose`** — NO RFCOMM, NO IOBluetooth, NO
   protocol code — reading via `bose info --json` and writing via the verbs. It is
   **user-launched and event-driven**: reads on window-open, on app-focus, after each
-  write, and on ⌘R — never on a timer. Build `bash macos/build.sh [--install]`
+  write, and on ⌘R — never on a timer. Open/focus reads are **cached-first** (#148):
+  `info --json` checks ACL presence (free, zero radio) and with no link serves the
+  timestamped last-good snapshot (`~/.cache/bose/state-<MAC>.json`) stamped
+  `reachable:false` + `ageSeconds` instead of PAGING the headphones — so opening the
+  app while audio plays on another sink is instant and can't glitch it. The app shows
+  a staleness banner ("Not connected to this Mac — last known state (Xm ago)") over
+  the full last-known dashboard; **⌘R forces a live read** (`--page`), and every
+  post-write/connect confirm read is `--page` too (a settle loop must never confirm
+  against the cache). `reachable` = this Mac's link now; `connected` = we have real
+  headphone state to paint (the app no longer wipes to "Not Connected" on a mere
+  unreachable read — only when there's nothing known at all). Build `bash macos/build.sh [--install]`
   (Developer-ID signed → `/Applications`; no LaunchAgent). In-window keys: ⌘1-6
   ANC modes (slots 0-5), ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M connect Mac. Global hotkeys stay in
   Hammerspoon. The `--json` read seam lives in `cli/main.swift` (`cmdInfoJSON`, pure
@@ -81,7 +91,8 @@ explicit user action.
 
 ### CLI (`cli/`) — regenerated on the shared layer
 - `cli/main.swift` -- `bose` command surface (status/battery/anc/anc-level/spatial/mode-name/devices/connect/disconnect/swap/pair/priority/volume/multipoint/auto-pause/auto-answer/favorites/play-pause-next-prev/eq/raw). `pair <primary> <secondary>` = the multipoint-pair composite (evict others → connect secondary held → primary active); `priority [--set n… | --clear]` shows/sets the runtime eviction order in `~/.config/bose/priority.json` (index 0 = primary). Pure order logic in `cli/Priority.swift` (`PriorityOrder` + `effectiveRank`, unit-tested); `evictLowestPriorityIfFull` ranks by it (runtime order overrides the compiled devices.toml priority, graceful fallback when absent). `mode-name [--slot 4|5] [name]` renames a custom mode via the 1F,06 RMW (name field, SET payload [3..34]) — custom slots only (`userConfigurable`; presets are locked, firmware ignores the write). Without `--slot` it targets the ACTIVE mode (`setActiveModeName`); with `--slot 4`/`5` it renames C1/C2 **in place without changing the active mode** (`setModeName`, used by the Mac app's right-click rename). Both share `renameModeSlot`. The name persists on-device and shows in the Bose app too. `info --json` emits `custom1Name`/`custom2Name` (slot 4/5 stored names) AND the active mode config (modeName/noiseLevel/spatial/adjustable) — all read in the SAME warm session as the bulk state, folded into `getAllStateWithDevices` (a separate `readModeInfo` call ran as a cold SECOND session and reliably came back empty, blanking the slider/spatial/C1-C2 names, #134). The Mac app labels the C1/C2 buttons with the names (falling back to "C1"/"C2" when unset = "None") and renames them via right-click → Rename… → `mode-name --slot`. The Android app does the same display on its mode selector — `Composites.readCustomModeNames()` (slots 4/5) → `BoseViewModel` `custom1Name`/`custom2Name` → `AncSection` label. (Display only on Android; renaming is Mac/CLI via `mode-name`.) **No inline byte parsing** — every command routes through the generated `BMAP.*` builders. `connect`/`swap` poll-confirm via `getConnectedDevices` (ACK is never success); volume uses the generated SET_GET builder.
-- `cli/Transport.swift` -- IOBluetooth RFCOMM transport (per-command open/drain-300ms/close, cold-start warm-up, serial queue).
+- `cli/Transport.swift` -- IOBluetooth RFCOMM transport (per-command open/drain-300ms/close, cold-start warm-up, serial queue). `isHeadphoneConnected()` = the free ACL-presence check (no channel, no page) gating the cached-first `info --json`.
+- `cli/StateCache.swift` -- timestamped last-good `info --json` snapshot (`~/.cache/bose/state-<MAC>.json`; `$BOSE_STATE_DIR` test override). Written on every successful live read; served with `reachable:false`/`cachedAt`/`ageSeconds` when the Mac has no ACL link (`--page` bypasses). Foundation-only, unit-tested.
 - `cli/Composites.swift` -- live-channel composites (cncLevel RMW, connectedDevices list, getAllState single-session).
 - `cli/Parsers.swift` -- pure, hardware-free response parsers; `cli/Tests/main.swift` + `cli/run-tests.sh` are the standalone unit tests (same captured-byte corpus as Android `Parsers.kt`).
 - `cli/build.sh` -- compiles the generated Swift + `cli/{Transport,Parsers,Composites}.swift` + `cli/main.swift` → `cli/build/bose`. Does NOT install over `~/bin/bose`.
@@ -435,6 +446,9 @@ event-driven, channel-free `blueutil` + a last-active-mac flag — was tried and
 **RFCOMM opens ACL.** Any RFCOMM connection (including state queries) establishes
 ACL to the headphones. Bose firmware may interpret this as "device wants audio".
 Don't probe/poll from a device that isn't supposed to be the active source.
+The cached-first `info --json` (#148) is the structural guard for the READ path:
+with no ACL it never opens RFCOMM at all (cache instead); only `--page`, writes,
+and explicit verbs touch the radio from a non-slot Mac.
 
 ## Rules
 

--- a/cli/StateCache.swift
+++ b/cli/StateCache.swift
@@ -1,0 +1,84 @@
+/// StateCache: the timestamped last-good `info --json` snapshot.
+///
+/// Written on every successful LIVE `info --json` read; served when the Mac has no
+/// ACL link to the headphones so the app (and any other front-end) can paint the
+/// last-known state INSTANTLY instead of paging the headphones over BT Classic.
+/// Paging from a non-slot device is slow (multi-second page + warm-up) and is the
+/// interference class behind the #69-era audio dropouts — the cached-first read
+/// makes "open the app while the golf plays through the Audikast" a zero-radio act.
+///
+/// The cache is a *presentation* cache, not a source of truth: every served
+/// snapshot is stamped `reachable: false` + `cachedAt`/`ageSeconds`, and the UI
+/// renders the staleness honestly. A live read (ACL up, or explicit `--page`)
+/// always bypasses and rewrites it.
+///
+/// Location: `~/.cache/bose/state-<MAC>.json` (same home as the identity memo);
+/// `$BOSE_STATE_DIR` overrides for tests (same env the priority tests use).
+/// Foundation-only — no IOBluetooth — so it compiles into the headless test binary.
+
+import Foundation
+
+enum StateCache {
+
+    /// Snapshot JSON keys added by the cache layer (kept in one place so the
+    /// stamping logic and its tests can't drift from the emitters in main.swift).
+    static let reachableKey = "reachable"
+    static let cachedAtKey = "cachedAt"
+    static let ageSecondsKey = "ageSeconds"
+
+    private static var path: String {
+        let dir: String
+        if let d = ProcessInfo.processInfo.environment["BOSE_STATE_DIR"], !d.isEmpty {
+            dir = d
+        } else {
+            dir = FileManager.default.homeDirectoryForCurrentUser.path + "/.cache/bose"
+        }
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return (dir as NSString).appendingPathComponent("state-\(Headphone.dashMac).json")
+    }
+
+    /// Persist a successful live snapshot (the exact `info --json` object) with a
+    /// wall-clock stamp. Cache-layer keys are stripped first so a re-served cached
+    /// object can never be re-persisted as if it were live (belt-and-braces — the
+    /// call site only saves live reads anyway).
+    static func save(_ snapshot: [String: Any], now: Date = Date()) {
+        var clean = snapshot
+        clean.removeValue(forKey: reachableKey)
+        clean.removeValue(forKey: cachedAtKey)
+        clean.removeValue(forKey: ageSecondsKey)
+        let wrapped: [String: Any] = ["savedAt": now.timeIntervalSince1970, "snapshot": clean]
+        if let data = try? JSONSerialization.data(withJSONObject: wrapped) {
+            try? data.write(to: URL(fileURLWithPath: path))
+        }
+    }
+
+    /// Load the raw cached snapshot + its save time. nil when absent/corrupt.
+    static func load() -> (snapshot: [String: Any], savedAt: Date)? {
+        guard let data = FileManager.default.contents(atPath: path),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let ts = obj["savedAt"] as? Double,
+              let snap = obj["snapshot"] as? [String: Any]
+        else { return nil }
+        return (snap, Date(timeIntervalSince1970: ts))
+    }
+
+    /// The cached snapshot stamped for serving to a front-end: `reachable: false`
+    /// (the Mac has no link right now) + `cachedAt` (epoch seconds) + `ageSeconds`.
+    /// `connected` keeps its cached value — it describes the HEADPHONE state the
+    /// snapshot captured, not the Mac's link; `reachable` carries the link truth.
+    /// nil when there is no usable cache (caller falls back to a bare
+    /// connected:false/reachable:false object).
+    static func staleOutput(now: Date = Date()) -> [String: Any]? {
+        guard let (snap, savedAt) = load() else { return nil }
+        return stamp(snap, savedAt: savedAt, now: now)
+    }
+
+    /// Pure stamping transform (unit-tested without touching disk).
+    static func stamp(_ snapshot: [String: Any], savedAt: Date, now: Date) -> [String: Any] {
+        var out = snapshot
+        out[reachableKey] = false
+        out[cachedAtKey] = savedAt.timeIntervalSince1970
+        out[ageSecondsKey] = max(0, Int(now.timeIntervalSince(savedAt)))
+        return out
+    }
+}

--- a/cli/Tests/main.swift
+++ b/cli/Tests/main.swift
@@ -316,6 +316,37 @@ PriorityOrder.clear()
 check(PriorityOrder.load().order == [], "priority.json: clear reverts to empty (compiled default)")
 try? FileManager.default.removeItem(atPath: tmpPrio)
 
+// ── StateCache (cached-first info --json, #148) ────────────────────────────────
+
+// Fresh temp dir (the priority tests above removed theirs; use our own regardless).
+let tmpCache = NSTemporaryDirectory() + "bose-cache-test-\(ProcessInfo.processInfo.processIdentifier)"
+setenv("BOSE_STATE_DIR", tmpCache, 1)
+
+check(StateCache.staleOutput() == nil, "stateCache: empty dir -> no stale output (bare fallback)")
+
+let liveSnap: [String: Any] = ["connected": true, "reachable": true,
+                               "batteryLevel": 80, "ancMode": 1, "ageSeconds": 999]
+let t0 = Date(timeIntervalSince1970: 1_000_000)
+StateCache.save(liveSnap, now: t0)
+let loaded = StateCache.load()
+check(loaded != nil, "stateCache: save/load round-trip")
+check((loaded?.snapshot["batteryLevel"] as? Int) == 80, "stateCache: snapshot preserves values")
+check(loaded?.snapshot["reachable"] == nil && loaded?.snapshot["ageSeconds"] == nil,
+      "stateCache: cache-layer keys stripped on save (can't re-persist as live)")
+check(loaded?.savedAt == t0, "stateCache: savedAt stamp survives")
+
+let stale = StateCache.staleOutput(now: t0.addingTimeInterval(90))
+check((stale?["reachable"] as? Bool) == false, "stateCache: stale output -> reachable=false")
+check((stale?["ageSeconds"] as? Int) == 90, "stateCache: ageSeconds computed from savedAt")
+check((stale?["connected"] as? Bool) == true, "stateCache: connected keeps the cached headphone state")
+check((stale?["cachedAt"] as? Double) == 1_000_000, "stateCache: cachedAt = save epoch")
+
+// Pure stamp: age clamps at zero (a clock skew can't emit a negative age).
+let stamped = StateCache.stamp(["connected": true], savedAt: t0, now: t0.addingTimeInterval(-5))
+check((stamped[StateCache.ageSecondsKey] as? Int) == 0, "stateCache: stamp clamps negative age to 0")
+
+try? FileManager.default.removeItem(atPath: tmpCache)
+
 // ── summary ─────────────────────────────────────────────────────────────────────
 
 if failures == 0 {

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -41,6 +41,7 @@ swiftc -O \
     "$SCRIPT_DIR/Parsers.swift" \
     "$SCRIPT_DIR/Profiles.swift" \
     "$SCRIPT_DIR/Priority.swift" \
+    "$SCRIPT_DIR/StateCache.swift" \
     "$SCRIPT_DIR/Composites.swift" \
     "$SCRIPT_DIR/main.swift" \
     -framework IOBluetooth \

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -120,11 +120,35 @@ func cmdInfo() {
 /// is the read seam the windowed macOS app consumes — the app shells `bose` and
 /// never touches RFCOMM itself, so it can't reintroduce the polling/transport bugs.
 /// Pure formatting over existing composites — no protocol/spec change.
-func cmdInfoJSON() {
+///
+/// Cached-first (#148): a live read requires RFCOMM, and RFCOMM to a Mac that holds
+/// neither multipoint slot means a multi-second BT-Classic PAGE of the headphones —
+/// the exact probe-from-a-non-sink the transport rules warn about (it can glitch
+/// audio on the active sink; #69-era). So with no ACL link this emits the cached
+/// last-good snapshot stamped `reachable:false` + `cachedAt`/`ageSeconds` instead of
+/// paging — instant and radio-silent. `--page` forces the old live-read behaviour
+/// (an EXPLICIT user action, e.g. the app's ⌘R). With ACL up the read is live as
+/// ever and rewrites the cache. `connected` describes the headphone state a snapshot
+/// captured; `reachable` describes THIS Mac's link right now — the app keys off
+/// `reachable` for its staleness banner and never wipes known state over it.
+func cmdInfoJSON(forcePage: Bool = false) {
     func emit(_ obj: [String: Any]) {
         guard let data = try? JSONSerialization.data(withJSONObject: obj, options: [.sortedKeys]),
               let str = String(data: data, encoding: .utf8) else { print("{\"connected\":false}"); return }
         print(str)
+    }
+
+    /// No usable live path (no ACL and not forced, or the live read failed):
+    /// cached snapshot if we have one, else the bare disconnected object.
+    func emitFallback() {
+        emit(StateCache.staleOutput() ?? ["connected": false, StateCache.reachableKey: false])
+    }
+
+    // The gate: ACL presence is a free, zero-radio local read (IOBluetooth device
+    // state — no channel, no page). Only a live read past this point touches radio.
+    if !forcePage && !transport.isHeadphoneConnected() {
+        emitFallback()
+        return
     }
 
     // Bulk state AND device grid from ONE warm RFCOMM session. The active sink comes from
@@ -136,7 +160,12 @@ func cmdInfoJSON() {
     // standalone session-1 read it's already warm, and it skips the bulk reads it doesn't need.
     guard let (s, idleDevices, modeInfo) = transport.getAllStateWithDevices(
         query: BoseDeviceMap.knownDevices.map { $0.mac }
-    ) else { emit(["connected": false]); return }
+    ) else {
+        // Live read failed (page refused / link blip). Serve the cache rather than a
+        // bare connected:false so one miss can't wipe a known-good dashboard.
+        emitFallback()
+        return
+    }
 
     // Per-device 3-state, resolved by NAME (same logic as cmdDevices, #81). Active wins
     // over idle when a device resolves to both.
@@ -172,6 +201,7 @@ func cmdInfoJSON() {
 
     var out: [String: Any] = [
         "connected": true,
+        StateCache.reachableKey: true,
         "deviceName": s.deviceName.isEmpty ? "verBosita" : s.deviceName,
         "firmware": s.firmware,
         "batteryLevel": s.batteryLevel,
@@ -189,6 +219,7 @@ func cmdInfoJSON() {
         "custom2Name": customName(5),
     ]
     out.merge(mode) { _, new in new }
+    StateCache.save(out)   // the shared last-good snapshot every front-end paints from
     emit(out)
 }
 
@@ -762,7 +793,8 @@ func usage() {
 
     Usage:
       bose status               Connection, battery, ANC, volume, EQ (one session)
-      bose info [--json]        Full state: identity, power, all audio config, devices (--json for the app)
+      bose info [--json]        Full state: identity, power, all audio config, devices (--json for the app;
+                                --json is cached-first with no ACL link — add --page to force a live read)
       bose battery              Battery level
       bose devices              Known devices: ● active / ○ connected / · offline
       bose connect <device>     Route audio to device (poll-confirmed)
@@ -799,7 +831,7 @@ func requireArg(_ name: String) -> String {
 
 switch args[1].lowercased() {
 case "status", "s":            cmdStatus()
-case "info":                   args.contains("--json") ? cmdInfoJSON() : cmdInfo()
+case "info":                   args.contains("--json") ? cmdInfoJSON(forcePage: args.contains("--page")) : cmdInfo()
 case "battery", "b":           cmdBattery()
 case "anc":                    cmdAnc(args.count >= 3 ? args[2] : nil)
 case "anc-level":              cmdAncLevel(args.count >= 3 ? args[2] : nil)

--- a/cli/run-tests.sh
+++ b/cli/run-tests.sh
@@ -16,9 +16,11 @@ swiftc \
     -target arm64-apple-macos13.0 \
     -sdk "$(xcrun --show-sdk-path)" \
     "$GEN_DIR/BMAP.generated.swift" \
+    "$GEN_DIR/Devices.generated.swift" \
     "$SCRIPT_DIR/Parsers.swift" \
     "$SCRIPT_DIR/Profiles.swift" \
     "$SCRIPT_DIR/Priority.swift" \
+    "$SCRIPT_DIR/StateCache.swift" \
     "$SCRIPT_DIR/Tests/main.swift" \
     -o "$BIN"
 

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -16,6 +16,18 @@ final class BoseManager: ObservableObject {
     // MARK: - Published State (bound by ContentView)
 
     @Published var isConnected: Bool = false
+
+    /// Whether THIS Mac currently has a link to the headphones (the `reachable` field
+    /// of `info --json`). False while painting a cached snapshot — the CLI's
+    /// cached-first read (#148) serves the last-good state instantly instead of
+    /// paging headphones the Mac isn't connected to (the probe class behind the
+    /// #69-era audio dropouts). Drives the staleness banner; `isConnected` keeps
+    /// meaning "we have real headphone state to show".
+    @Published var reachable: Bool = true
+
+    /// Age of the painted snapshot in seconds (nil when live). From `ageSeconds`.
+    @Published var stateAgeSeconds: Int? = nil
+
     @Published var batteryLevel: Int = 0
     @Published var batteryCharging: Bool = false
     @Published var ancMode: Int = 0          // hardware slot: 0=quiet 1=aware 2=immersion 3=cinema 4=custom1 5=custom2
@@ -153,11 +165,16 @@ final class BoseManager: ObservableObject {
     // MARK: - Read
 
     /// Read full state via `info --json` and publish it. Event-driven only.
-    func refreshState() {
+    ///
+    /// Default reads are CACHED-FIRST: with no ACL link the CLI serves the last-good
+    /// snapshot instantly (zero radio) instead of paging the headphones — so window
+    /// open / app focus can never stall on a multi-second page or glitch audio on
+    /// another sink. `forcePage: true` (⌘R) deliberately pages for a live read.
+    func refreshState(forcePage: Bool = false) {
         DispatchQueue.main.async { self.isRefreshing = true }
         queue.async { [weak self] in
             guard let self = self else { return }
-            let (_, out) = self.run(["info", "--json"])
+            let (_, out) = self.run(["info", "--json"] + (forcePage ? ["--page"] : []))
             let parsed = Self.parse(out)
             DispatchQueue.main.async {
                 self.apply(parsed)
@@ -178,7 +195,12 @@ final class BoseManager: ObservableObject {
     /// Apply a decoded snapshot to published properties. Must run on the main thread.
     private func apply(_ s: [String: Any]) {
         let connected = (s["connected"] as? Bool) ?? false
+        // `reachable` absent (pre-#148 output) == the old semantics: a connected
+        // snapshot was by definition a live read.
+        let reach = (s["reachable"] as? Bool) ?? connected
         guard connected else {
+            reachable = false
+            stateAgeSeconds = nil
             // One transient unreachable `info` read shouldn't wipe a known-good
             // dashboard to "Not Connected". The CLI does a single RFCOMM attempt per
             // command, so an occasional miss when the link is briefly busy is expected,
@@ -193,6 +215,8 @@ final class BoseManager: ObservableObject {
         }
         consecutiveFailures = 0
         isConnected = true
+        reachable = reach
+        stateAgeSeconds = reach ? nil : (s["ageSeconds"] as? Int)
         batteryLevel = (s["batteryLevel"] as? Int) ?? batteryLevel
         batteryCharging = (s["batteryCharging"] as? Bool) ?? false
         let snapAnc = (s["ancMode"] as? Int) ?? ancMode
@@ -329,7 +353,9 @@ final class BoseManager: ObservableObject {
             // multipoint kept audio on the previous device (ACL up, not the active sink).
             let ok = code == 0 && out.range(of: "connected", options: .caseInsensitive) != nil
             let idle = out.range(of: "(idle", options: .caseInsensitive) != nil
-            let snapshot = Self.parse(self.run(["info", "--json"]).out)
+            // --page: this read follows an explicit connect — it must reflect the
+            // device's REAL post-connect state, never the cached-first snapshot.
+            let snapshot = Self.parse(self.run(["info", "--json", "--page"]).out)
             DispatchQueue.main.async {
                 if ok { self.assertedActiveDevice = idle ? nil : name }
                 self.apply(snapshot)   // refresh battery/EQ/etc; honours the assertion above
@@ -409,7 +435,7 @@ final class BoseManager: ObservableObject {
         queue.async { [weak self] in
             guard let self = self else { return }
             _ = self.run(["pair", primary, secondary])
-            let snapshot = Self.parse(self.run(["info", "--json"]).out)
+            let snapshot = Self.parse(self.run(["info", "--json", "--page"]).out)   // real post-pair state
             DispatchQueue.main.async {
                 self.apply(snapshot)
                 self.connectingDevice = nil
@@ -435,7 +461,9 @@ final class BoseManager: ObservableObject {
             guard let self = self else { return }
             _ = self.run(verb)
             for i in 0..<attempts {
-                let parsed = Self.parse(self.run(["info", "--json"]).out)
+                // --page: a settle loop reading the cache would "confirm" stale data
+                // (or spin to timeout) — post-write reads are always live.
+                let parsed = Self.parse(self.run(["info", "--json", "--page"]).out)
                 let ok = confirm(parsed)
                 DispatchQueue.main.async {
                     self.apply(parsed)

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -156,7 +156,7 @@ struct ContentView: View {
             case "4": manager.setAncMode(3); return nil
             case "5": manager.setAncMode(4); return nil
             case "6": manager.setAncMode(5); return nil
-            case "r": manager.refreshState(); return nil
+            case "r": manager.refreshState(forcePage: true); return nil   // ⌘R = deliberate live read
             case "m": manager.connectDevice("mac"); return nil
             default: break
             }
@@ -171,6 +171,41 @@ struct ContentView: View {
     // MARK: - Connected Layout
 
     private var connectedLayout: some View {
+        VStack(spacing: 0) {
+            // Staleness banner — painting the cached snapshot because this Mac has no
+            // link to the headphones (the CLI's cached-first read, #148). Honest about
+            // age; ⌘R deliberately pages for a live read (may blip audio on the sink).
+            if !manager.reachable {
+                HStack(spacing: 6) {
+                    Image(systemName: "wifi.slash")
+                        .font(.system(size: 10, weight: .medium))
+                    Text("Not connected to this Mac — last known state\(staleAgeText) · ⌘R reads live")
+                        .font(.system(size: 11, weight: .medium))
+                    Spacer()
+                }
+                .foregroundColor(secondaryColor)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 5)
+                .background(offlineColor.opacity(0.18))
+                .overlay(Rectangle().fill(dividerColor).frame(height: 1), alignment: .bottom)
+            }
+            connectedPanels
+        }
+    }
+
+    /// " (14m ago)" — the painted snapshot's age, humanised. Empty when unknown.
+    private var staleAgeText: String {
+        guard let s = manager.stateAgeSeconds else { return "" }
+        let text: String
+        switch s {
+        case ..<60: text = "just now"
+        case ..<3600: text = "\(s / 60)m ago"
+        default: text = "\(s / 3600)h \((s % 3600) / 60)m ago"
+        }
+        return " (\(text))"
+    }
+
+    private var connectedPanels: some View {
         HStack(spacing: 0) {
             // Left panel — status sidebar
             leftPanel


### PR DESCRIPTION
info --json now checks ACL presence before touching radio: no link → serve the timestamped last-good snapshot (reachable:false + ageSeconds) instead of paging the headphones; --page forces a live read (⌘R, post-write confirms). App paints instantly with a staleness banner and never wipes known state on an unreachable read. New cli/StateCache.swift (unit-tested), shared cache at ~/.cache/bose/state-<MAC>.json.