### PR TITLE
chore: wire brain_project_id into harness config

### DIFF
--- a/.harness/config.json
+++ b/.harness/config.json
@@ -1,5 +1,6 @@
 {
   "base_branch": "main",
   "max_parallel": 3,
-  "worktree_parent": ".worktrees"
+  "worktree_parent": ".worktrees",
+  "brain_project_id": "01KNESEMSP7EF7QXNP52YBT2EY"
 }


### PR DESCRIPTION
The repo's harness config never carried the Brain project id, so /f:new task creation 404'd (found + hand-repaired locally tonight). Persist it.