### PR TITLE
feat(android): 04,04 paired-list preflight before multipoint eviction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,11 @@ primary active). The order is host-side only — never pushed to the headphones 
 priority hierarchy). **Android now replicates
 it too**: pure victim selection in `android/.../Eviction.kt` (`evictionVictim`, JVM-unit-
 tested), held-state read via `Composites.getDeviceStates`, wired into `BoseService.switchDevice`
-(evict-then-page, restore on failure). **The local phone is excluded from victim selection**
+(evict-then-page, restore on failure). The **04,04 paired-list preflight** guards this too
+(`Composites.unpairedHint` + `Parsers.parsePairedDevices`, the port of the CLI's `preflightPaired`):
+`switchDevice` checks the headset's own pairing table BEFORE evicting, so it never sacrifices a
+slot for a mapped-but-unpaired target (tv/appletv) that can only time out — a no-op when the list
+is unreadable, so it never blocks a legitimate connect. **The local phone is excluded from victim selection**
 (`localDeviceName`, default `"phone"`) — Android differs from the Mac here because the app runs
 *on* one of the two slots it arbitrates. `phone` is priority 2 and `mac` is 1, so with the
 everyday `{mac, phone}` pair held, plain victim selection chose THIS PHONE for any third target;
@@ -441,7 +445,7 @@ surface. Keep this in sync when adding a verb or control.
 | Auto-answer | **01,1B** | ✅ `auto-answer` | — | ✅ toggle |
 | Favorites | **1F,08** | ✅ `favorites` | — | — (parser only, no UI) |
 | Connect device | 04,01 | ✅ `connect`/`swap` | Opt+B opens app (Opt+⇧B/Opt+J disabled 2026-06-20) | ✅ widget/tile/picker |
-| Paired-device list | **04,04** | 👁 preflight in `connect`/`swap`/`pair` | — | — |
+| Paired-device list | **04,04** | 👁 preflight in `connect`/`swap`/`pair` | — | 👁 preflight in `switchDevice` |
 | ~~CNC depth~~ | ~~1F,0A~~ | 👁 read-only GET inside `getAllState` — **NEVER write (#83)** | — | — |
 | Multipoint pair / priority | host-side (priority.json) | ✅ `pair` / `priority` | — | — (compiled `Eviction.kt` only) |
 | Disconnect device | 04,02 | ✅ `disconnect` | — | — |

--- a/android/app/src/main/java/au/com/jd/bose/BoseService.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseService.kt
@@ -262,6 +262,16 @@ class BoseService : Service() {
                 return
             }
 
+            // Preflight the headphones' OWN paired table (04,04) BEFORE evicting a slot — a device
+            // in the map the headset never paired with (tv/appletv) can only time out, so don't
+            // sacrifice a multipoint slot for it. Parity with the CLI's #157 preflightPaired; a
+            // no-op when the list is unreadable, so it never blocks a legitimate connect.
+            Composites.unpairedHint(mac, deviceName)?.let {
+                Log.w(TAG, "Preflight refused $deviceName: $it")
+                broadcastError(it)
+                return
+            }
+
             // Multipoint eviction (parity with the CLI's evictLowestPriorityIfFull): the
             // headset holds 2 devices and the firmware only evicts by its own LRU. When both
             // slots are full and the target isn't already held, drop the LOWEST-priority held

--- a/android/app/src/main/java/au/com/jd/bose/Composites.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Composites.kt
@@ -132,6 +132,26 @@ object Composites {
     }
 
     /**
+     * Preflight a connect target against the headphones' OWN paired table (04,04) — the Android
+     * parity of the CLI's `preflightPaired` (#157). The host-side device map drifts from the
+     * headset's pairing list (tv/appletv are mapped but were never paired), and paging an
+     * unpaired device ACKs then silently never connects — an indistinguishable ~20s timeout.
+     *
+     * Returns an abort hint ONLY when the device is provably absent from a readable paired list,
+     * so the caller can fail fast BEFORE evicting a multipoint slot for a device that can't
+     * answer. A no-op (null) when the list is unreadable or the device IS paired — it never
+     * blocks a connect on an unreadable list. Caller must hold an open RFCOMM channel.
+     */
+    fun unpairedHint(mac: IntArray, deviceName: String): String? {
+        val resp = Transport.send(BMAP.getListDevices()) ?: return null
+        val paired = Parsers.parsePairedDevices(resp)
+        if (paired.isEmpty() || paired.any { it.toList() == mac.toList() }) return null
+        return "$deviceName is not in the headphones' paired list — it's in the device map, but " +
+            "the headphones have never been paired with it (or have forgotten it). Pair it from " +
+            "the device itself first; paging it can only time out."
+    }
+
+    /**
      * Connect (switch audio to) a device by MAC. Sends connectDevice (04,01) for the
      * ACK, then polls getConnectedDevices on the SAME channel until the target MAC is
      * audio-active (up to ~16s). NEVER treats ACK as success (CLAUDE.md / #61-#64) — a

--- a/android/app/src/main/java/au/com/jd/bose/Parsers.kt
+++ b/android/app/src/main/java/au/com/jd/bose/Parsers.kt
@@ -97,6 +97,29 @@ object Parsers {
     }
 
     /**
+     * Parse the 04,04 ListDevices RESPONSE → the MACs the HEADPHONES themselves have paired.
+     * This is the headset's OWN pairing table, not the host-side device map — the two drift, so
+     * a device can be in the map yet never paired (tv/appletv on verBosita), and paging one only
+     * times out. Layout:
+     *   [0x04, 0x04, RESP, len, capacity(0x10), {6-byte MAC}*]
+     * Variable-length with NO count byte — MACs run from byte 5 to the end, six at a time; a
+     * trailing partial MAC is dropped, never half-read. Returns [] on any malformed/short/non-RESP
+     * frame (never speculate). Mirrors the Swift `parsePairedDevices`; same captured-byte corpus.
+     */
+    fun parsePairedDevices(resp: IntArray): List<IntArray> {
+        if (resp.size < 5 || resp[0] != 0x04 || resp[1] != 0x04 || resp[2] != OP_RESP) {
+            return emptyList()
+        }
+        val devices = mutableListOf<IntArray>()
+        var offset = 5
+        while (offset + 6 <= resp.size) {
+            devices.add(resp.copyOfRange(offset, offset + 6))
+            offset += 6
+        }
+        return devices
+    }
+
+    /**
      * Parse a 1F,06 AudioModesModeConfig RESPONSE. Payload (resp[4..]) offsets, confirmed
      * live + against the decompiled AudioModesModeConfigResponse: [0]=index, [1..2]=prompt,
      * [3]=userConfigurable, [6..37]=32-byte name, [41]=mutability bitfield (bit0=cncMutable),

--- a/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
+++ b/android/app/src/test/java/au/com/jd/bose/ParsersTest.kt
@@ -56,6 +56,56 @@ class ParsersTest {
         assertTrue(Parsers.parseConnectedDevices(intArrayOf()).isEmpty())
     }
 
+    // ── parsePairedDevices (04,04) ─────────────────────────────────────────────
+    // EXACT live capture, fw 8.2.20, 2026-07-20 — the same corpus as cli/Tests/main.swift.
+    // Header [04 04 RESP len], capacity byte 0x10 at [4], then 6 MACs: phone, quest, audikast,
+    // ipad, mac, iphone. NB tv (14:C1:4E:..) and appletv (48:E1:5C:..) are ABSENT — they're in
+    // the device map but the headphones have never paired with them (what the preflight reports).
+    private val pairedList = intArrayOf(
+        0x04, 0x04, 0x03, 0x25, 0x10,
+        0xA8, 0x76, 0x50, 0xD3, 0xB1, 0x1B, // phone
+        0x78, 0xC4, 0xFA, 0xC8, 0x5C, 0x3D, // quest
+        0x00, 0x1D, 0x43, 0xB8, 0x03, 0x01, // audikast
+        0xF4, 0x81, 0xC4, 0xB5, 0xFA, 0xAB, // ipad
+        0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x27, // mac
+        0xF8, 0x4D, 0x89, 0xC4, 0xB6, 0xED, // iphone
+    )
+
+    @Test
+    fun pairedDevices_parsesAllSixFromLiveCapture() {
+        val pd = Parsers.parsePairedDevices(pairedList)
+        assertEquals(6, pd.size)
+        assertArrayEquals(intArrayOf(0xA8, 0x76, 0x50, 0xD3, 0xB1, 0x1B), pd.first()) // phone
+        assertArrayEquals(intArrayOf(0xF8, 0x4D, 0x89, 0xC4, 0xB6, 0xED), pd.last()) // iphone
+    }
+
+    @Test
+    fun pairedDevices_membershipMatchesTheMotivatingFindings() {
+        val pd = Parsers.parsePairedDevices(pairedList).map { it.toList() }
+        assertTrue(pd.contains(intArrayOf(0x00, 0x1D, 0x43, 0xB8, 0x03, 0x01).toList())) // audikast IS paired
+        assertFalse(pd.contains(intArrayOf(0x14, 0xC1, 0x4E, 0xB7, 0xCB, 0x68).toList())) // tv NOT paired
+        assertFalse(pd.contains(intArrayOf(0x48, 0xE1, 0x5C, 0x5D, 0x33, 0xB6).toList())) // appletv NOT paired
+    }
+
+    @Test
+    fun pairedDevices_wrongBlockIsEmpty() {
+        assertTrue(Parsers.parsePairedDevices(intArrayOf(0x05, 0x01, 0x03, 0x25, 0x10)).isEmpty())
+    }
+
+    @Test
+    fun pairedDevices_noMacsIsEmpty() {
+        assertTrue(Parsers.parsePairedDevices(intArrayOf(0x04, 0x04, 0x03, 0x01, 0x10)).isEmpty())
+    }
+
+    @Test
+    fun pairedDevices_trailingPartialMacDropped() {
+        val ragged = intArrayOf(
+            0x04, 0x04, 0x03, 0x0B, 0x10,
+            0xBC, 0xD0, 0x74, 0x11, 0xDB, 0x27, 0xAA, 0xBB,
+        )
+        assertEquals(1, Parsers.parsePairedDevices(ragged).size)
+    }
+
     // ── parseModeConfig (1F,06) + buildModeConfigSet ──────────────────────────
     // The CORRECT noise-level path (1F,06 RMW), replacing the 1F,0A footgun (#83).
     // Mirrors macOS `cli/Tests/main.swift` byte-for-byte (52-byte response).


### PR DESCRIPTION
Port of the Swift #157 `preflightPaired` to Android. `switchDevice` checks the headphones' own paired table (04,04) before evicting a multipoint slot, so a mapped-but-unpaired target (tv/appletv) fails fast instead of sacrificing a slot for a device that can only time out. No-op when the list is unreadable — never blocks a live connect.

- `Parsers.parsePairedDevices` — pure 04,04 decode, mirrors Swift + same corpus
- `Composites.unpairedHint` — abort hint only when provably absent
- `BoseService.switchDevice` — preflight ahead of eviction
- 5 new JVM tests

Part of #157.