### PR TITLE
fix(macos): local-Mac disconnect must not force --page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,14 @@ explicit user action.
   confirming against the cache (fixed 2026-07-20), and that was not a race but a
   guarantee: after a write that drops the link (`disconnect mac`) there is no ACL, so the
   cache is the ONLY thing that can be served and the app repainted pre-write state every
-  time. **Corollary, and the thing a future change is most likely to get wrong again: any
+  time. **The ONE carve-out (2026-07-21): a local-Mac `disconnect` must NOT force `--page`.**
+  That write intentionally drops this Mac's ACL, and a forced `--page` confirm reopens
+  RFCOMM and re-pages the very device just disconnected — an audible disconnect-then-
+  reconnect. So `write()` forces `--page` for everything EXCEPT `disconnect mac`, which
+  confirms cached-first (serves the last-known snapshot behind the staleness banner —
+  the correct "disconnected" view — without re-paging). Every other write keeps the link,
+  so cached-first there still reads live; only the self-disconnect must skip the page.
+  **Corollary, and the thing a future change is most likely to get wrong again: any
   guard that reads `deviceStates` must also check `reachable`** — the painted state is
   last-known, not live. Both HIGH findings here were that mistake: the skip-if-active
   guard made the Mac row un-tappable exactly when you needed it (cached state said

--- a/macos/BoseControl/BoseManager.swift
+++ b/macos/BoseControl/BoseManager.swift
@@ -540,7 +540,18 @@ final class BoseManager: ObservableObject {
             // (confirmWrite / connectDevice / applyProfile / applyPair) already forces
             // `--page`; this one was the hole. See CLAUDE.md: "a settle loop must never
             // confirm against the cache".
-            self.refreshState(forcePage: true)
+            //
+            // EXCEPTION — disconnecting the local Mac: that write intentionally drops
+            // THIS Mac's ACL (via `bose disconnect mac` → blueutil --disconnect, #157).
+            // Forcing `--page` here reopens RFCOMM and re-pages the very device we just
+            // disconnected, so the headphones route audio straight back — an audible
+            // disconnect-then-reconnect. With no link there is nothing to page anyway;
+            // confirm cached-first so the read serves the last-known snapshot behind the
+            // staleness banner (reachable:false = the correct "disconnected" view) and
+            // never re-pages. Every OTHER write keeps this Mac's link, so cached-first
+            // there still reads live — only the self-disconnect must skip the page.
+            let localMacDisconnect = args.first == "disconnect" && args.dropFirst().first == "mac"
+            self.refreshState(forcePage: !localMacDisconnect)
         }
     }
 


### PR DESCRIPTION
Found by hardware testing. Disconnecting the Mac from the app forced a `--page` confirm that reopened RFCOMM and re-paged the Mac it just disconnected (audible disconnect→reconnect). `write()` now skips the forced page only for `disconnect mac`, confirming cached-first instead. Part of #157 macOS verification.