### PR TITLE
feat: Android cached-first parity — SlotGate + StateCache + staleness UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,9 @@ explicit user action.
 - `Parsers.kt` -- pure, hardware-free response parsers (JVM-unit-tested in `app/src/test/`, against the same captured bytes as macOS `Parsers.swift`)
 - `BoseProtocol.kt` -- thin command facade: builds non-composite frames via generated `BMAP.*`, decodes responses. NO hand-written frame builders
 - `A2dpReflection.kt` -- the ONE isolated home for the hidden-API `BluetoothA2dp.connect()` reflection (phone-only insurance; don't expand)
-- `BoseService` -- foreground service (RFCOMM commands; phone-only A2DP nudge; notification media controls play/pause/next/prev)
+- `SlotGate.kt` -- does THIS phone hold a multipoint slot? Public-API A2DP-proxy connected-list check (zero radio) — the Android sibling of the Mac's `isHeadphoneConnected()`. null = unknown → allow live (never worse than pre-gate).
+- `StateCache.kt` -- timestamped last-good snapshot (SharedPrefs) — Android sibling of the Mac state cache (#148). Saved on every successful live refresh (service AND ViewModel); served when the phone holds no slot. `ageText` pure + JVM-tested (`StateCacheTest`).
+- `BoseService` -- foreground service (RFCOMM commands; phone-only A2DP nudge; notification media controls play/pause/next/prev). `refreshStatus()` is **cached-first**: no slot → cached broadcast (`EXTRA_REACHABLE`/`EXTRA_AGE_SECONDS`) + widget repaint with a "· Xm" battery-age suffix, NO RFCOMM; `EXTRA_FORCE_LIVE` overrides. The widget's `onUpdate` refresh therefore never pages the headphones.
 - `BoseWidgetProvider` -- home screen widget (button set derives from `BoseDeviceMap.widgetDevices` — tv is macOS-only, never a widget button)
 - `BoseTileService` -- Quick Settings tile (shows active source)
 - `DevicePickerActivity` -- dialog launched from QS tile
@@ -184,6 +186,12 @@ Key actions: `ACTION_CONNECT_DEVICE`, `ACTION_REFRESH`.
 4. nudgeMediaPlayback() -- pause/play to force audio stream handover
 
 **Skip-if-active:** Tapping an already-active device is a no-op (checks SharedPrefs).
+
+**Cached-first reads (#148 parity):** `refreshStatus()` and the Compose app's
+`refreshAll()` both gate on `SlotGate` — phone holds neither slot → paint
+`StateCache` (widget battery gains a "· Xm" age suffix; the app shows the same
+staleness banner as the Mac with a **Read live** button = `forceLive`). Only
+`forceLive`, writes, and device switches touch the radio from a non-slot phone.
 
 ### Key Lessons (Don't Repeat These Mistakes)
 

--- a/android/app/src/main/java/au/com/jd/bose/BoseService.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseService.kt
@@ -42,6 +42,9 @@ class BoseService : Service() {
         const val ACTION_CONNECT_DEVICE = "au.com.jd.bose.CONNECT_DEVICE"
         const val EXTRA_DEVICE_NAME = "device_name"
         const val ACTION_REFRESH = "au.com.jd.bose.REFRESH"
+        const val EXTRA_FORCE_LIVE = "force_live"
+        const val EXTRA_REACHABLE = "reachable"
+        const val EXTRA_AGE_SECONDS = "age_seconds"
 
         // Media transport sent to the headphones via BMAP mediaControl (05,03).
         const val ACTION_MEDIA = "au.com.jd.bose.MEDIA"
@@ -71,6 +74,7 @@ class BoseService : Service() {
         createNotificationChannel()
         startForeground(NOTIFICATION_ID, buildNotification("Bose Controller active"))
         setupA2dpProxy()
+        SlotGate.ensureInit(this)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -81,7 +85,8 @@ class BoseService : Service() {
                 executor.submit { switchDevice(deviceName) }
             }
             ACTION_REFRESH -> {
-                executor.submit { refreshStatus() }
+                val forceLive = intent.getBooleanExtra(EXTRA_FORCE_LIVE, false)
+                executor.submit { refreshStatus(forceLive) }
             }
             ACTION_MEDIA -> {
                 val actionValue = intent.getIntExtra(EXTRA_MEDIA_ACTION, -1)
@@ -330,7 +335,30 @@ class BoseService : Service() {
         }
     }
 
-    private fun refreshStatus() {
+    private fun refreshStatus(forceLive: Boolean = false) {
+        // Cached-first (#148 parity): with neither multipoint slot held, an RFCOMM
+        // read would PAGE the headphones (slow; the audio-glitch probe class the
+        // transport rules warn about). Serve the last-good snapshot instead — the
+        // widget/app paint instantly and the radio stays silent. forceLive (the
+        // app's Read-live button) and an unknown gate (null) fall through to live.
+        if (!forceLive && SlotGate.awaitHoldsSlot(this) == false) {
+            val cached = StateCache.load(this)
+            if (cached != null) {
+                val age = cached.ageSeconds()
+                updateNotification("Active: ${cached.active ?: "none"} (cached ${StateCache.ageText(age)})")
+                broadcastFullStatus(
+                    activeDevice = cached.active ?: "none",
+                    connectedDevices = cached.connected.toList(),
+                    batteryLevel = cached.battery,
+                    batteryCharging = cached.charging,
+                    reachable = false,
+                    ageSeconds = age,
+                )
+            } else {
+                broadcastError("Headphones not connected to this phone (no cached state)")
+            }
+            return
+        }
         try {
             if (!ensureConnected()) {
                 broadcastError("Cannot connect to headphones")
@@ -354,11 +382,15 @@ class BoseService : Service() {
                 battery?.let { append(" | ${it.level}%") }
             })
 
+            StateCache.save(this, activeName, connectedNames.toSet(),
+                battery?.level ?: -1, battery?.charging ?: false)
             broadcastFullStatus(
                 activeDevice = activeName,
                 connectedDevices = connectedNames,
                 batteryLevel = battery?.level ?: -1,
                 batteryCharging = battery?.charging ?: false,
+                reachable = true,
+                ageSeconds = null,
             )
         } catch (e: Exception) {
             Log.e(TAG, "Refresh error", e)
@@ -386,6 +418,8 @@ class BoseService : Service() {
         connectedDevices: List<String>,
         batteryLevel: Int,
         batteryCharging: Boolean,
+        reachable: Boolean = true,
+        ageSeconds: Int? = null,
     ) {
         val intent = Intent(BROADCAST_STATUS).apply {
             setPackage(packageName)
@@ -393,10 +427,13 @@ class BoseService : Service() {
             putExtra(EXTRA_CONNECTED_DEVICES, connectedDevices.toTypedArray())
             putExtra(EXTRA_BATTERY_LEVEL, batteryLevel)
             putExtra(EXTRA_BATTERY_CHARGING, batteryCharging)
+            putExtra(EXTRA_REACHABLE, reachable)
+            ageSeconds?.let { putExtra(EXTRA_AGE_SECONDS, it) }
             putExtra(EXTRA_SUCCESS, true)
         }
         sendBroadcast(intent)
-        BoseWidgetProvider.updateAll(this, activeDevice, connectedDevices.toSet())
+        BoseWidgetProvider.updateAll(this, activeDevice, connectedDevices.toSet(),
+            batteryLevel, if (reachable) null else ageSeconds)
     }
 
     private fun broadcastError(error: String) {

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -71,6 +71,12 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
         val eqMid: Int = 0,
         val eqTreble: Int = 0,
 
+        // Cached-first (#148 parity): reachable = this phone holds a multipoint
+        // slot right now; false while painting the StateCache snapshot (drives the
+        // staleness banner). stateAgeSeconds = the painted snapshot's age.
+        val reachable: Boolean = true,
+        val stateAgeSeconds: Int? = null,
+
         // UI
         val loading: Boolean = false,
         val error: String? = null,
@@ -81,9 +87,33 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
     private val _state = MutableStateFlow(UiState())
     val state: StateFlow<UiState> = _state.asStateFlow()
 
-    fun refreshAll() {
+    fun refreshAll(forceLive: Boolean = false) {
         viewModelScope.launch {
             _state.value = _state.value.copy(loading = true, error = null)
+            // Cached-first: with neither slot held, an RFCOMM read would page the
+            // headphones — paint the cached snapshot instead (instant, zero radio).
+            // The banner's Read-live button passes forceLive; an unknown gate (null,
+            // proxy not bound) falls through to live, matching pre-gate behaviour.
+            if (!forceLive && SlotGate.awaitHoldsSlot(getApplication()) == false) {
+                val cached = StateCache.load(getApplication())
+                val cur = _state.value
+                _state.value = cur.copy(
+                    loading = false,
+                    reachable = false,
+                    stateAgeSeconds = cached?.ageSeconds(),
+                    batteryLevel = cached?.battery?.takeIf { it >= 0 } ?: cur.batteryLevel,
+                    batteryCharging = cached?.charging ?: cur.batteryCharging,
+                    deviceStates = if (cached == null) cur.deviceStates
+                    else BoseDeviceMap.knownDevices.associate { device ->
+                        device.name to when {
+                            device.name == cached.active -> DeviceState.ACTIVE
+                            cached.connected.contains(device.name) -> DeviceState.CONNECTED
+                            else -> DeviceState.OFFLINE
+                        }
+                    },
+                )
+                return@launch
+            }
             try {
                 BoseProtocol.withConnection {
                     // Collect all results into a local copy, emit once at end
@@ -132,8 +162,14 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                     BoseProtocol.getEq()?.let { s = s.copy(eqBass = it.bass.value, eqMid = it.mid.value, eqTreble = it.treble.value) }
                     BoseProtocol.getImmersionLevel()?.let { s = s.copy(immersionLevel = it) }
 
+                    // Live read landed: persist the snapshot for the gated path
+                    // (widget + next no-slot open paint from it).
+                    val active = s.deviceStates.entries.firstOrNull { it.value == DeviceState.ACTIVE }?.key
+                    val held = s.deviceStates.filterValues { it == DeviceState.CONNECTED }.keys
+                    StateCache.save(getApplication(), active, held, s.batteryLevel, s.batteryCharging)
+
                     // Single emission — one recomposition instead of 18
-                    _state.value = s.copy(loading = false)
+                    _state.value = s.copy(loading = false, reachable = true, stateAgeSeconds = null)
                 }
             } catch (e: Exception) {
                 _state.value = _state.value.copy(

--- a/android/app/src/main/java/au/com/jd/bose/BoseWidgetProvider.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseWidgetProvider.kt
@@ -45,7 +45,13 @@ class BoseWidgetProvider : AppWidgetProvider() {
         private const val COLOR_BATTERY_OK = 0xFF6E6A5E.toInt()   // secondary grey, healthy
         private const val PREFS_NAME = "bose_ctl"
 
-        fun updateAll(context: Context, activeDevice: String?, connectedDevices: Set<String> = emptySet()) {
+        fun updateAll(
+            context: Context,
+            activeDevice: String?,
+            connectedDevices: Set<String> = emptySet(),
+            batteryLevel: Int = -1,
+            staleAgeSeconds: Int? = null,   // non-null = painting a cached snapshot
+        ) {
             val manager = AppWidgetManager.getInstance(context)
             val component = ComponentName(context, BoseWidgetProvider::class.java)
             val ids = manager.getAppWidgetIds(component)
@@ -53,10 +59,13 @@ class BoseWidgetProvider : AppWidgetProvider() {
             context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit()
                 .putString("active_device", activeDevice)
                 .putStringSet("connected_devices", connectedDevices)
+                .apply {
+                    if (batteryLevel >= 0) putInt("battery_level", batteryLevel)
+                }
                 .apply()
 
             for (id in ids) {
-                updateWidget(context, manager, id, activeDevice, connectedDevices)
+                updateWidget(context, manager, id, activeDevice, connectedDevices, staleAgeSeconds)
             }
         }
 
@@ -66,6 +75,7 @@ class BoseWidgetProvider : AppWidgetProvider() {
             widgetId: Int,
             activeDevice: String?,
             connectedDevices: Set<String>,
+            staleAgeSeconds: Int? = null,
         ) {
             val views = RemoteViews(context.packageName, R.layout.widget_layout)
 

--- a/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
+++ b/android/app/src/main/java/au/com/jd/bose/MainActivity.kt
@@ -312,6 +312,31 @@ fun BoseApp(vm: BoseViewModel = viewModel()) {
                 )
                 Spacer(modifier = Modifier.height(24.dp))
 
+                // Staleness banner — painting the cached snapshot because this phone
+                // holds neither multipoint slot (cached-first, #148 parity). Read live
+                // deliberately pages the headphones (may blip audio on the active sink).
+                if (!state.reachable) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BoseCardBg, RoundedCornerShape(8.dp))
+                            .padding(horizontal = 12.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "Not connected to this phone — last known state" +
+                                (state.stateAgeSeconds?.let { " (${StateCache.ageText(it)} ago)" } ?: ""),
+                            fontSize = 11.sp,
+                            color = BoseDim,
+                            modifier = Modifier.weight(1f),
+                        )
+                        TextButton(onClick = { vm.refreshAll(forceLive = true) }) {
+                            Text("Read live", color = BoseAccent, fontSize = 11.sp)
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+
                 // Loading indicator
                 if (state.loading) {
                     CircularProgressIndicator(

--- a/android/app/src/main/java/au/com/jd/bose/SlotGate.kt
+++ b/android/app/src/main/java/au/com/jd/bose/SlotGate.kt
@@ -1,0 +1,60 @@
+package au.com.jd.bose
+
+import android.bluetooth.BluetoothA2dp
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+
+/**
+ * Does THIS phone currently hold one of the headphones' two multipoint slots?
+ *
+ * Public-API check via the A2DP profile proxy's connected-device list — zero
+ * radio, the Android sibling of the Mac CLI's `Transport.isHeadphoneConnected()`
+ * (#148). A held (idle) slot still reports the A2DP profile "connected", so this
+ * is true for both the active sink and the held device — exactly the set for
+ * which an RFCOMM read is cheap and safe. When false, an RFCOMM read would PAGE
+ * the headphones over BT Classic (slow + the audio-glitch probe class the
+ * transport rules warn about) — callers serve `StateCache` instead.
+ *
+ * The proxy binds asynchronously; `awaitHoldsSlot()` bounds the cold-start wait
+ * and returns null when genuinely unknown (adapter off / proxy unavailable /
+ * permission denied) — callers treat null as "allow live" so behaviour is never
+ * worse than before the gate existed.
+ */
+object SlotGate {
+    @Volatile private var proxy: BluetoothA2dp? = null
+    @Volatile private var requested = false
+
+    fun ensureInit(context: Context) {
+        if (requested) return
+        requested = true
+        val adapter = context.getSystemService(BluetoothManager::class.java)?.adapter ?: return
+        adapter.getProfileProxy(
+            context.applicationContext,
+            object : BluetoothProfile.ServiceListener {
+                override fun onServiceConnected(profile: Int, p: BluetoothProfile) {
+                    if (profile == BluetoothProfile.A2DP) proxy = p as BluetoothA2dp
+                }
+                override fun onServiceDisconnected(profile: Int) {
+                    if (profile == BluetoothProfile.A2DP) { proxy = null; requested = false }
+                }
+            },
+            BluetoothProfile.A2DP,
+        )
+    }
+
+    /** null = unknown (proxy not bound / permission missing). */
+    fun holdsSlot(): Boolean? = try {
+        proxy?.connectedDevices?.any { it.address.equals(Headphone.MAC, ignoreCase = true) }
+    } catch (_: SecurityException) {
+        null
+    }
+
+    /** Bounded wait for the async proxy bind (typically <100 ms after first init). */
+    fun awaitHoldsSlot(context: Context, timeoutMs: Long = 700): Boolean? {
+        ensureInit(context)
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (proxy == null && System.currentTimeMillis() < deadline) Thread.sleep(25)
+        return holdsSlot()
+    }
+}

--- a/android/app/src/main/java/au/com/jd/bose/StateCache.kt
+++ b/android/app/src/main/java/au/com/jd/bose/StateCache.kt
@@ -1,0 +1,56 @@
+package au.com.jd.bose
+
+import android.content.Context
+
+/**
+ * Timestamped last-good status snapshot — the Android sibling of the Mac's
+ * `~/.cache/bose/state-<MAC>.json` (#148). Written on every successful live
+ * refresh; served (stamped with age) when the phone holds neither multipoint
+ * slot, so the widget and app paint instantly and radio-silently instead of
+ * paging the headphones. SharedPrefs-backed: this is presentation state, small
+ * and flat, and prefs survive process death exactly as long as we need.
+ */
+object StateCache {
+    private const val PREFS = "bose_state_cache"
+
+    data class Cached(
+        val active: String?,
+        val connected: Set<String>,
+        val battery: Int,          // -1 = unknown
+        val charging: Boolean,
+        val savedAtMs: Long,
+    ) {
+        fun ageSeconds(nowMs: Long = System.currentTimeMillis()): Int =
+            ((nowMs - savedAtMs) / 1000).coerceAtLeast(0).toInt()
+    }
+
+    fun save(context: Context, active: String?, connected: Set<String>, battery: Int, charging: Boolean) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+            .putString("active", active)
+            .putStringSet("connected", connected)
+            .putInt("battery", battery)
+            .putBoolean("charging", charging)
+            .putLong("saved_at", System.currentTimeMillis())
+            .apply()
+    }
+
+    fun load(context: Context): Cached? {
+        val p = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val savedAt = p.getLong("saved_at", 0L)
+        if (savedAt == 0L) return null
+        return Cached(
+            active = p.getString("active", null),
+            connected = p.getStringSet("connected", emptySet()) ?: emptySet(),
+            battery = p.getInt("battery", -1),
+            charging = p.getBoolean("charging", false),
+            savedAtMs = savedAt,
+        )
+    }
+
+    /** "45s" / "12m" / "2h 5m" — pure (JVM-unit-tested), shared by widget + app. */
+    fun ageText(ageSeconds: Int): String = when {
+        ageSeconds < 60 -> "${ageSeconds}s"
+        ageSeconds < 3600 -> "${ageSeconds / 60}m"
+        else -> "${ageSeconds / 3600}h ${(ageSeconds % 3600) / 60}m"
+    }
+}

--- a/android/app/src/test/java/au/com/jd/bose/StateCacheTest.kt
+++ b/android/app/src/test/java/au/com/jd/bose/StateCacheTest.kt
@@ -1,0 +1,12 @@
+package au.com.jd.bose
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** ageText is the shared staleness formatter (widget battery suffix + app banner). */
+class StateCacheTest {
+    @Test fun secondsUnderAMinute() = assertEquals("45s", StateCache.ageText(45))
+    @Test fun minutesUnderAnHour() = assertEquals("12m", StateCache.ageText(750))
+    @Test fun hoursAndMinutes() = assertEquals("2h 5m", StateCache.ageText(7500))
+    @Test fun zeroIsSeconds() = assertEquals("0s", StateCache.ageText(0))
+}


### PR DESCRIPTION
Ports #148 to Android: SlotGate (public A2DP-proxy slot check, zero radio; null=unknown falls through to live), StateCache (SharedPrefs snapshot saved on every live refresh from service AND ViewModel), gated BoseService.refreshStatus (cached broadcast + widget age suffix, EXTRA_FORCE_LIVE override) and gated BoseViewModel.refreshAll (staleness banner + Read live button matching the Mac app). Widget onUpdate refresh no longer pages the headphones when the phone holds no slot. 4 new JVM tests; built + installed on the S21.