### PR TITLE
fix(android): 04,04 preflight on the in-app connect path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,7 +445,7 @@ surface. Keep this in sync when adding a verb or control.
 | Auto-answer | **01,1B** | ✅ `auto-answer` | — | ✅ toggle |
 | Favorites | **1F,08** | ✅ `favorites` | — | — (parser only, no UI) |
 | Connect device | 04,01 | ✅ `connect`/`swap` | Opt+B opens app (Opt+⇧B/Opt+J disabled 2026-06-20) | ✅ widget/tile/picker |
-| Paired-device list | **04,04** | 👁 preflight in `connect`/`swap`/`pair` | — | 👁 preflight in `switchDevice` |
+| Paired-device list | **04,04** | 👁 preflight in `connect`/`swap`/`pair` | — | 👁 preflight in both connect paths (service `switchDevice` + in-app `BoseViewModel`) |
 | ~~CNC depth~~ | ~~1F,0A~~ | 👁 read-only GET inside `getAllState` — **NEVER write (#83)** | — | — |
 | Multipoint pair / priority | host-side (priority.json) | ✅ `pair` / `priority` | — | — (compiled `Eviction.kt` only) |
 | Disconnect device | 04,02 | ✅ `disconnect` | — | — |

--- a/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
+++ b/android/app/src/main/java/au/com/jd/bose/BoseViewModel.kt
@@ -199,8 +199,20 @@ class BoseViewModel(application: Application) : AndroidViewModel(application) {
                     _state.value = _state.value.copy(loading = false)
                     return@launch
                 }
+                // Preflight the headphones' paired table (04,04) before paging — parity with the
+                // widget/service path (BoseService.switchDevice) and the CLI's #157 preflightPaired.
+                // An unpaired target (tv/appletv) can only be ERROR-rejected or time out, so fail
+                // fast with the real reason instead of the silent no-op the bare connect gave. A
+                // no-op when the list is unreadable — never blocks a legitimate connect. Shares the
+                // one channel session with the connect so nothing races in between.
+                var unpaired: String? = null
                 val result = BoseProtocol.withConnection {
-                    Composites.connectDevice(mac)
+                    unpaired = Composites.unpairedHint(mac, name)
+                    if (unpaired != null) null else Composites.connectDevice(mac)
+                }
+                if (unpaired != null) {
+                    _state.value = _state.value.copy(loading = false, error = unpaired)
+                    return@launch
                 }
                 if (result == Composites.SwitchResult.TARGET_OFFLINE) {
                     _state.value = _state.value.copy(


### PR DESCRIPTION
Follow-up to #158 (found by hardware testing). Extends the paired-list preflight to `BoseViewModel.switchDevice` so the in-app device tile fails fast with the real reason on an unpaired target, matching the widget/service path. Part of #157.