### PR TITLE
feat: repoint tv device to Google TV Streamer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ own MAC. Use `getConnectedDevices` (05,01) for audio-active devices and
 | mac | BC:D0:74:11:DB:27 | yes | MacBook |
 | ipad | F4:81:C4:B5:FA:AB | yes | |
 | iphone | F8:4D:89:C4:B6:ED | yes | |
-| tv | 14:C1:4E:B7:CB:68 | macOS only | Chromecast. **⚠ NOT in the headphones' paired list** (04,04, verified 2026-07-20) — connects can only time out until it's paired |
+| tv | B4:23:A2:45:9C:4D | macOS only | Google TV Streamer (`kirkwood`, BT name "Living Room TV"). Replaced the old Chromecast (`14:C1:4E:B7:CB:68`) in this slot 2026-07-23. **⚠ Verify it's in the headphones' paired list (04,04) before relying on connect** — an unpaired target only times out until it's paired to verBosita from the streamer's Bluetooth settings |
 | appletv | 48:E1:5C:5D:33:B6 | macOS + S21 in-app | Katrina's Apple TV 4K (label "Katrina's Apple TV"; `widget=false` → no home-screen widget). **⚠ NOT in the headphones' paired list** (04,04, verified 2026-07-20) |
 | quest | 78:C4:FA:C8:5C:3D | yes | Meta Quest 3 |
 | audikast | 00:1D:43:B8:03:01 | macOS tile only | Avantree Audikast Plus BT transmitter (TV → headphones), Shenzhen G-link OUI. Lowest priority (evicted first); deliberately NOT in cycle_order (never cycle audio to a transmitter) |

--- a/android/app/src/generated/java/au/com/jd/bose/Devices.generated.kt
+++ b/android/app/src/generated/java/au/com/jd/bose/Devices.generated.kt
@@ -41,7 +41,7 @@ object BoseDeviceMap {
         BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null, priority = 5),
         BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true, label = null, priority = 4),
         BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true, label = null, priority = 7),
-        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null, priority = 6),
+        BoseDevice("tv", byteArrayOf(0xB4.toByte(), 0x23, 0xA2.toByte(), 0x45, 0x9C.toByte(), 0x4D), widget = false, label = "Living Room TV", priority = 6),
         BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV", priority = 3),
         BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null, priority = 2),
         BoseDevice("audikast", byteArrayOf(0x00, 0x1D, 0x43, 0xB8.toByte(), 0x03, 0x01), widget = false, label = "Avantree Audikast Plus", priority = 8),

--- a/macos/BoseControl/ContentView.swift
+++ b/macos/BoseControl/ContentView.swift
@@ -41,7 +41,7 @@ private let deviceButtons: [DeviceButton] = [
     DeviceButton(id: "phone", label: "Phone", symbol: "iphone", priority: 2),
     DeviceButton(id: "ipad", label: "iPad", symbol: "ipad", priority: 4),
     DeviceButton(id: "iphone", label: "iPhone", symbol: "iphone", priority: 7),
-    DeviceButton(id: "tv", label: "TV", symbol: "tv", priority: 6),
+    DeviceButton(id: "tv", label: "Living Room TV", symbol: "tv", priority: 6),
     DeviceButton(id: "appletv", label: "Katrina's Apple TV", symbol: "appletv", priority: 3),
     DeviceButton(id: "quest", label: "Quest", symbol: "visionpro", priority: 5),
     DeviceButton(id: "audikast", label: "Avantree Audikast", symbol: "antenna.radiowaves.left.and.right", priority: 8),

--- a/protocol/generated/Devices.generated.kt
+++ b/protocol/generated/Devices.generated.kt
@@ -41,7 +41,7 @@ object BoseDeviceMap {
         BoseDevice("quest", byteArrayOf(0x78, 0xC4.toByte(), 0xFA.toByte(), 0xC8.toByte(), 0x5C, 0x3D), widget = true, label = null, priority = 5),
         BoseDevice("ipad", byteArrayOf(0xF4.toByte(), 0x81.toByte(), 0xC4.toByte(), 0xB5.toByte(), 0xFA.toByte(), 0xAB.toByte()), widget = true, label = null, priority = 4),
         BoseDevice("iphone", byteArrayOf(0xF8.toByte(), 0x4D, 0x89.toByte(), 0xC4.toByte(), 0xB6.toByte(), 0xED.toByte()), widget = true, label = null, priority = 7),
-        BoseDevice("tv", byteArrayOf(0x14, 0xC1.toByte(), 0x4E, 0xB7.toByte(), 0xCB.toByte(), 0x68), widget = false, label = null, priority = 6),
+        BoseDevice("tv", byteArrayOf(0xB4.toByte(), 0x23, 0xA2.toByte(), 0x45, 0x9C.toByte(), 0x4D), widget = false, label = "Living Room TV", priority = 6),
         BoseDevice("appletv", byteArrayOf(0x48, 0xE1.toByte(), 0x5C, 0x5D, 0x33, 0xB6.toByte()), widget = false, label = "Katrina's Apple TV", priority = 3),
         BoseDevice("phone", byteArrayOf(0xA8.toByte(), 0x76, 0x50, 0xD3.toByte(), 0xB1.toByte(), 0x1B), widget = true, label = null, priority = 2),
         BoseDevice("audikast", byteArrayOf(0x00, 0x1D, 0x43, 0xB8.toByte(), 0x03, 0x01), widget = false, label = "Avantree Audikast Plus", priority = 8),

--- a/protocol/generated/Devices.generated.swift
+++ b/protocol/generated/Devices.generated.swift
@@ -30,7 +30,7 @@ enum BoseDeviceMap {
         BoseDevice(name: "quest", mac: [0x78, 0xC4, 0xFA, 0xC8, 0x5C, 0x3D], widget: true, label: nil, priority: 5),
         BoseDevice(name: "ipad", mac: [0xF4, 0x81, 0xC4, 0xB5, 0xFA, 0xAB], widget: true, label: nil, priority: 4),
         BoseDevice(name: "iphone", mac: [0xF8, 0x4D, 0x89, 0xC4, 0xB6, 0xED], widget: true, label: nil, priority: 7),
-        BoseDevice(name: "tv", mac: [0x14, 0xC1, 0x4E, 0xB7, 0xCB, 0x68], widget: false, label: nil, priority: 6),
+        BoseDevice(name: "tv", mac: [0xB4, 0x23, 0xA2, 0x45, 0x9C, 0x4D], widget: false, label: "Living Room TV", priority: 6),
         BoseDevice(name: "appletv", mac: [0x48, 0xE1, 0x5C, 0x5D, 0x33, 0xB6], widget: false, label: "Katrina's Apple TV", priority: 3),
         BoseDevice(name: "phone", mac: [0xA8, 0x76, 0x50, 0xD3, 0xB1, 0x1B], widget: true, label: nil, priority: 2),
         BoseDevice(name: "audikast", mac: [0x00, 0x1D, 0x43, 0xB8, 0x03, 0x01], widget: false, label: "Avantree Audikast Plus", priority: 8),

--- a/protocol/spec/devices.toml
+++ b/protocol/spec/devices.toml
@@ -34,10 +34,11 @@ widget = true
 notes = ""
 
 [devices.tv]
-mac = "14:C1:4E:B7:CB:68"          # verified 2026-07-18: read live off the Chromecast itself (adb settings get secure bluetooth_address — exact match)
+mac = "B4:23:A2:45:9C:4D"          # verified 2026-07-23: read live off the Google TV Streamer itself (adb settings get secure bluetooth_address — exact match)
 priority = 6
-widget = false          # CLAUDE.md: "macOS only" — no Android widget button
-notes = "Chromecast (macOS only)"
+label = "Living Room TV"
+widget = false          # macOS only — a TV source, never an Android home-screen button
+notes = "Google TV Streamer (kirkwood; BT name 'Living Room TV'). Replaced the old Chromecast (14:C1:4E:B7:CB:68) in this slot 2026-07-23."
 
 [devices.quest]
 mac = "78:C4:FA:C8:5C:3D"          # OUI verified 2026-07-18: 78:C4:FA = Meta Platforms, Inc. (IEEE registry); full MAC unverified (Quest not adb-reachable)


### PR DESCRIPTION
Repoints the `tv` device from the retired Chromecast (14:C1:4E:B7:CB:68) to the new Google TV Streamer (B4:23:A2:45:9C:4D, BT name "Living Room TV"), MAC read live off the device via ADB. Regenerated protocol layer, synced Android copies, updated Mac app mirror + Device Map docs. 35 golden byte tests + CLI tests pass; CLI and Mac app build.