### PR TITLE
chore: remove unused cmd-R/cmd-M shortcuts

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Cached-first info reads with ACL gate and state cache
-Cached-first info reads with ACL gate and state cache
+Remove unused cmd-M and cmd-R shortcuts; banner gets Read live button
+Remove unused cmd-M and cmd-R shortcuts; banner gets Read live button
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - cached-first-info
+# Agent Progress - remove-cmd-m-r
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-07-18T04:18:41Z
+# Created: 2026-07-18T04:30:34Z
 
-feature=cached-first-info
-name=Cached-first info reads with ACL gate and state cache
+feature=remove-cmd-m-r
+name=Remove unused cmd-M and cmd-R shortcuts; banner gets Read live button
 status=pending
 step=0
 step_name=Not started
-created=2026-07-18T04:18:41Z
+created=2026-07-18T04:30:34Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,19 +47,19 @@ explicit user action.
   It is a **thin front-end that shells `bose`** — NO RFCOMM, NO IOBluetooth, NO
   protocol code — reading via `bose info --json` and writing via the verbs. It is
   **user-launched and event-driven**: reads on window-open, on app-focus, after each
-  write, and on ⌘R — never on a timer. Open/focus reads are **cached-first** (#148):
+  write, and on the banner's Read-live button — never on a timer. Open/focus reads are **cached-first** (#148):
   `info --json` checks ACL presence (free, zero radio) and with no link serves the
   timestamped last-good snapshot (`~/.cache/bose/state-<MAC>.json`) stamped
   `reachable:false` + `ageSeconds` instead of PAGING the headphones — so opening the
   app while audio plays on another sink is instant and can't glitch it. The app shows
   a staleness banner ("Not connected to this Mac — last known state (Xm ago)") over
-  the full last-known dashboard; **⌘R forces a live read** (`--page`), and every
+  the full last-known dashboard with a **Read live** button (a forced `--page` read), and every
   post-write/connect confirm read is `--page` too (a settle loop must never confirm
   against the cache). `reachable` = this Mac's link now; `connected` = we have real
   headphone state to paint (the app no longer wipes to "Not Connected" on a mere
   unreachable read — only when there's nothing known at all). Build `bash macos/build.sh [--install]`
   (Developer-ID signed → `/Applications`; no LaunchAgent). In-window keys: ⌘1-6
-  ANC modes (slots 0-5), ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M connect Mac. Global hotkeys stay in
+  ANC modes (slots 0-5), ⌘↑/⌘↓ volume (⌘R/⌘M removed 2026-07-18 — unused; live read = the banner button, connect Mac = its device row). Global hotkeys stay in
   Hammerspoon. The `--json` read seam lives in `cli/main.swift` (`cmdInfoJSON`, pure
   formatting over `getAllStateWithDevices` — bulk state + the device grid's active sink
   AND idle ACL probes in ONE warm session, so neither is lost to the cold-second-session

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -4,7 +4,7 @@
 /// the Hammerspoon module. It holds NO RFCOMM channel, imports NO IOBluetooth, and
 /// runs NO timer. Every read shells `bose info --json`; every write shells the
 /// matching verb. Reads happen only on explicit events (window open, window focus,
-/// after a write, manual ⌘R) — never on a poll. The v1 BoseManager's 10 s poll
+/// after a write, the banner's Read-live button) — never on a poll. The v1 BoseManager's 10 s poll
 /// timer was the audio-dropout root cause (#69-era); this design makes that class of
 /// bug structurally impossible here, and inherits every CLI fix (incl. #83) for free.
 
@@ -169,7 +169,7 @@ final class BoseManager: ObservableObject {
     /// Default reads are CACHED-FIRST: with no ACL link the CLI serves the last-good
     /// snapshot instantly (zero radio) instead of paging the headphones — so window
     /// open / app focus can never stall on a multi-second page or glitch audio on
-    /// another sink. `forcePage: true` (⌘R) deliberately pages for a live read.
+    /// another sink. `forcePage: true` (the staleness banner's Read-live button) deliberately pages for a live read.
     func refreshState(forcePage: Bool = false) {
         DispatchQueue.main.async { self.isRefreshing = true }
         queue.async { [weak self] in

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -145,7 +145,9 @@ struct ContentView: View {
     }
 
     /// In-window keyboard shortcuts (only while the app is focused — global hotkeys
-    /// stay in Hammerspoon). ⌘1-6 ANC modes (slots 0-5), ⌘↑/⌘↓ volume, ⌘R refresh, ⌘M Mac.
+    /// stay in Hammerspoon). ⌘1-6 ANC modes (slots 0-5), ⌘↑/⌘↓ volume. (⌘R/⌘M were
+    /// removed 2026-07-18 — unused; the live-read affordance is the staleness
+    /// banner's "Read live" button, and connecting the Mac is its device row.)
     private func installShortcuts() {
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             guard event.modifierFlags.contains(.command) else { return event }
@@ -156,8 +158,6 @@ struct ContentView: View {
             case "4": manager.setAncMode(3); return nil
             case "5": manager.setAncMode(4); return nil
             case "6": manager.setAncMode(5); return nil
-            case "r": manager.refreshState(forcePage: true); return nil   // ⌘R = deliberate live read
-            case "m": manager.connectDevice("mac"); return nil
             default: break
             }
             switch event.keyCode {
@@ -174,14 +174,23 @@ struct ContentView: View {
         VStack(spacing: 0) {
             // Staleness banner — painting the cached snapshot because this Mac has no
             // link to the headphones (the CLI's cached-first read, #148). Honest about
-            // age; ⌘R deliberately pages for a live read (may blip audio on the sink).
+            // age; its Read-live button deliberately pages for a live read (may blip audio).
             if !manager.reachable {
                 HStack(spacing: 6) {
                     Image(systemName: "wifi.slash")
                         .font(.system(size: 10, weight: .medium))
-                    Text("Not connected to this Mac — last known state\(staleAgeText) · ⌘R reads live")
+                    Text("Not connected to this Mac — last known state\(staleAgeText)")
                         .font(.system(size: 11, weight: .medium))
                     Spacer()
+                    // The deliberate live read (pages the headphones — may blip audio
+                    // on the active sink). Replaced ⌘R, removed 2026-07-18.
+                    Button(action: { manager.refreshState(forcePage: true) }) {
+                        Text(manager.isRefreshing ? "Reading…" : "Read live")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(boseAccent)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(manager.isRefreshing)
                 }
                 .foregroundColor(secondaryColor)
                 .padding(.horizontal, 12)


### PR DESCRIPTION
Drops the unused ⌘R (force refresh) and ⌘M (connect Mac) in-window shortcuts. The deliberate live read moves to a Read-live button on the staleness banner (where the affordance is actually needed); connecting the Mac stays on its device row. ⌘1-6 and ⌘↑/⌘↓ unchanged.